### PR TITLE
feat(capacity): M10 — capacity planning mode with scaling model

### DIFF
--- a/src/xpyd_plan/capacity.py
+++ b/src/xpyd_plan/capacity.py
@@ -1,0 +1,272 @@
+"""Capacity planning module for xpyd-plan.
+
+Given benchmark data at various cluster sizes, recommends the minimum
+total instances and optimal P:D ratio to meet a target QPS and SLA.
+"""
+
+from __future__ import annotations
+
+import math
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from xpyd_plan.analyzer import BenchmarkAnalyzer
+from xpyd_plan.benchmark_models import BenchmarkData
+from xpyd_plan.models import SLAConfig
+
+
+class ConfidenceLevel(str, Enum):
+    """Confidence level of the capacity recommendation."""
+
+    HIGH = "high"  # interpolation between known data points
+    MEDIUM = "medium"  # slight extrapolation beyond known range
+    LOW = "low"  # significant extrapolation beyond known range
+
+
+class ScalingDataPoint(BaseModel):
+    """A data point mapping cluster size to measured performance."""
+
+    total_instances: int
+    num_prefill: int
+    num_decode: int
+    measured_qps: float
+    max_qps_meeting_sla: float | None = None
+    ttft_p95_ms: float
+    tpot_p95_ms: float
+    waste_rate: float
+
+
+class CapacityRecommendation(BaseModel):
+    """Result of capacity planning."""
+
+    target_qps: float = Field(..., description="Requested target QPS")
+    recommended_instances: int = Field(..., description="Minimum total instances needed")
+    recommended_ratio: str = Field(..., description="Recommended P:D ratio string")
+    num_prefill: int
+    num_decode: int
+    confidence: ConfidenceLevel
+    estimated_headroom_pct: float = Field(
+        ..., description="Estimated QPS headroom above target (%)"
+    )
+    scaling_points: list[ScalingDataPoint] = Field(
+        default_factory=list, description="Data points used for scaling model"
+    )
+    notes: list[str] = Field(default_factory=list)
+
+
+class CapacityPlanner:
+    """Plans capacity based on benchmark data at different cluster sizes.
+
+    Usage:
+        planner = CapacityPlanner()
+        planner.fit(benchmark_datasets)
+        rec = planner.recommend(target_qps=50.0, sla=SLAConfig(...))
+    """
+
+    def __init__(self) -> None:
+        self._points: list[ScalingDataPoint] = []
+        self._fitted = False
+
+    @property
+    def points(self) -> list[ScalingDataPoint]:
+        """Return fitted scaling data points."""
+        return list(self._points)
+
+    def fit(
+        self,
+        datasets: list[BenchmarkData],
+        sla: SLAConfig | None = None,
+    ) -> None:
+        """Learn scaling characteristics from benchmark datasets.
+
+        Args:
+            datasets: Benchmark data from runs at different cluster sizes/QPS levels.
+            sla: SLA config for determining which configs meet SLA.
+        """
+        if not datasets:
+            raise ValueError("At least one benchmark dataset is required")
+
+        if sla is None:
+            sla = SLAConfig()
+
+        points: list[ScalingDataPoint] = []
+
+        for data in datasets:
+            analyzer = BenchmarkAnalyzer()
+            analyzer._data = data
+
+            sla_check = analyzer.check_sla(sla)
+            util = analyzer.compute_utilization()
+
+            max_qps = data.metadata.measured_qps if sla_check.meets_all else None
+
+            points.append(
+                ScalingDataPoint(
+                    total_instances=data.metadata.total_instances,
+                    num_prefill=data.metadata.num_prefill_instances,
+                    num_decode=data.metadata.num_decode_instances,
+                    measured_qps=data.metadata.measured_qps,
+                    max_qps_meeting_sla=max_qps,
+                    ttft_p95_ms=sla_check.ttft_p95_ms,
+                    tpot_p95_ms=sla_check.tpot_p95_ms,
+                    waste_rate=util.waste_rate,
+                )
+            )
+
+        # Sort by total instances
+        points.sort(key=lambda p: (p.total_instances, p.measured_qps))
+        self._points = points
+        self._fitted = True
+
+    def _estimate_qps_per_instance(self) -> float:
+        """Estimate throughput per instance from data points that meet SLA."""
+        valid = [p for p in self._points if p.max_qps_meeting_sla is not None]
+        if not valid:
+            # Fall back to all points
+            valid = self._points
+            values = [p.measured_qps / p.total_instances for p in valid]
+        else:
+            values = [p.max_qps_meeting_sla / p.total_instances for p in valid]  # type: ignore[operator]
+
+        return sum(values) / len(values)
+
+    def _determine_confidence(self, target_qps: float) -> ConfidenceLevel:
+        """Determine confidence based on how far target is from known data."""
+        all_qps = [p.measured_qps for p in self._points]
+        min_qps = min(all_qps)
+        max_qps = max(all_qps)
+        qps_range = max_qps - min_qps if max_qps > min_qps else max_qps
+
+        if min_qps <= target_qps <= max_qps:
+            return ConfidenceLevel.HIGH
+        elif target_qps < min_qps:
+            # Below range — usually safe
+            return ConfidenceLevel.HIGH
+
+        # Extrapolation above
+        overshoot = (target_qps - max_qps) / qps_range if qps_range > 0 else float("inf")
+        if overshoot <= 0.5:
+            return ConfidenceLevel.MEDIUM
+        return ConfidenceLevel.LOW
+
+    def _find_best_ratio(self, target_instances: int) -> tuple[int, int]:
+        """Find the best P:D split for the given total from known data.
+
+        Uses the ratio from the closest data point that meets SLA,
+        or falls back to the ratio with lowest waste.
+        """
+        valid = [p for p in self._points if p.max_qps_meeting_sla is not None]
+        if not valid:
+            valid = self._points
+
+        # Find closest point by total_instances
+        closest = min(valid, key=lambda p: abs(p.total_instances - target_instances))
+        ratio = closest.num_prefill / (closest.num_prefill + closest.num_decode)
+
+        num_prefill = max(1, round(ratio * target_instances))
+        num_decode = max(1, target_instances - num_prefill)
+
+        return num_prefill, num_decode
+
+    def recommend(
+        self,
+        target_qps: float,
+        sla: SLAConfig | None = None,
+        max_instances: int = 64,
+    ) -> CapacityRecommendation:
+        """Recommend minimum instances and P:D ratio for target QPS.
+
+        Args:
+            target_qps: Target queries per second to support.
+            sla: SLA constraints (used for confidence, not re-checked).
+            max_instances: Upper bound on instance search (default: 64).
+
+        Returns:
+            CapacityRecommendation with minimum instances and ratio.
+
+        Raises:
+            RuntimeError: If fit() hasn't been called.
+            ValueError: If target_qps is not positive.
+        """
+        if not self._fitted:
+            raise RuntimeError("Call fit() before recommend()")
+
+        if target_qps <= 0:
+            raise ValueError("target_qps must be positive")
+
+        qps_per_instance = self._estimate_qps_per_instance()
+        raw_instances = target_qps / qps_per_instance
+
+        # Add 20% headroom and round up
+        min_instances = max(2, math.ceil(raw_instances * 1.2))
+
+        # Cap at max_instances
+        recommended = min(min_instances, max_instances)
+
+        num_prefill, num_decode = self._find_best_ratio(recommended)
+        actual_total = num_prefill + num_decode
+        estimated_qps = actual_total * qps_per_instance
+        headroom = ((estimated_qps - target_qps) / target_qps) * 100.0
+
+        confidence = self._determine_confidence(target_qps)
+
+        notes: list[str] = []
+        if confidence == ConfidenceLevel.LOW:
+            notes.append(
+                "Significant extrapolation beyond benchmark data range. "
+                "Run additional benchmarks at higher instance counts to improve accuracy."
+            )
+        if recommended >= max_instances:
+            notes.append(
+                f"Reached max_instances limit ({max_instances}). "
+                "Target QPS may not be achievable."
+            )
+
+        return CapacityRecommendation(
+            target_qps=target_qps,
+            recommended_instances=actual_total,
+            recommended_ratio=f"{num_prefill}P:{num_decode}D",
+            num_prefill=num_prefill,
+            num_decode=num_decode,
+            confidence=confidence,
+            estimated_headroom_pct=round(headroom, 1),
+            scaling_points=self._points,
+            notes=notes,
+        )
+
+
+def plan_capacity(
+    benchmark_paths: list[str],
+    target_qps: float,
+    sla_config: SLAConfig | dict | None = None,
+    max_instances: int = 64,
+) -> dict[str, Any]:
+    """Programmatic API for capacity planning.
+
+    Args:
+        benchmark_paths: Paths to benchmark JSON files at different scales.
+        target_qps: Target QPS to achieve.
+        sla_config: SLA configuration.
+        max_instances: Maximum instances to consider.
+
+    Returns:
+        Dictionary with capacity recommendation.
+    """
+    import json
+
+    from xpyd_plan.bench_adapter import load_benchmark_auto
+
+    if isinstance(sla_config, dict):
+        sla_config = SLAConfig(**sla_config)
+    elif sla_config is None:
+        sla_config = SLAConfig()
+
+    datasets = [load_benchmark_auto(p) for p in benchmark_paths]
+
+    planner = CapacityPlanner()
+    planner.fit(datasets, sla=sla_config)
+    rec = planner.recommend(target_qps=target_qps, sla=sla_config, max_instances=max_instances)
+
+    return json.loads(rec.model_dump_json())

--- a/src/xpyd_plan/cli.py
+++ b/src/xpyd_plan/cli.py
@@ -503,6 +503,68 @@ def _cmd_export(args: argparse.Namespace) -> None:
     print(output, end="" if args.output_format == "csv" else "\n")
 
 
+def _cmd_plan_capacity(args: argparse.Namespace) -> None:
+    """Handle the 'plan-capacity' subcommand."""
+    from xpyd_plan.bench_adapter import load_benchmark_auto
+    from xpyd_plan.capacity import CapacityPlanner
+
+    console = Console()
+
+    sla = SLAConfig(
+        ttft_ms=args.sla_ttft,
+        tpot_ms=args.sla_tpot,
+        max_latency_ms=args.sla_max_latency,
+    )
+
+    datasets = [load_benchmark_auto(b) for b in args.benchmark]
+    planner = CapacityPlanner()
+    planner.fit(datasets, sla=sla)
+    rec = planner.recommend(
+        target_qps=args.target_qps,
+        sla=sla,
+        max_instances=args.max_instances,
+    )
+
+    if args.output_format == "json":
+        print(rec.model_dump_json(indent=2))
+        return
+
+    console.print(f"\n[bold]📐 Capacity Planning — Target QPS: {rec.target_qps:.1f}[/bold]")
+    confidence_color = {"high": "green", "medium": "yellow", "low": "red"}[rec.confidence.value]
+    console.print(
+        f"\n   [bold {confidence_color}]Recommendation: {rec.recommended_ratio}"
+        f" ({rec.recommended_instances} instances)[/bold {confidence_color}]"
+    )
+    console.print(f"   Confidence: [{confidence_color}]{rec.confidence.value}[/{confidence_color}]")
+    console.print(f"   Estimated headroom: {rec.estimated_headroom_pct:+.1f}%")
+
+    if rec.notes:
+        for note in rec.notes:
+            console.print(f"   ⚠️  {note}")
+
+    # Scaling data table
+    table = Table(title="\nScaling Data Points")
+    table.add_column("Instances", justify="right")
+    table.add_column("Config", style="cyan")
+    table.add_column("QPS", justify="right")
+    table.add_column("Meets SLA", justify="center")
+    table.add_column("TTFT P95", justify="right")
+    table.add_column("TPOT P95", justify="right")
+
+    for p in rec.scaling_points:
+        sla_str = "✅" if p.max_qps_meeting_sla is not None else "❌"
+        table.add_row(
+            str(p.total_instances),
+            f"{p.num_prefill}P:{p.num_decode}D",
+            f"{p.measured_qps:.1f}",
+            sla_str,
+            f"{p.ttft_p95_ms:.1f}",
+            f"{p.tpot_p95_ms:.1f}",
+        )
+
+    console.print(table)
+
+
 def main(argv: list[str] | None = None) -> None:
     """Entry point for `xpyd-plan` command."""
     parser = argparse.ArgumentParser(
@@ -607,6 +669,37 @@ def main(argv: list[str] | None = None) -> None:
         help="Total instances to optimize for",
     )
 
+    # plan-capacity subcommand
+    cap_parser = subparsers.add_parser(
+        "plan-capacity",
+        help="Recommend minimum instances and P:D ratio for a target QPS",
+    )
+    cap_parser.add_argument(
+        "--benchmark", type=str, nargs="+", required=True,
+        help="Benchmark JSON files at different cluster sizes/QPS levels",
+    )
+    cap_parser.add_argument(
+        "--target-qps", type=float, required=True,
+        help="Target QPS to achieve",
+    )
+    cap_parser.add_argument(
+        "--sla-ttft", type=float, default=None, help="SLA: max TTFT P95 (ms)",
+    )
+    cap_parser.add_argument(
+        "--sla-tpot", type=float, default=None, help="SLA: max TPOT P95 (ms)",
+    )
+    cap_parser.add_argument(
+        "--sla-max-latency", type=float, default=None, help="SLA: max total latency P95 (ms)",
+    )
+    cap_parser.add_argument(
+        "--max-instances", type=int, default=64,
+        help="Maximum instances to consider (default: 64)",
+    )
+    cap_parser.add_argument(
+        "--output-format", type=str, choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "analyze":
@@ -615,6 +708,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_plan_legacy(args)
     elif args.command == "export":
         _cmd_export(args)
+    elif args.command == "plan-capacity":
+        _cmd_plan_capacity(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -1,0 +1,298 @@
+"""Tests for capacity planning module (M10)."""
+
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+import pytest
+
+from xpyd_plan.capacity import (
+    CapacityPlanner,
+    CapacityRecommendation,
+    ConfidenceLevel,
+    ScalingDataPoint,
+    plan_capacity,
+)
+from xpyd_plan.models import SLAConfig
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+def _make_requests(
+    n: int = 100,
+    ttft_range: tuple[float, float] = (50, 300),
+    tpot_range: tuple[float, float] = (10, 35),
+    seed: int = 42,
+) -> list[dict]:
+    rng = random.Random(seed)
+    requests = []
+    base_ts = 1700000000.0
+    for i in range(n):
+        prompt_tokens = rng.randint(100, 2000)
+        output_tokens = rng.randint(50, 500)
+        ttft = rng.uniform(*ttft_range)
+        tpot = rng.uniform(*tpot_range)
+        total = ttft + tpot * output_tokens
+        requests.append({
+            "request_id": f"req-{i:04d}",
+            "prompt_tokens": prompt_tokens,
+            "output_tokens": output_tokens,
+            "ttft_ms": round(ttft, 2),
+            "tpot_ms": round(tpot, 2),
+            "total_latency_ms": round(total, 2),
+            "timestamp": base_ts + i * 0.1,
+        })
+    return requests
+
+
+def _make_benchmark(
+    num_p: int = 2,
+    num_d: int = 6,
+    qps: float = 10.0,
+    n: int = 100,
+    seed: int = 42,
+    ttft_range: tuple[float, float] = (50, 300),
+    tpot_range: tuple[float, float] = (10, 35),
+) -> dict:
+    return {
+        "metadata": {
+            "num_prefill_instances": num_p,
+            "num_decode_instances": num_d,
+            "total_instances": num_p + num_d,
+            "measured_qps": qps,
+        },
+        "requests": _make_requests(
+            n=n, seed=seed, ttft_range=ttft_range, tpot_range=tpot_range
+        ),
+    }
+
+
+def _make_datasets():
+    """Create benchmark datasets at different scales."""
+    from xpyd_plan.benchmark_models import BenchmarkData
+
+    configs = [
+        (1, 3, 5.0, 10),
+        (2, 6, 10.0, 20),
+        (3, 9, 15.0, 30),
+        (4, 12, 20.0, 40),
+    ]
+    datasets = []
+    for num_p, num_d, qps, seed in configs:
+        data = _make_benchmark(num_p=num_p, num_d=num_d, qps=qps, seed=seed)
+        datasets.append(BenchmarkData(**data))
+    return datasets
+
+
+@pytest.fixture
+def datasets():
+    return _make_datasets()
+
+
+@pytest.fixture
+def sla() -> SLAConfig:
+    return SLAConfig(ttft_ms=500.0, tpot_ms=50.0)
+
+
+@pytest.fixture
+def benchmark_files(tmp_path: Path) -> list[str]:
+    configs = [
+        (1, 3, 5.0, 10),
+        (2, 6, 10.0, 20),
+        (3, 9, 15.0, 30),
+    ]
+    paths = []
+    for num_p, num_d, qps, seed in configs:
+        data = _make_benchmark(num_p=num_p, num_d=num_d, qps=qps, seed=seed)
+        p = tmp_path / f"bench_{qps:.0f}.json"
+        p.write_text(json.dumps(data))
+        paths.append(str(p))
+    return paths
+
+
+# ── CapacityPlanner.fit ───────────────────────────────────────────────────
+
+
+class TestFit:
+    def test_fit_stores_points(self, datasets, sla) -> None:
+        planner = CapacityPlanner()
+        planner.fit(datasets, sla)
+        assert len(planner.points) == 4
+
+    def test_fit_points_sorted(self, datasets, sla) -> None:
+        planner = CapacityPlanner()
+        planner.fit(datasets, sla)
+        totals = [p.total_instances for p in planner.points]
+        assert totals == sorted(totals)
+
+    def test_fit_empty_raises(self) -> None:
+        planner = CapacityPlanner()
+        with pytest.raises(ValueError, match="At least one"):
+            planner.fit([])
+
+    def test_fit_no_sla_defaults(self, datasets) -> None:
+        planner = CapacityPlanner()
+        planner.fit(datasets)
+        assert len(planner.points) == 4
+
+    def test_fit_point_fields(self, datasets, sla) -> None:
+        planner = CapacityPlanner()
+        planner.fit(datasets, sla)
+        p = planner.points[0]
+        assert p.total_instances > 0
+        assert p.measured_qps > 0
+        assert p.ttft_p95_ms > 0
+        assert p.tpot_p95_ms > 0
+
+
+# ── CapacityPlanner.recommend ─────────────────────────────────────────────
+
+
+class TestRecommend:
+    def test_recommend_basic(self, datasets, sla) -> None:
+        planner = CapacityPlanner()
+        planner.fit(datasets, sla)
+        rec = planner.recommend(target_qps=10.0, sla=sla)
+        assert isinstance(rec, CapacityRecommendation)
+        assert rec.recommended_instances >= 2
+        assert rec.num_prefill >= 1
+        assert rec.num_decode >= 1
+        assert rec.num_prefill + rec.num_decode == rec.recommended_instances
+
+    def test_recommend_higher_qps_needs_more(self, datasets, sla) -> None:
+        planner = CapacityPlanner()
+        planner.fit(datasets, sla)
+        rec_low = planner.recommend(target_qps=5.0, sla=sla)
+        rec_high = planner.recommend(target_qps=30.0, sla=sla)
+        assert rec_high.recommended_instances >= rec_low.recommended_instances
+
+    def test_recommend_ratio_string(self, datasets, sla) -> None:
+        planner = CapacityPlanner()
+        planner.fit(datasets, sla)
+        rec = planner.recommend(target_qps=10.0, sla=sla)
+        assert "P:" in rec.recommended_ratio
+        assert "D" in rec.recommended_ratio
+
+    def test_recommend_headroom_positive(self, datasets, sla) -> None:
+        planner = CapacityPlanner()
+        planner.fit(datasets, sla)
+        rec = planner.recommend(target_qps=5.0, sla=sla)
+        # With 20% headroom built in, should be positive
+        assert rec.estimated_headroom_pct > 0
+
+    def test_recommend_not_fitted_raises(self) -> None:
+        planner = CapacityPlanner()
+        with pytest.raises(RuntimeError, match="fit"):
+            planner.recommend(target_qps=10.0)
+
+    def test_recommend_negative_qps_raises(self, datasets, sla) -> None:
+        planner = CapacityPlanner()
+        planner.fit(datasets, sla)
+        with pytest.raises(ValueError, match="positive"):
+            planner.recommend(target_qps=-1.0)
+
+    def test_recommend_zero_qps_raises(self, datasets, sla) -> None:
+        planner = CapacityPlanner()
+        planner.fit(datasets, sla)
+        with pytest.raises(ValueError, match="positive"):
+            planner.recommend(target_qps=0.0)
+
+    def test_recommend_max_instances_cap(self, datasets, sla) -> None:
+        planner = CapacityPlanner()
+        planner.fit(datasets, sla)
+        rec = planner.recommend(target_qps=1000.0, sla=sla, max_instances=10)
+        assert rec.recommended_instances <= 10
+        assert any("max_instances" in n for n in rec.notes)
+
+    def test_recommend_scaling_points_included(self, datasets, sla) -> None:
+        planner = CapacityPlanner()
+        planner.fit(datasets, sla)
+        rec = planner.recommend(target_qps=10.0, sla=sla)
+        assert len(rec.scaling_points) == 4
+
+
+# ── Confidence levels ─────────────────────────────────────────────────────
+
+
+class TestConfidence:
+    def test_interpolation_high(self, datasets, sla) -> None:
+        planner = CapacityPlanner()
+        planner.fit(datasets, sla)
+        rec = planner.recommend(target_qps=12.0, sla=sla)
+        assert rec.confidence == ConfidenceLevel.HIGH
+
+    def test_below_range_high(self, datasets, sla) -> None:
+        planner = CapacityPlanner()
+        planner.fit(datasets, sla)
+        rec = planner.recommend(target_qps=2.0, sla=sla)
+        assert rec.confidence == ConfidenceLevel.HIGH
+
+    def test_far_extrapolation_low(self, datasets, sla) -> None:
+        planner = CapacityPlanner()
+        planner.fit(datasets, sla)
+        rec = planner.recommend(target_qps=200.0, sla=sla, max_instances=200)
+        assert rec.confidence == ConfidenceLevel.LOW
+
+    def test_slight_extrapolation_medium(self, datasets, sla) -> None:
+        planner = CapacityPlanner()
+        planner.fit(datasets, sla)
+        # QPS range is 5-20; slight overshoot
+        rec = planner.recommend(target_qps=25.0, sla=sla)
+        assert rec.confidence in (ConfidenceLevel.MEDIUM, ConfidenceLevel.HIGH)
+
+
+# ── Programmatic API ──────────────────────────────────────────────────────
+
+
+class TestPlanCapacityApi:
+    def test_basic(self, benchmark_files) -> None:
+        result = plan_capacity(benchmark_files, target_qps=10.0)
+        assert "recommended_instances" in result
+        assert "recommended_ratio" in result
+        assert "confidence" in result
+
+    def test_with_dict_sla(self, benchmark_files) -> None:
+        result = plan_capacity(
+            benchmark_files, target_qps=10.0, sla_config={"ttft_ms": 500.0}
+        )
+        assert result["target_qps"] == 10.0
+
+    def test_with_none_sla(self, benchmark_files) -> None:
+        result = plan_capacity(benchmark_files, target_qps=10.0, sla_config=None)
+        assert "recommended_instances" in result
+
+    def test_max_instances(self, benchmark_files) -> None:
+        result = plan_capacity(benchmark_files, target_qps=500.0, max_instances=8)
+        assert result["recommended_instances"] <= 8
+
+
+# ── ScalingDataPoint model ────────────────────────────────────────────────
+
+
+class TestScalingDataPoint:
+    def test_create(self) -> None:
+        p = ScalingDataPoint(
+            total_instances=8,
+            num_prefill=2,
+            num_decode=6,
+            measured_qps=10.0,
+            ttft_p95_ms=200.0,
+            tpot_p95_ms=30.0,
+            waste_rate=0.1,
+        )
+        assert p.max_qps_meeting_sla is None
+
+    def test_with_max_qps(self) -> None:
+        p = ScalingDataPoint(
+            total_instances=8,
+            num_prefill=2,
+            num_decode=6,
+            measured_qps=10.0,
+            max_qps_meeting_sla=10.0,
+            ttft_p95_ms=200.0,
+            tpot_p95_ms=30.0,
+            waste_rate=0.1,
+        )
+        assert p.max_qps_meeting_sla == 10.0


### PR DESCRIPTION
## Summary

Add capacity planning module that answers: *given a target QPS and SLA, what's the minimum total instances needed and the optimal P:D ratio?*

### Changes
- `CapacityPlanner` class with `fit()` (learn from benchmarks) and `recommend()` (predict)
- Linear scaling model: estimates QPS-per-instance from measured data, adds 20% headroom
- Confidence levels: HIGH (interpolation), MEDIUM (slight extrapolation), LOW (far extrapolation)
- CLI `plan-capacity` subcommand with `--target-qps`, `--benchmark`, table/JSON output
- Programmatic API: `plan_capacity()` returns structured dict
- 24 new tests (233 total, all passing)

### Key design decisions
- Uses average QPS-per-instance from SLA-passing benchmarks for scaling estimation
- Best P:D ratio derived from closest known data point
- 20% headroom built into recommendations
- `max_instances` cap with user warning

Closes #22