### PR TITLE
feat(export): M9 — JSON/CSV export and programmatic API

### DIFF
--- a/src/xpyd_plan/cli.py
+++ b/src/xpyd_plan/cli.py
@@ -316,6 +316,16 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
             result = analyzer.find_optimal_ratio(total, sla)
             Path(args.output).write_text(result.model_dump_json(indent=2))
             console.print(f"\n[dim]Result written to {args.output}[/dim]")
+
+        # Machine-readable output format
+        if args.output_format in ("json", "csv"):
+            from xpyd_plan.export import result_to_csv, result_to_json
+
+            result = analyzer.find_optimal_ratio(total, sla)
+            if args.output_format == "json":
+                print(result_to_json(result))
+            else:
+                print(result_to_csv(result), end="")
     else:
         # Multi-file mode
         if load_fn:
@@ -401,6 +411,15 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
             Path(args.output).write_text(multi_result.model_dump_json(indent=2))
             console.print(f"\n[dim]Result written to {args.output}[/dim]")
 
+        # Machine-readable output format
+        if args.output_format in ("json", "csv"):
+            from xpyd_plan.export import result_to_csv, result_to_json
+
+            if args.output_format == "json":
+                print(result_to_json(multi_result))
+            else:
+                print(result_to_csv(multi_result), end="")
+
 
 def _cmd_plan_legacy(args: argparse.Namespace) -> None:
     """Handle the legacy 'plan' subcommand (deprecated)."""
@@ -466,6 +485,24 @@ def _cmd_plan_legacy(args: argparse.Namespace) -> None:
         console.print(f"\n[dim]Result written to {args.output}[/dim]")
 
 
+def _cmd_export(args: argparse.Namespace) -> None:
+    """Handle the 'export' subcommand for batch export."""
+    from xpyd_plan.export import export_batch
+
+    sla = SLAConfig(
+        ttft_ms=args.sla_ttft,
+        tpot_ms=args.sla_tpot,
+        max_latency_ms=args.sla_max_latency,
+    )
+    output = export_batch(
+        benchmark_dir=args.dir,
+        sla_config=sla,
+        output_format=args.output_format,
+        total_instances=args.total_instances,
+    )
+    print(output, end="" if args.output_format == "csv" else "\n")
+
+
 def main(argv: list[str] | None = None) -> None:
     """Entry point for `xpyd-plan` command."""
     parser = argparse.ArgumentParser(
@@ -527,6 +564,11 @@ def main(argv: list[str] | None = None) -> None:
         "--budget-ceiling", type=float, default=None,
         help="Max hourly cost budget (used with --cost-model)",
     )
+    analyze_parser.add_argument(
+        "--output-format", type=str, choices=["table", "json", "csv"],
+        default="table",
+        help="Output format: table (Rich), json, or csv (default: table)",
+    )
 
     # plan subcommand (legacy, deprecated)
     plan_parser = subparsers.add_parser(
@@ -538,12 +580,41 @@ def main(argv: list[str] | None = None) -> None:
     plan_parser.add_argument("--top", type=int, default=5, help="Top N candidates")
     plan_parser.add_argument("--output", type=str, default=None, help="Output JSON path")
 
+    # export subcommand
+    export_parser = subparsers.add_parser(
+        "export",
+        help="Batch export benchmark analysis results from a directory",
+    )
+    export_parser.add_argument(
+        "--dir", type=str, required=True,
+        help="Directory containing benchmark JSON files",
+    )
+    export_parser.add_argument(
+        "--output-format", type=str, choices=["json", "csv"], default="json",
+        help="Export format (default: json)",
+    )
+    export_parser.add_argument(
+        "--sla-ttft", type=float, default=None, help="SLA: max TTFT P95 (ms)",
+    )
+    export_parser.add_argument(
+        "--sla-tpot", type=float, default=None, help="SLA: max TPOT P95 (ms)",
+    )
+    export_parser.add_argument(
+        "--sla-max-latency", type=float, default=None, help="SLA: max total latency P95 (ms)",
+    )
+    export_parser.add_argument(
+        "--total-instances", type=int, default=None,
+        help="Total instances to optimize for",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "analyze":
         _cmd_analyze(args)
     elif args.command == "plan":
         _cmd_plan_legacy(args)
+    elif args.command == "export":
+        _cmd_export(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/export.py
+++ b/src/xpyd_plan/export.py
@@ -1,0 +1,212 @@
+"""JSON/CSV export and programmatic API for xpyd-plan.
+
+Provides machine-readable output formats and a clean Python API
+for programmatic usage without the CLI.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+from xpyd_plan.analyzer import BenchmarkAnalyzer
+from xpyd_plan.benchmark_models import (
+    AnalysisResult,
+    MultiScenarioResult,
+    RatioCandidate,
+)
+from xpyd_plan.models import SLAConfig
+
+
+def analyze(
+    benchmark_paths: list[str] | str,
+    sla_config: SLAConfig | dict | None = None,
+    total_instances: int | None = None,
+    cost_model_path: str | None = None,
+    budget_ceiling: float | None = None,
+) -> dict[str, Any]:
+    """Programmatic API: analyze benchmark data and return structured results.
+
+    Args:
+        benchmark_paths: Path(s) to benchmark JSON file(s).
+        sla_config: SLA configuration (SLAConfig object or dict).
+        total_instances: Total instances to optimize for (default: from benchmark).
+        cost_model_path: Optional YAML path for cost model.
+        budget_ceiling: Optional max hourly cost budget.
+
+    Returns:
+        Dictionary with analysis results, optionally including cost data.
+    """
+    from xpyd_plan.bench_adapter import load_benchmark_auto
+
+    if isinstance(benchmark_paths, str):
+        benchmark_paths = [benchmark_paths]
+
+    if isinstance(sla_config, dict):
+        sla_config = SLAConfig(**sla_config)
+    elif sla_config is None:
+        sla_config = SLAConfig()
+
+    analyzer = BenchmarkAnalyzer()
+    output: dict[str, Any] = {}
+
+    if len(benchmark_paths) == 1:
+        data = load_benchmark_auto(benchmark_paths[0])
+        analyzer._data = data
+        total = total_instances or data.metadata.total_instances
+        result = analyzer.find_optimal_ratio(total, sla_config)
+        output["mode"] = "single"
+        output["analysis"] = json.loads(result.model_dump_json())
+    else:
+        datasets = [load_benchmark_auto(b) for b in benchmark_paths]
+        datasets.sort(key=lambda d: d.metadata.measured_qps)
+        analyzer._multi_data = datasets
+        analyzer._data = datasets[0]
+        total = total_instances or datasets[0].metadata.total_instances
+        multi_result = analyzer.find_optimal_ratio_multi(total, sla_config)
+        output["mode"] = "multi"
+        output["analysis"] = json.loads(multi_result.model_dump_json())
+
+    if cost_model_path:
+        from xpyd_plan.cost import CostAnalyzer, CostConfig
+
+        cost_config = CostConfig.from_yaml(cost_model_path)
+        cost_analyzer = CostAnalyzer(cost_config)
+        if len(benchmark_paths) == 1:
+            result = analyzer.find_optimal_ratio(total, sla_config)
+            qps = analyzer.data.metadata.measured_qps
+            comparison = cost_analyzer.compare(result, qps, budget_ceiling)
+            output["cost"] = json.loads(comparison.model_dump_json())
+
+    return output
+
+
+def result_to_json(result: AnalysisResult | MultiScenarioResult, indent: int = 2) -> str:
+    """Convert analysis result to JSON string."""
+    return result.model_dump_json(indent=indent)
+
+
+def _candidate_to_row(candidate: RatioCandidate, scenario_qps: float | None = None) -> dict:
+    """Convert a RatioCandidate to a flat dict for CSV export."""
+    row: dict[str, Any] = {}
+    if scenario_qps is not None:
+        row["qps"] = scenario_qps
+    row["config"] = candidate.ratio_str
+    row["num_prefill"] = candidate.num_prefill
+    row["num_decode"] = candidate.num_decode
+    row["total_instances"] = candidate.total
+    row["prefill_utilization"] = round(candidate.prefill_utilization, 4)
+    row["decode_utilization"] = round(candidate.decode_utilization, 4)
+    row["waste_rate"] = round(candidate.waste_rate, 4)
+    row["meets_sla"] = candidate.meets_sla
+
+    if candidate.sla_check:
+        row["ttft_p95_ms"] = round(candidate.sla_check.ttft_p95_ms, 2)
+        row["ttft_p99_ms"] = round(candidate.sla_check.ttft_p99_ms, 2)
+        row["tpot_p95_ms"] = round(candidate.sla_check.tpot_p95_ms, 2)
+        row["tpot_p99_ms"] = round(candidate.sla_check.tpot_p99_ms, 2)
+        row["total_latency_p95_ms"] = round(candidate.sla_check.total_latency_p95_ms, 2)
+        row["total_latency_p99_ms"] = round(candidate.sla_check.total_latency_p99_ms, 2)
+    else:
+        for k in [
+            "ttft_p95_ms", "ttft_p99_ms", "tpot_p95_ms", "tpot_p99_ms",
+            "total_latency_p95_ms", "total_latency_p99_ms",
+        ]:
+            row[k] = ""
+
+    return row
+
+
+def result_to_csv(result: AnalysisResult | MultiScenarioResult) -> str:
+    """Convert analysis result to CSV string.
+
+    For single analysis: one row per candidate.
+    For multi-scenario: one row per candidate per scenario, with qps column.
+    """
+    rows: list[dict] = []
+
+    if isinstance(result, MultiScenarioResult):
+        for scenario in result.scenarios:
+            for candidate in scenario.analysis.candidates:
+                rows.append(_candidate_to_row(candidate, scenario_qps=scenario.qps))
+    else:
+        for candidate in result.candidates:
+            rows.append(_candidate_to_row(candidate))
+
+    if not rows:
+        return ""
+
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=list(rows[0].keys()))
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def export_batch(
+    benchmark_dir: str,
+    sla_config: SLAConfig | dict | None = None,
+    output_format: str = "json",
+    total_instances: int | None = None,
+) -> str:
+    """Batch export all benchmark JSON files in a directory.
+
+    Args:
+        benchmark_dir: Directory containing benchmark JSON files.
+        sla_config: SLA configuration.
+        output_format: "json" or "csv".
+        total_instances: Total instances to optimize for.
+
+    Returns:
+        Formatted string (JSON or CSV).
+    """
+    from xpyd_plan.bench_adapter import load_benchmark_auto
+
+    if isinstance(sla_config, dict):
+        sla_config = SLAConfig(**sla_config)
+    elif sla_config is None:
+        sla_config = SLAConfig()
+
+    benchmark_files = sorted(Path(benchmark_dir).glob("*.json"))
+    if not benchmark_files:
+        raise FileNotFoundError(f"No JSON files found in {benchmark_dir}")
+
+    results: list[dict[str, Any]] = []
+
+    for bf in benchmark_files:
+        analyzer = BenchmarkAnalyzer()
+        data = load_benchmark_auto(str(bf))
+        analyzer._data = data
+        total = total_instances or data.metadata.total_instances
+        result = analyzer.find_optimal_ratio(total, sla_config)
+
+        entry = {
+            "file": bf.name,
+            "qps": data.metadata.measured_qps,
+            "total_instances": total,
+            "analysis": json.loads(result.model_dump_json()),
+        }
+        results.append(entry)
+
+    if output_format == "json":
+        return json.dumps(results, indent=2)
+    elif output_format == "csv":
+        all_rows: list[dict] = []
+        for entry in results:
+            result_obj = AnalysisResult(**entry["analysis"])
+            for candidate in result_obj.candidates:
+                row = _candidate_to_row(candidate, scenario_qps=entry["qps"])
+                row["file"] = entry["file"]
+                all_rows.append(row)
+        if not all_rows:
+            return ""
+        output = io.StringIO()
+        writer = csv.DictWriter(output, fieldnames=list(all_rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(all_rows)
+        return output.getvalue()
+    else:
+        raise ValueError(f"Unsupported output format: {output_format}")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,297 @@
+"""Tests for JSON/CSV export and programmatic API (M9)."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import random
+from pathlib import Path
+
+import pytest
+
+from xpyd_plan.benchmark_models import (
+    AnalysisResult,
+    MultiScenarioResult,
+    RatioCandidate,
+    SLACheck,
+)
+from xpyd_plan.export import (
+    _candidate_to_row,
+    analyze,
+    export_batch,
+    result_to_csv,
+    result_to_json,
+)
+from xpyd_plan.models import SLAConfig
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+def _make_requests(
+    n: int = 100,
+    ttft_range: tuple[float, float] = (50, 500),
+    tpot_range: tuple[float, float] = (10, 40),
+    seed: int = 42,
+) -> list[dict]:
+    rng = random.Random(seed)
+    requests = []
+    base_ts = 1700000000.0
+    for i in range(n):
+        prompt_tokens = rng.randint(100, 2000)
+        output_tokens = rng.randint(50, 500)
+        ttft = rng.uniform(*ttft_range)
+        tpot = rng.uniform(*tpot_range)
+        total = ttft + tpot * output_tokens
+        requests.append({
+            "request_id": f"req-{i:04d}",
+            "prompt_tokens": prompt_tokens,
+            "output_tokens": output_tokens,
+            "ttft_ms": round(ttft, 2),
+            "tpot_ms": round(tpot, 2),
+            "total_latency_ms": round(total, 2),
+            "timestamp": base_ts + i * 0.1,
+        })
+    return requests
+
+
+def _make_benchmark_data(
+    n: int = 100, num_p: int = 2, num_d: int = 6, qps: float = 10.0, **kwargs
+) -> dict:
+    return {
+        "metadata": {
+            "num_prefill_instances": num_p,
+            "num_decode_instances": num_d,
+            "total_instances": num_p + num_d,
+            "measured_qps": qps,
+        },
+        "requests": _make_requests(n=n, **kwargs),
+    }
+
+
+@pytest.fixture
+def benchmark_file(tmp_path: Path) -> Path:
+    p = tmp_path / "bench.json"
+    p.write_text(json.dumps(_make_benchmark_data()))
+    return p
+
+
+@pytest.fixture
+def benchmark_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "benchmarks"
+    d.mkdir()
+    for qps in [5.0, 10.0, 15.0]:
+        p = d / f"bench_qps{qps:.0f}.json"
+        p.write_text(json.dumps(_make_benchmark_data(qps=qps, seed=int(qps))))
+    return d
+
+
+@pytest.fixture
+def sla() -> SLAConfig:
+    return SLAConfig(ttft_ms=600.0, tpot_ms=50.0)
+
+
+@pytest.fixture
+def analysis_result() -> AnalysisResult:
+    sla_check = SLACheck(
+        ttft_p95_ms=400.0, ttft_p99_ms=450.0,
+        tpot_p95_ms=35.0, tpot_p99_ms=38.0,
+        total_latency_p95_ms=5000.0, total_latency_p99_ms=5500.0,
+        meets_ttft=True, meets_tpot=True, meets_total_latency=True, meets_all=True,
+    )
+    candidates = [
+        RatioCandidate(
+            num_prefill=2, num_decode=6,
+            prefill_utilization=0.8, decode_utilization=0.9,
+            waste_rate=0.1, meets_sla=True, sla_check=sla_check,
+        ),
+        RatioCandidate(
+            num_prefill=3, num_decode=5,
+            prefill_utilization=0.6, decode_utilization=0.95,
+            waste_rate=0.35, meets_sla=True, sla_check=sla_check,
+        ),
+        RatioCandidate(
+            num_prefill=1, num_decode=7,
+            prefill_utilization=0.99, decode_utilization=0.7,
+            waste_rate=0.29, meets_sla=False, sla_check=sla_check,
+        ),
+    ]
+    return AnalysisResult(
+        best=candidates[0], candidates=candidates, total_instances=8,
+    )
+
+
+# ── result_to_json ────────────────────────────────────────────────────────
+
+
+class TestResultToJson:
+    def test_valid_json(self, analysis_result: AnalysisResult) -> None:
+        out = result_to_json(analysis_result)
+        data = json.loads(out)
+        assert "best" in data
+        assert "candidates" in data
+
+    def test_candidates_count(self, analysis_result: AnalysisResult) -> None:
+        data = json.loads(result_to_json(analysis_result))
+        assert len(data["candidates"]) == 3
+
+    def test_indent_custom(self, analysis_result: AnalysisResult) -> None:
+        out = result_to_json(analysis_result, indent=4)
+        assert "    " in out
+
+    def test_best_fields(self, analysis_result: AnalysisResult) -> None:
+        data = json.loads(result_to_json(analysis_result))
+        best = data["best"]
+        assert best["num_prefill"] == 2
+        assert best["num_decode"] == 6
+        assert best["meets_sla"] is True
+
+
+# ── result_to_csv ─────────────────────────────────────────────────────────
+
+
+class TestResultToCsv:
+    def test_csv_header(self, analysis_result: AnalysisResult) -> None:
+        out = result_to_csv(analysis_result)
+        reader = csv.DictReader(io.StringIO(out))
+        assert "config" in reader.fieldnames
+        assert "waste_rate" in reader.fieldnames
+
+    def test_csv_row_count(self, analysis_result: AnalysisResult) -> None:
+        out = result_to_csv(analysis_result)
+        reader = csv.DictReader(io.StringIO(out))
+        rows = list(reader)
+        assert len(rows) == 3
+
+    def test_csv_values(self, analysis_result: AnalysisResult) -> None:
+        out = result_to_csv(analysis_result)
+        reader = csv.DictReader(io.StringIO(out))
+        rows = list(reader)
+        assert rows[0]["config"] == "2P:6D"
+        assert rows[0]["meets_sla"] == "True"
+
+    def test_csv_empty_result(self) -> None:
+        result = AnalysisResult(best=None, candidates=[], total_instances=8)
+        out = result_to_csv(result)
+        assert out == ""
+
+    def test_csv_no_sla_check(self) -> None:
+        c = RatioCandidate(
+            num_prefill=2, num_decode=6,
+            prefill_utilization=0.8, decode_utilization=0.9,
+            waste_rate=0.1, meets_sla=True, sla_check=None,
+        )
+        result = AnalysisResult(best=c, candidates=[c], total_instances=8)
+        out = result_to_csv(result)
+        reader = csv.DictReader(io.StringIO(out))
+        rows = list(reader)
+        assert rows[0]["ttft_p95_ms"] == ""
+
+
+# ── _candidate_to_row ─────────────────────────────────────────────────────
+
+
+class TestCandidateToRow:
+    def test_basic_fields(self) -> None:
+        c = RatioCandidate(
+            num_prefill=3, num_decode=5,
+            prefill_utilization=0.6, decode_utilization=0.95,
+            waste_rate=0.35, meets_sla=True,
+        )
+        row = _candidate_to_row(c)
+        assert row["config"] == "3P:5D"
+        assert row["total_instances"] == 8
+        assert "qps" not in row
+
+    def test_with_qps(self) -> None:
+        c = RatioCandidate(
+            num_prefill=2, num_decode=6,
+            prefill_utilization=0.8, decode_utilization=0.9,
+            waste_rate=0.1, meets_sla=True,
+        )
+        row = _candidate_to_row(c, scenario_qps=10.0)
+        assert row["qps"] == 10.0
+
+
+# ── Multi-scenario CSV ────────────────────────────────────────────────────
+
+
+class TestMultiScenarioCsv:
+    def test_multi_csv_has_qps(self) -> None:
+        from xpyd_plan.benchmark_models import ScenarioResult
+
+        sla_check = SLACheck(
+            ttft_p95_ms=400.0, ttft_p99_ms=450.0,
+            tpot_p95_ms=35.0, tpot_p99_ms=38.0,
+            total_latency_p95_ms=5000.0, total_latency_p99_ms=5500.0,
+            meets_ttft=True, meets_tpot=True, meets_total_latency=True, meets_all=True,
+        )
+        c = RatioCandidate(
+            num_prefill=2, num_decode=6,
+            prefill_utilization=0.8, decode_utilization=0.9,
+            waste_rate=0.1, meets_sla=True, sla_check=sla_check,
+        )
+        scenario = ScenarioResult(
+            qps=10.0,
+            analysis=AnalysisResult(best=c, candidates=[c], total_instances=8),
+        )
+        multi = MultiScenarioResult(
+            scenarios=[scenario], total_instances=8, unified_best=c,
+        )
+        out = result_to_csv(multi)
+        reader = csv.DictReader(io.StringIO(out))
+        rows = list(reader)
+        assert rows[0]["qps"] == "10.0"
+
+
+# ── Programmatic API (analyze) ────────────────────────────────────────────
+
+
+class TestAnalyzeApi:
+    def test_single_file(self, benchmark_file: Path, sla: SLAConfig) -> None:
+        result = analyze(str(benchmark_file), sla_config=sla)
+        assert result["mode"] == "single"
+        assert "analysis" in result
+        assert "candidates" in result["analysis"]
+
+    def test_single_file_string(self, benchmark_file: Path) -> None:
+        result = analyze(str(benchmark_file))
+        assert result["mode"] == "single"
+
+    def test_dict_sla(self, benchmark_file: Path) -> None:
+        result = analyze(str(benchmark_file), sla_config={"ttft_ms": 600.0})
+        assert result["mode"] == "single"
+
+    def test_none_sla(self, benchmark_file: Path) -> None:
+        result = analyze(str(benchmark_file), sla_config=None)
+        assert result["mode"] == "single"
+
+
+# ── Batch export ──────────────────────────────────────────────────────────
+
+
+class TestExportBatch:
+    def test_json_export(self, benchmark_dir: Path, sla: SLAConfig) -> None:
+        out = export_batch(str(benchmark_dir), sla_config=sla, output_format="json")
+        data = json.loads(out)
+        assert isinstance(data, list)
+        assert len(data) == 3
+        assert "file" in data[0]
+        assert "analysis" in data[0]
+
+    def test_csv_export(self, benchmark_dir: Path, sla: SLAConfig) -> None:
+        out = export_batch(str(benchmark_dir), sla_config=sla, output_format="csv")
+        reader = csv.DictReader(io.StringIO(out))
+        rows = list(reader)
+        assert len(rows) > 0
+        assert "file" in reader.fieldnames
+
+    def test_empty_dir(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        with pytest.raises(FileNotFoundError):
+            export_batch(str(empty))
+
+    def test_invalid_format(self, benchmark_dir: Path) -> None:
+        with pytest.raises(ValueError, match="Unsupported"):
+            export_batch(str(benchmark_dir), output_format="xml")


### PR DESCRIPTION
## Summary
Add machine-readable output formats and a clean Python API for programmatic usage.

### Changes
- **`xpyd_plan.export` module**: `result_to_json()`, `result_to_csv()`, `analyze()`, `export_batch()`
- **CLI `--output-format json|csv|table`**: Machine-readable output to stdout
- **CLI `export` subcommand**: Batch export all benchmarks in a directory
- **Programmatic API**: `analyze(benchmarks, sla_config)` returns structured dict
- **20 new tests** covering all export paths

Closes #19