### PR TITLE
M2: 排队论性能模型 + GPU Profile 库 + 批处理效应

### DIFF
--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -2,6 +2,7 @@
 
 __version__ = "0.1.0"
 
+from xpyd_plan.gpu_profiles import get_gpu_profile, list_gpu_profiles
 from xpyd_plan.models import (
     CandidateResult,
     DatasetStats,
@@ -21,5 +22,7 @@ __all__ = [
     "PerformanceEstimate",
     "PlanResult",
     "SLAConfig",
+    "get_gpu_profile",
+    "list_gpu_profiles",
     "plan",
 ]

--- a/src/xpyd_plan/estimator.py
+++ b/src/xpyd_plan/estimator.py
@@ -1,6 +1,22 @@
-"""Performance estimator — predict TTFT/TPOT for a given PD configuration."""
+"""Performance estimator — predict TTFT/TPOT for a given PD configuration.
+
+V2: Queuing-theory based estimator (M/M/c) with batching effects.
+
+Model:
+  In PD disaggregation with continuous batching, each GPU processes multiple
+  sequences concurrently. The per-request throughput degrades with batch size
+  but sub-linearly (continuous batching is efficient).
+
+  - batch_degradation(bs) ∈ (0, 1]: fraction of single-request throughput
+    retained at batch size bs. Models memory-bandwidth sharing.
+  - per_request_tps = base_tps * batch_degradation(concurrent_per_gpu)
+  - TTFT = prompt_len / per_request_prefill_tps + queue_wait
+  - TPOT = 1 / per_request_decode_tps + queue_wait
+"""
 
 from __future__ import annotations
+
+import math
 
 from xpyd_plan.models import (
     DatasetStats,
@@ -10,35 +26,123 @@ from xpyd_plan.models import (
 )
 
 
+def _erlang_c(c: int, rho_total: float) -> float:
+    """Compute Erlang-C probability P(queuing) for an M/M/c system.
+
+    Args:
+        c: Number of servers (GPUs).
+        rho_total: Total offered load (lambda / mu). Must be < c for stability.
+
+    Returns:
+        Probability that an arriving request has to wait.
+    """
+    if c <= 0:
+        return 1.0
+    if rho_total <= 0.0:
+        return 0.0
+    if rho_total >= c:
+        return 1.0
+
+    log_rho_c = c * math.log(rho_total) - math.lgamma(c + 1)
+    factor = c / (c - rho_total)
+
+    terms = []
+    for k in range(c):
+        if k == 0:
+            terms.append(1.0)
+        else:
+            terms.append(math.exp(k * math.log(rho_total) - math.lgamma(k + 1)))
+
+    erlang_c_num = math.exp(log_rho_c) * factor
+    return erlang_c_num / (sum(terms) + erlang_c_num)
+
+
+def _batch_degradation(batch_size: float) -> float:
+    """Per-request throughput degradation factor due to batching.
+
+    With continuous batching, a GPU shares memory bandwidth among concurrent
+    sequences. Per-request throughput degrades but sub-linearly:
+
+        degradation = 1 / batch_size^alpha,  alpha = 0.3
+
+    This means at batch_size=1, factor=1.0 (full speed); at bs=8, ~0.52;
+    at bs=64, ~0.27. The total GPU throughput (factor * bs) still grows.
+
+    Returns a value in (0, 1].
+    """
+    if batch_size <= 1.0:
+        return 1.0
+    alpha = 0.3
+    return 1.0 / (batch_size**alpha)
+
+
 def estimate_performance(
     dataset: DatasetStats,
     gpu: GPUProfile,
     config: PDConfig,
 ) -> PerformanceEstimate:
-    """Estimate performance metrics for a PD configuration.
+    """Estimate performance for a PD configuration using queuing + batching model.
 
-    Uses a simplified linear model (v1):
-    - TTFT = prompt_tokens_p95 / (prefill_throughput_per_gpu * num_prefill) * 1000
-    - TPOT = (num_concurrent_decode_requests / (decode_throughput_per_gpu * num_decode)) * 1000
-      where concurrent decode requests ≈ num_requests spread across decode GPUs
-    - throughput = decode_throughput_per_gpu * num_decode / output_len_mean
-    - cost = total_gpus * cost_per_hour
+    Prefill (TTFT):
+        - concurrent_per_gpu = num_requests / num_prefill
+        - per_request_prefill_tps = prefill_tps * batch_degradation(concurrent)
+        - service_time = prompt_len_p95 / per_request_prefill_tps
+        - M/M/c queue wait layered on top
+
+    Decode (TPOT):
+        - concurrent_per_gpu = num_requests / num_decode
+        - per_request_decode_tps = decode_tps * batch_degradation(concurrent)
+        - service_time = 1 / per_request_decode_tps
+        - M/M/c queue wait layered on top
     """
-    # TTFT: time to process the P95 prompt on the prefill fleet
-    total_prefill_tps = gpu.prefill_tokens_per_sec * config.num_prefill
-    ttft_ms = (dataset.prompt_len_p95 / total_prefill_tps) * 1000.0
+    # --- Prefill (TTFT) ---
+    prefill_concurrent = dataset.num_requests / config.num_prefill
+    prefill_degrad = _batch_degradation(prefill_concurrent)
+    per_req_prefill_tps = gpu.prefill_tokens_per_sec * prefill_degrad
 
-    # TPOT: per-token decode latency under load
-    # Model: each decode GPU handles (num_requests / num_decode) concurrent sequences
-    # Each sequence needs 1 token/step, so effective TPOT = concurrent_seqs / decode_tps * 1000
-    concurrent_per_gpu = dataset.num_requests / config.num_decode
-    tpot_ms = (concurrent_per_gpu / gpu.decode_tokens_per_sec) * 1000.0
+    # Service time for one P95 prompt on one GPU
+    prefill_service_s = dataset.prompt_len_p95 / per_req_prefill_tps
+    mu_prefill = 1.0 / prefill_service_s  # service rate (requests/s per GPU)
 
-    # Throughput: total decode tokens/s / avg output length = requests/s
-    total_decode_tps = gpu.decode_tokens_per_sec * config.num_decode
-    throughput_rps = total_decode_tps / dataset.output_len_mean
+    # Arrival rate: steady-state where total arrival = total capacity * utilization_target
+    # Use 70% target utilization to model a realistic operating point
+    utilization = 0.7
+    lambda_prefill = utilization * config.num_prefill * mu_prefill
+    rho_prefill = lambda_prefill / mu_prefill  # = utilization * c
 
-    # Cost
+    if rho_prefill < config.num_prefill:
+        p_q = _erlang_c(config.num_prefill, rho_prefill)
+        avg_wait_s = p_q / (config.num_prefill * mu_prefill - lambda_prefill)
+    else:
+        avg_wait_s = prefill_service_s * 5.0
+
+    ttft_ms = (prefill_service_s + avg_wait_s) * 1000.0
+
+    # --- Decode (TPOT) ---
+    decode_concurrent = dataset.num_requests / config.num_decode
+    decode_degrad = _batch_degradation(decode_concurrent)
+    per_req_decode_tps = gpu.decode_tokens_per_sec * decode_degrad
+
+    decode_service_s = 1.0 / per_req_decode_tps
+    mu_decode = per_req_decode_tps
+
+    lambda_decode = utilization * config.num_decode * mu_decode
+    rho_decode = lambda_decode / mu_decode
+
+    if rho_decode < config.num_decode:
+        p_q_d = _erlang_c(config.num_decode, rho_decode)
+        avg_wait_decode_s = p_q_d / (config.num_decode * mu_decode - lambda_decode)
+    else:
+        avg_wait_decode_s = decode_service_s * 5.0
+
+    tpot_ms = (decode_service_s + avg_wait_decode_s) * 1000.0
+
+    # --- Throughput ---
+    # Total system tokens/s = per_request_tps * concurrent_per_gpu * num_decode
+    total_system_tps = per_req_decode_tps * decode_concurrent * config.num_decode
+    throughput_rps = total_system_tps / dataset.output_len_mean
+
+    # --- Cost ---
     total_cost = config.total * gpu.cost_per_hour
 
     return PerformanceEstimate(

--- a/src/xpyd_plan/gpu_profiles.py
+++ b/src/xpyd_plan/gpu_profiles.py
@@ -1,0 +1,42 @@
+"""Built-in GPU profile library."""
+
+from __future__ import annotations
+
+from xpyd_plan.models import GPUProfile
+
+# Built-in GPU profiles with realistic throughput numbers.
+# prefill_tokens_per_sec: tokens/s per GPU for prompt processing (compute-bound)
+# decode_tokens_per_sec: tokens/s per GPU for autoregressive decode (memory-bandwidth-bound)
+_BUILTIN_PROFILES: dict[str, GPUProfile] = {
+    "A100-80G": GPUProfile(
+        name="A100-80G",
+        prefill_tokens_per_sec=50_000,
+        decode_tokens_per_sec=2_000,
+        memory_gb=80.0,
+        cost_per_hour=2.50,
+    ),
+    "H100-80G": GPUProfile(
+        name="H100-80G",
+        prefill_tokens_per_sec=120_000,
+        decode_tokens_per_sec=5_000,
+        memory_gb=80.0,
+        cost_per_hour=4.50,
+    ),
+}
+
+
+def get_gpu_profile(name: str) -> GPUProfile:
+    """Get a built-in GPU profile by name.
+
+    Raises:
+        KeyError: If the profile name is not found.
+    """
+    if name not in _BUILTIN_PROFILES:
+        available = ", ".join(sorted(_BUILTIN_PROFILES.keys()))
+        raise KeyError(f"Unknown GPU profile '{name}'. Available: {available}")
+    return _BUILTIN_PROFILES[name].model_copy()
+
+
+def list_gpu_profiles() -> list[str]:
+    """Return names of all built-in GPU profiles."""
+    return sorted(_BUILTIN_PROFILES.keys())

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -36,16 +36,16 @@ class TestEstimator:
         gpu = _make_gpu()
         perf_1p = estimate_performance(dataset, gpu, PDConfig(num_prefill=1, num_decode=7))
         perf_2p = estimate_performance(dataset, gpu, PDConfig(num_prefill=2, num_decode=6))
-        # Doubling prefill GPUs should halve TTFT
-        assert abs(perf_1p.ttft_ms / perf_2p.ttft_ms - 2.0) < 0.01
+        # More prefill GPUs should reduce TTFT
+        assert perf_2p.ttft_ms < perf_1p.ttft_ms
 
     def test_tpot_scales_with_decode_gpus(self):
         dataset = _make_dataset()
         gpu = _make_gpu()
         perf_2d = estimate_performance(dataset, gpu, PDConfig(num_prefill=6, num_decode=2))
         perf_4d = estimate_performance(dataset, gpu, PDConfig(num_prefill=4, num_decode=4))
-        # Doubling decode GPUs should halve TPOT
-        assert abs(perf_2d.tpot_ms / perf_4d.tpot_ms - 2.0) < 0.01
+        # More decode GPUs should reduce TPOT
+        assert perf_4d.tpot_ms < perf_2d.tpot_ms
 
     def test_cost_is_proportional_to_total_gpus(self):
         dataset = _make_dataset()

--- a/tests/test_gpu_profiles.py
+++ b/tests/test_gpu_profiles.py
@@ -1,0 +1,40 @@
+"""Tests for GPU profile library."""
+
+from __future__ import annotations
+
+import pytest
+
+from xpyd_plan.gpu_profiles import get_gpu_profile, list_gpu_profiles
+
+
+class TestGPUProfiles:
+    def test_list_profiles(self):
+        profiles = list_gpu_profiles()
+        assert "A100-80G" in profiles
+        assert "H100-80G" in profiles
+
+    def test_get_a100(self):
+        gpu = get_gpu_profile("A100-80G")
+        assert gpu.name == "A100-80G"
+        assert gpu.prefill_tokens_per_sec > 0
+        assert gpu.decode_tokens_per_sec > 0
+        assert gpu.memory_gb == 80.0
+
+    def test_get_h100(self):
+        gpu = get_gpu_profile("H100-80G")
+        assert gpu.name == "H100-80G"
+        # H100 should be faster than A100
+        a100 = get_gpu_profile("A100-80G")
+        assert gpu.prefill_tokens_per_sec > a100.prefill_tokens_per_sec
+        assert gpu.decode_tokens_per_sec > a100.decode_tokens_per_sec
+
+    def test_unknown_profile_raises(self):
+        with pytest.raises(KeyError, match="Unknown GPU profile"):
+            get_gpu_profile("RTX-4090")
+
+    def test_returned_profile_is_copy(self):
+        """Modifying returned profile should not affect the library."""
+        gpu1 = get_gpu_profile("A100-80G")
+        gpu1.cost_per_hour = 999.0
+        gpu2 = get_gpu_profile("A100-80G")
+        assert gpu2.cost_per_hour != 999.0

--- a/tests/test_queueing_estimator.py
+++ b/tests/test_queueing_estimator.py
@@ -1,0 +1,140 @@
+"""Tests for the queuing-theory based estimator (M2)."""
+
+from __future__ import annotations
+
+import math
+
+from xpyd_plan.estimator import (
+    _batch_degradation,
+    _erlang_c,
+    estimate_performance,
+)
+from xpyd_plan.gpu_profiles import get_gpu_profile
+from xpyd_plan.models import DatasetStats, GPUProfile, PDConfig
+
+
+def _make_dataset(**kwargs) -> DatasetStats:
+    defaults = dict(
+        prompt_len_mean=500,
+        prompt_len_p95=2000,
+        output_len_mean=200,
+        output_len_p95=800,
+        num_requests=1000,
+    )
+    defaults.update(kwargs)
+    return DatasetStats(**defaults)
+
+
+def _make_gpu(**kwargs) -> GPUProfile:
+    defaults = dict(
+        name="A100-80G",
+        prefill_tokens_per_sec=50000,
+        decode_tokens_per_sec=2000,
+        memory_gb=80,
+        cost_per_hour=2.50,
+    )
+    defaults.update(kwargs)
+    return GPUProfile(**defaults)
+
+
+class TestErlangC:
+    def test_zero_load(self):
+        assert _erlang_c(4, 0.0) == 0.0
+
+    def test_single_server_light_load(self):
+        """M/M/1 with rho=0.5 → Erlang-C = rho = 0.5."""
+        p = _erlang_c(1, 0.5)
+        assert abs(p - 0.5) < 0.01
+
+    def test_saturated_returns_one(self):
+        assert _erlang_c(4, 4.0) == 1.0
+        assert _erlang_c(4, 5.0) == 1.0
+
+    def test_more_servers_less_queuing(self):
+        p4 = _erlang_c(4, 3.0)
+        p8 = _erlang_c(8, 3.0)
+        assert p8 < p4
+
+    def test_zero_servers(self):
+        assert _erlang_c(0, 1.0) == 1.0
+
+
+class TestBatchDegradation:
+    def test_single_request(self):
+        assert _batch_degradation(1.0) == 1.0
+
+    def test_below_one(self):
+        assert _batch_degradation(0.5) == 1.0
+
+    def test_degrades_with_batch_size(self):
+        assert _batch_degradation(8) < _batch_degradation(1)
+
+    def test_monotonically_decreasing(self):
+        values = [_batch_degradation(bs) for bs in [1, 4, 16, 64, 256]]
+        for i in range(len(values) - 1):
+            assert values[i] >= values[i + 1]
+
+    def test_always_positive(self):
+        assert _batch_degradation(10000) > 0
+
+
+class TestQueueingEstimator:
+    def test_ttft_scales_with_prefill_gpus(self):
+        dataset = _make_dataset()
+        gpu = _make_gpu()
+        perf_1p = estimate_performance(dataset, gpu, PDConfig(num_prefill=1, num_decode=7))
+        perf_4p = estimate_performance(dataset, gpu, PDConfig(num_prefill=4, num_decode=4))
+        assert perf_4p.ttft_ms < perf_1p.ttft_ms
+
+    def test_tpot_scales_with_decode_gpus(self):
+        dataset = _make_dataset()
+        gpu = _make_gpu()
+        perf_2d = estimate_performance(dataset, gpu, PDConfig(num_prefill=6, num_decode=2))
+        perf_6d = estimate_performance(dataset, gpu, PDConfig(num_prefill=2, num_decode=6))
+        assert perf_6d.tpot_ms < perf_2d.tpot_ms
+
+    def test_cost_proportional(self):
+        dataset = _make_dataset()
+        gpu = _make_gpu()
+        perf = estimate_performance(dataset, gpu, PDConfig(num_prefill=3, num_decode=5))
+        assert perf.total_cost_per_hour == 8 * 2.50
+
+    def test_throughput_positive(self):
+        dataset = _make_dataset()
+        gpu = _make_gpu()
+        perf = estimate_performance(dataset, gpu, PDConfig(num_prefill=2, num_decode=6))
+        assert perf.throughput_rps > 0
+
+    def test_h100_faster_than_a100(self):
+        dataset = _make_dataset(num_requests=100)
+        config = PDConfig(num_prefill=2, num_decode=6)
+        perf_a100 = estimate_performance(dataset, get_gpu_profile("A100-80G"), config)
+        perf_h100 = estimate_performance(dataset, get_gpu_profile("H100-80G"), config)
+        assert perf_h100.ttft_ms < perf_a100.ttft_ms
+        assert perf_h100.tpot_ms < perf_a100.tpot_ms
+
+    def test_higher_load_increases_latency(self):
+        gpu = _make_gpu()
+        config = PDConfig(num_prefill=4, num_decode=4)
+        perf_low = estimate_performance(_make_dataset(num_requests=10), gpu, config)
+        perf_high = estimate_performance(_make_dataset(num_requests=500), gpu, config)
+        assert perf_high.tpot_ms > perf_low.tpot_ms
+        assert perf_high.ttft_ms > perf_low.ttft_ms
+
+    def test_all_values_finite(self):
+        dataset = _make_dataset()
+        gpu = _make_gpu()
+        perf = estimate_performance(dataset, gpu, PDConfig(num_prefill=4, num_decode=4))
+        assert math.isfinite(perf.ttft_ms)
+        assert math.isfinite(perf.tpot_ms)
+        assert math.isfinite(perf.throughput_rps)
+        assert math.isfinite(perf.total_cost_per_hour)
+
+    def test_all_values_positive(self):
+        dataset = _make_dataset()
+        gpu = _make_gpu()
+        perf = estimate_performance(dataset, gpu, PDConfig(num_prefill=4, num_decode=4))
+        assert perf.ttft_ms > 0
+        assert perf.tpot_ms > 0
+        assert perf.throughput_rps > 0
+        assert perf.total_cost_per_hour > 0


### PR DESCRIPTION
## 关联 Issue

Closes #3

## 改动内容

### 排队论模型（M/M/c Erlang-C）
- 用 Erlang-C 公式计算排队等待概率，替代 M1 的简单线性估算
- Prefill 和 Decode 分别建模为独立的 M/M/c 排队系统
- TTFT = 服务时间 + 排队等待时间
- TPOT = 单 token 服务时间 + 排队等待时间

### 批处理效应（Batch Degradation）
- 连续批处理下，每个请求的有效吞吐随并发数衰减（内存带宽共享）
- 模型：`degradation = 1 / batch_size^0.3`
- 总 GPU 吞吐仍随并发增长（亚线性），但单请求延迟增加

### GPU Profile 库
- 内置 A100-80G、H100-80G profile
- `get_gpu_profile(name)` 工厂函数，返回独立副本
- `list_gpu_profiles()` 查看可用 profile

### 测试
- 原有 17 个测试继续通过（调整了线性假设的断言为单调性断言）
- 新增 23 个测试：Erlang-C 5个、批处理 5个、排队估算器 8个、GPU Profile 5个
- 总计 40 个测试全部通过

### 向后兼容
- `estimate_performance()` 函数签名不变
- CLI 和配置格式不变
