### PR TITLE
feat: M11 What-If Scenario Simulation

### DIFF
--- a/src/xpyd_plan/cli.py
+++ b/src/xpyd_plan/cli.py
@@ -481,6 +481,118 @@ def _cmd_plan_capacity(args: argparse.Namespace) -> None:
     console.print(table)
 
 
+def _cmd_what_if(args: argparse.Namespace) -> None:
+    """Handle the 'what-if' subcommand."""
+    from xpyd_plan.bench_adapter import load_benchmark_auto
+    from xpyd_plan.whatif import WhatIfSimulator
+
+    console = Console()
+
+    sla = SLAConfig(
+        ttft_ms=args.sla_ttft,
+        tpot_ms=args.sla_tpot,
+        max_latency_ms=args.sla_max_latency,
+    )
+
+    data = load_benchmark_auto(args.benchmark)
+    sim = WhatIfSimulator()
+    sim.load(data)
+
+    # Build scenario specs from CLI args
+    scenarios: list[dict] = []
+    if args.scale_qps:
+        for part in args.scale_qps.split(","):
+            part = part.strip().rstrip("xX")
+            scenarios.append({"scale_qps": float(part)})
+
+    if args.add_instances is not None:
+        if scenarios:
+            # Combine with each QPS scenario
+            combined = []
+            for s in scenarios:
+                combined.append({**s, "add_instances": args.add_instances})
+            # Also add instance-only scenario
+            combined.append({"add_instances": args.add_instances})
+            scenarios = combined
+        else:
+            scenarios.append({"add_instances": args.add_instances})
+
+    if not scenarios:
+        console.print("[red]Error: specify --scale-qps and/or --add-instances[/red]")
+        sys.exit(1)
+
+    comparison = sim.compare(scenarios, sla)
+
+    if args.output_format == "json":
+        print(comparison.model_dump_json(indent=2))
+        return
+
+    # Rich table output
+    meta = data.metadata
+    console.print("\n[bold]🔮 What-If Analysis[/bold]")
+    console.print(
+        f"   Baseline: {meta.num_prefill_instances}P:{meta.num_decode_instances}D"
+        f"  ({meta.total_instances} instances, QPS: {meta.measured_qps:.1f})"
+    )
+
+    table = Table(title="\nScenario Comparison")
+    table.add_column("Scenario", style="cyan")
+    table.add_column("Instances", justify="right")
+    table.add_column("Best P:D", style="green")
+    table.add_column("Waste", justify="right")
+    table.add_column("TTFT P95", justify="right")
+    table.add_column("TPOT P95", justify="right")
+    table.add_column("SLA", justify="center")
+
+    # Baseline row
+    b = comparison.baseline
+    if b.best and b.best.sla_check:
+        table.add_row(
+            "[bold]Baseline[/bold]",
+            str(b.total_instances),
+            b.best.ratio_str,
+            f"{b.best.waste_rate:.1%}",
+            f"{b.best.sla_check.ttft_p95_ms:.1f}",
+            f"{b.best.sla_check.tpot_p95_ms:.1f}",
+            "✅" if b.best.meets_sla else "❌",
+        )
+    else:
+        table.add_row(
+            "[bold]Baseline[/bold]",
+            str(b.total_instances),
+            "N/A",
+            "N/A",
+            "N/A",
+            "N/A",
+            "❌",
+        )
+
+    # Scenario rows
+    for s in comparison.scenarios:
+        if s.best and s.best.sla_check:
+            table.add_row(
+                s.label,
+                str(s.total_instances),
+                s.best.ratio_str,
+                f"{s.best.waste_rate:.1%}",
+                f"{s.best.sla_check.ttft_p95_ms:.1f}",
+                f"{s.best.sla_check.tpot_p95_ms:.1f}",
+                "✅" if s.best.meets_sla else "❌",
+            )
+        else:
+            table.add_row(
+                s.label,
+                str(s.total_instances),
+                "N/A",
+                "N/A",
+                "N/A",
+                "N/A",
+                "❌",
+            )
+
+    console.print(table)
+
+
 def main(argv: list[str] | None = None) -> None:
     """Entry point for `xpyd-plan` command."""
     parser = argparse.ArgumentParser(
@@ -606,6 +718,37 @@ def main(argv: list[str] | None = None) -> None:
         help="Output format (default: table)",
     )
 
+    # what-if subcommand
+    whatif_parser = subparsers.add_parser(
+        "what-if",
+        help="Simulate what-if scenarios: scale QPS or change instance count",
+    )
+    whatif_parser.add_argument(
+        "--benchmark", type=str, required=True,
+        help="Path to benchmark JSON file",
+    )
+    whatif_parser.add_argument(
+        "--scale-qps", type=str, default=None,
+        help="QPS multiplier(s), comma-separated (e.g. '0.5,1.5,2.0' or '2x')",
+    )
+    whatif_parser.add_argument(
+        "--add-instances", type=int, default=None,
+        help="Number of instances to add (negative to remove)",
+    )
+    whatif_parser.add_argument(
+        "--sla-ttft", type=float, default=None, help="SLA: max TTFT P95 (ms)",
+    )
+    whatif_parser.add_argument(
+        "--sla-tpot", type=float, default=None, help="SLA: max TPOT P95 (ms)",
+    )
+    whatif_parser.add_argument(
+        "--sla-max-latency", type=float, default=None, help="SLA: max total latency P95 (ms)",
+    )
+    whatif_parser.add_argument(
+        "--output-format", type=str, choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "analyze":
@@ -614,6 +757,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_export(args)
     elif args.command == "plan-capacity":
         _cmd_plan_capacity(args)
+    elif args.command == "what-if":
+        _cmd_what_if(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/whatif.py
+++ b/src/xpyd_plan/whatif.py
@@ -1,0 +1,291 @@
+"""What-If Scenario Simulation for xpyd-plan (M11).
+
+Lets users explore hypothetical scenarios — scaling QPS or changing instance
+counts — without re-running benchmarks. All predictions are based on scaling
+measured data, consistent with the analyzer's approach.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from xpyd_plan.analyzer import BenchmarkAnalyzer
+from xpyd_plan.benchmark_models import (
+    AnalysisResult,
+    BenchmarkData,
+    BenchmarkMetadata,
+    BenchmarkRequest,
+    RatioCandidate,
+)
+from xpyd_plan.models import SLAConfig
+
+
+class WhatIfScenario(BaseModel):
+    """A single what-if scenario with its analysis results."""
+
+    label: str = Field(..., description="Human-readable scenario label")
+    total_instances: int
+    scale_qps: float = Field(1.0, description="QPS multiplier applied")
+    instance_delta: int = Field(0, description="Instance count change from baseline")
+    best: RatioCandidate | None = None
+    analysis: AnalysisResult | None = None
+
+
+class WhatIfComparison(BaseModel):
+    """Side-by-side comparison of multiple what-if scenarios."""
+
+    baseline: WhatIfScenario
+    scenarios: list[WhatIfScenario] = Field(default_factory=list)
+
+
+class WhatIfSimulator:
+    """Simulate what-if scenarios by scaling benchmark data.
+
+    Usage:
+        sim = WhatIfSimulator()
+        sim.load(benchmark_data)
+        result = sim.scale_qps(2.0, sla)          # double QPS
+        result = sim.scale_instances(4, sla)       # add 4 instances
+        comparison = sim.compare([...], sla)       # side-by-side
+    """
+
+    def __init__(self) -> None:
+        self._data: BenchmarkData | None = None
+
+    @property
+    def data(self) -> BenchmarkData:
+        if self._data is None:
+            raise RuntimeError("No data loaded. Call load() or load_file() first.")
+        return self._data
+
+    def load(self, data: BenchmarkData) -> None:
+        """Load benchmark data directly."""
+        self._data = data
+
+    def load_file(self, path: str | Path) -> BenchmarkData:
+        """Load benchmark data from a JSON file."""
+        path = Path(path)
+        if not path.exists():
+            raise FileNotFoundError(f"Benchmark file not found: {path}")
+        raw = json.loads(path.read_text())
+        self._data = BenchmarkData(**raw)
+        return self._data
+
+    def load_from_dict(self, data: dict) -> BenchmarkData:
+        """Load benchmark data from a dictionary."""
+        self._data = BenchmarkData(**data)
+        return self._data
+
+    def _scale_data_for_qps(self, qps_multiplier: float) -> BenchmarkData:
+        """Create a synthetic dataset with scaled QPS.
+
+        When QPS scales by k, per-instance load increases by k, so latencies
+        scale proportionally (more queuing, more contention).
+        """
+        data = self.data
+        scaled_requests = []
+        for r in data.requests:
+            scaled_requests.append(
+                BenchmarkRequest(
+                    request_id=r.request_id,
+                    prompt_tokens=r.prompt_tokens,
+                    output_tokens=r.output_tokens,
+                    ttft_ms=r.ttft_ms * qps_multiplier,
+                    tpot_ms=r.tpot_ms * qps_multiplier,
+                    total_latency_ms=r.total_latency_ms * qps_multiplier,
+                    timestamp=r.timestamp,
+                )
+            )
+        meta = data.metadata
+        return BenchmarkData(
+            metadata=BenchmarkMetadata(
+                num_prefill_instances=meta.num_prefill_instances,
+                num_decode_instances=meta.num_decode_instances,
+                total_instances=meta.total_instances,
+                measured_qps=meta.measured_qps * qps_multiplier,
+            ),
+            requests=scaled_requests,
+        )
+
+    def scale_qps(
+        self,
+        qps_multiplier: float,
+        sla: SLAConfig,
+        total_instances: int | None = None,
+    ) -> WhatIfScenario:
+        """Predict impact of scaling QPS by the given multiplier.
+
+        Args:
+            qps_multiplier: Factor to scale QPS (e.g. 2.0 = double QPS).
+            sla: SLA constraints.
+            total_instances: Total instances to optimize for (default: same as data).
+
+        Returns:
+            WhatIfScenario with analysis at scaled QPS.
+        """
+        if qps_multiplier <= 0:
+            raise ValueError("qps_multiplier must be positive")
+
+        scaled_data = self._scale_data_for_qps(qps_multiplier)
+        total = total_instances or scaled_data.metadata.total_instances
+
+        analyzer = BenchmarkAnalyzer()
+        analyzer._data = scaled_data
+        analysis = analyzer.find_optimal_ratio(total, sla)
+
+        label = f"{qps_multiplier:.1f}x QPS"
+        return WhatIfScenario(
+            label=label,
+            total_instances=total,
+            scale_qps=qps_multiplier,
+            best=analysis.best,
+            analysis=analysis,
+        )
+
+    def scale_instances(
+        self,
+        instance_delta: int,
+        sla: SLAConfig,
+    ) -> WhatIfScenario:
+        """Predict impact of adding/removing instances.
+
+        Args:
+            instance_delta: Number of instances to add (positive) or remove (negative).
+            sla: SLA constraints.
+
+        Returns:
+            WhatIfScenario with analysis at new instance count.
+        """
+        current_total = self.data.metadata.total_instances
+        new_total = current_total + instance_delta
+        if new_total < 2:
+            raise ValueError(
+                f"Cannot reduce to {new_total} instances (minimum 2). "
+                f"Current: {current_total}, delta: {instance_delta}"
+            )
+
+        analyzer = BenchmarkAnalyzer()
+        analyzer._data = self.data
+        analysis = analyzer.find_optimal_ratio(new_total, sla)
+
+        sign = "+" if instance_delta >= 0 else ""
+        label = f"{sign}{instance_delta} instances ({new_total} total)"
+        return WhatIfScenario(
+            label=label,
+            total_instances=new_total,
+            instance_delta=instance_delta,
+            best=analysis.best,
+            analysis=analysis,
+        )
+
+    def baseline(self, sla: SLAConfig) -> WhatIfScenario:
+        """Compute baseline scenario (current data as-is)."""
+        total = self.data.metadata.total_instances
+        analyzer = BenchmarkAnalyzer()
+        analyzer._data = self.data
+        analysis = analyzer.find_optimal_ratio(total, sla)
+
+        return WhatIfScenario(
+            label="Baseline",
+            total_instances=total,
+            best=analysis.best,
+            analysis=analysis,
+        )
+
+    def compare(
+        self,
+        scenarios: list[dict],
+        sla: SLAConfig,
+    ) -> WhatIfComparison:
+        """Compare multiple what-if scenarios side-by-side.
+
+        Args:
+            scenarios: List of scenario specs, each a dict with optional keys:
+                - scale_qps: float (QPS multiplier)
+                - add_instances: int (instance delta)
+                - label: str (optional custom label)
+            sla: SLA constraints.
+
+        Returns:
+            WhatIfComparison with baseline and all scenarios.
+        """
+        base = self.baseline(sla)
+        results: list[WhatIfScenario] = []
+
+        for spec in scenarios:
+            qps_mult = spec.get("scale_qps", 1.0)
+            inst_delta = spec.get("add_instances", 0)
+            custom_label = spec.get("label")
+
+            total = self.data.metadata.total_instances + inst_delta
+            if total < 2:
+                raise ValueError(
+                    f"Scenario would result in {total} instances (minimum 2)"
+                )
+
+            # Scale QPS first, then analyze at new instance count
+            if qps_mult != 1.0:
+                scaled_data = self._scale_data_for_qps(qps_mult)
+            else:
+                scaled_data = self.data
+
+            analyzer = BenchmarkAnalyzer()
+            analyzer._data = scaled_data
+            analysis = analyzer.find_optimal_ratio(total, sla)
+
+            if custom_label:
+                label = custom_label
+            else:
+                parts = []
+                if qps_mult != 1.0:
+                    parts.append(f"{qps_mult:.1f}x QPS")
+                if inst_delta != 0:
+                    sign = "+" if inst_delta >= 0 else ""
+                    parts.append(f"{sign}{inst_delta} instances")
+                label = ", ".join(parts) if parts else "Baseline"
+
+            results.append(
+                WhatIfScenario(
+                    label=label,
+                    total_instances=total,
+                    scale_qps=qps_mult,
+                    instance_delta=inst_delta,
+                    best=analysis.best,
+                    analysis=analysis,
+                )
+            )
+
+        return WhatIfComparison(baseline=base, scenarios=results)
+
+
+def what_if(
+    benchmark_path: str,
+    scenarios: list[dict],
+    sla_config: SLAConfig | dict | None = None,
+) -> dict[str, Any]:
+    """Programmatic API for what-if simulation.
+
+    Args:
+        benchmark_path: Path to benchmark JSON file.
+        scenarios: List of scenario specs (see WhatIfSimulator.compare).
+        sla_config: SLA configuration.
+
+    Returns:
+        Dictionary with comparison results.
+    """
+    from xpyd_plan.bench_adapter import load_benchmark_auto
+
+    if isinstance(sla_config, dict):
+        sla_config = SLAConfig(**sla_config)
+    elif sla_config is None:
+        sla_config = SLAConfig()
+
+    data = load_benchmark_auto(benchmark_path)
+    sim = WhatIfSimulator()
+    sim.load(data)
+    comparison = sim.compare(scenarios, sla_config)
+    return json.loads(comparison.model_dump_json())

--- a/tests/test_whatif.py
+++ b/tests/test_whatif.py
@@ -1,0 +1,231 @@
+"""Tests for what-if scenario simulation (M11)."""
+
+from __future__ import annotations
+
+import json
+import random
+
+import pytest
+
+from xpyd_plan.models import SLAConfig
+from xpyd_plan.whatif import WhatIfScenario, WhatIfSimulator, what_if
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+def _make_requests(
+    n: int = 100,
+    ttft_range: tuple[float, float] = (50, 200),
+    tpot_range: tuple[float, float] = (10, 30),
+    seed: int = 42,
+) -> list[dict]:
+    rng = random.Random(seed)
+    requests = []
+    base_ts = 1700000000.0
+    for i in range(n):
+        prompt_tokens = rng.randint(100, 2000)
+        output_tokens = rng.randint(50, 500)
+        ttft = rng.uniform(*ttft_range)
+        tpot = rng.uniform(*tpot_range)
+        total = ttft + tpot * output_tokens
+        requests.append({
+            "request_id": f"req-{i:04d}",
+            "prompt_tokens": prompt_tokens,
+            "output_tokens": output_tokens,
+            "ttft_ms": round(ttft, 2),
+            "tpot_ms": round(tpot, 2),
+            "total_latency_ms": round(total, 2),
+            "timestamp": base_ts + i * 0.1,
+        })
+    return requests
+
+
+def _make_benchmark(num_p=2, num_d=6, qps=10.0, n=100, seed=42):
+    return {
+        "metadata": {
+            "num_prefill_instances": num_p,
+            "num_decode_instances": num_d,
+            "total_instances": num_p + num_d,
+            "measured_qps": qps,
+        },
+        "requests": _make_requests(n=n, seed=seed),
+    }
+
+
+@pytest.fixture
+def benchmark_data():
+    return _make_benchmark()
+
+
+@pytest.fixture
+def benchmark_file(tmp_path, benchmark_data):
+    p = tmp_path / "bench.json"
+    p.write_text(json.dumps(benchmark_data))
+    return str(p)
+
+
+@pytest.fixture
+def sla():
+    return SLAConfig(ttft_ms=500.0, tpot_ms=50.0, max_latency_ms=20000.0)
+
+
+@pytest.fixture
+def strict_sla():
+    return SLAConfig(ttft_ms=50.0, tpot_ms=5.0, max_latency_ms=1000.0)
+
+
+# ── WhatIfSimulator tests ────────────────────────────────────────────────
+
+
+class TestWhatIfSimulator:
+    def test_load_from_dict(self, benchmark_data):
+        sim = WhatIfSimulator()
+        sim.load_from_dict(benchmark_data)
+        assert sim.data.metadata.measured_qps == 10.0
+
+    def test_load_file(self, benchmark_file):
+        sim = WhatIfSimulator()
+        data = sim.load_file(benchmark_file)
+        assert data.metadata.total_instances == 8
+
+    def test_load_file_not_found(self):
+        sim = WhatIfSimulator()
+        with pytest.raises(FileNotFoundError):
+            sim.load_file("/nonexistent/file.json")
+
+    def test_no_data_raises(self):
+        sim = WhatIfSimulator()
+        with pytest.raises(RuntimeError, match="No data loaded"):
+            sim.data
+
+    def test_baseline(self, benchmark_data, sla):
+        sim = WhatIfSimulator()
+        sim.load_from_dict(benchmark_data)
+        base = sim.baseline(sla)
+        assert base.label == "Baseline"
+        assert base.total_instances == 8
+        assert base.analysis is not None
+
+    def test_scale_qps_double(self, benchmark_data, sla):
+        sim = WhatIfSimulator()
+        sim.load_from_dict(benchmark_data)
+        result = sim.scale_qps(2.0, sla)
+        assert result.scale_qps == 2.0
+        assert "2.0x QPS" in result.label
+        assert result.analysis is not None
+
+    def test_scale_qps_half(self, benchmark_data, sla):
+        sim = WhatIfSimulator()
+        sim.load_from_dict(benchmark_data)
+        result = sim.scale_qps(0.5, sla)
+        assert result.scale_qps == 0.5
+
+    def test_scale_qps_invalid(self, benchmark_data, sla):
+        sim = WhatIfSimulator()
+        sim.load_from_dict(benchmark_data)
+        with pytest.raises(ValueError, match="positive"):
+            sim.scale_qps(0, sla)
+
+    def test_scale_instances_add(self, benchmark_data, sla):
+        sim = WhatIfSimulator()
+        sim.load_from_dict(benchmark_data)
+        result = sim.scale_instances(4, sla)
+        assert result.total_instances == 12
+        assert result.instance_delta == 4
+        assert "+4 instances" in result.label
+
+    def test_scale_instances_remove(self, benchmark_data, sla):
+        sim = WhatIfSimulator()
+        sim.load_from_dict(benchmark_data)
+        result = sim.scale_instances(-2, sla)
+        assert result.total_instances == 6
+        assert result.instance_delta == -2
+
+    def test_scale_instances_too_few(self, benchmark_data, sla):
+        sim = WhatIfSimulator()
+        sim.load_from_dict(benchmark_data)
+        with pytest.raises(ValueError, match="minimum 2"):
+            sim.scale_instances(-7, sla)
+
+    def test_compare_multiple(self, benchmark_data, sla):
+        sim = WhatIfSimulator()
+        sim.load_from_dict(benchmark_data)
+        scenarios = [
+            {"scale_qps": 2.0},
+            {"add_instances": 4},
+            {"scale_qps": 1.5, "add_instances": 2},
+        ]
+        comparison = sim.compare(scenarios, sla)
+        assert comparison.baseline.label == "Baseline"
+        assert len(comparison.scenarios) == 3
+        assert comparison.scenarios[0].scale_qps == 2.0
+        assert comparison.scenarios[1].instance_delta == 4
+        assert comparison.scenarios[2].scale_qps == 1.5
+
+    def test_compare_custom_label(self, benchmark_data, sla):
+        sim = WhatIfSimulator()
+        sim.load_from_dict(benchmark_data)
+        scenarios = [{"scale_qps": 2.0, "label": "Peak hour"}]
+        comparison = sim.compare(scenarios, sla)
+        assert comparison.scenarios[0].label == "Peak hour"
+
+    def test_compare_invalid_instances(self, benchmark_data, sla):
+        sim = WhatIfSimulator()
+        sim.load_from_dict(benchmark_data)
+        with pytest.raises(ValueError, match="minimum 2"):
+            sim.compare([{"add_instances": -7}], sla)
+
+    def test_scale_qps_with_custom_total(self, benchmark_data, sla):
+        sim = WhatIfSimulator()
+        sim.load_from_dict(benchmark_data)
+        result = sim.scale_qps(2.0, sla, total_instances=12)
+        assert result.total_instances == 12
+
+    def test_strict_sla_fails(self, benchmark_data, strict_sla):
+        sim = WhatIfSimulator()
+        sim.load_from_dict(benchmark_data)
+        result = sim.scale_qps(3.0, strict_sla)
+        # With very strict SLA and 3x QPS, likely no ratio meets SLA
+        assert result.analysis is not None
+
+
+# ── Programmatic API tests ────────────────────────────────────────────────
+
+
+class TestWhatIfAPI:
+    def test_what_if_api(self, benchmark_file):
+        result = what_if(
+            benchmark_path=benchmark_file,
+            scenarios=[{"scale_qps": 1.5}],
+            sla_config={"ttft_ms": 500, "tpot_ms": 50},
+        )
+        assert "baseline" in result
+        assert "scenarios" in result
+        assert len(result["scenarios"]) == 1
+
+    def test_what_if_api_none_sla(self, benchmark_file):
+        result = what_if(
+            benchmark_path=benchmark_file,
+            scenarios=[{"add_instances": 2}],
+        )
+        assert "baseline" in result
+
+
+# ── Model tests ───────────────────────────────────────────────────────────
+
+
+class TestWhatIfModels:
+    def test_scenario_defaults(self):
+        s = WhatIfScenario(label="test", total_instances=8)
+        assert s.scale_qps == 1.0
+        assert s.instance_delta == 0
+        assert s.best is None
+
+    def test_comparison_serialization(self, benchmark_data, sla):
+        sim = WhatIfSimulator()
+        sim.load_from_dict(benchmark_data)
+        comparison = sim.compare([{"scale_qps": 2.0}], sla)
+        # Should be JSON-serializable
+        data = json.loads(comparison.model_dump_json())
+        assert "baseline" in data
+        assert len(data["scenarios"]) == 1


### PR DESCRIPTION
## Summary

Implements M11: What-If Scenario Simulation — lets users explore hypothetical scenarios (scaling QPS, changing instance counts) without re-running benchmarks.

## Changes

- **`WhatIfSimulator`** class with `scale_qps()`, `scale_instances()`, `baseline()`, and `compare()` methods
- **`WhatIfScenario`** and **`WhatIfComparison`** Pydantic models
- **CLI `what-if` subcommand** with `--benchmark`, `--scale-qps`, `--add-instances`, `--output-format json`
- **Programmatic API**: `what_if()` function for scripting
- **20 new tests** (223 total, all passing)
- Lint clean (ruff + isort)

## Usage

```bash
# Scale QPS 2x
xpyd-plan what-if --benchmark bench.json --scale-qps 2.0 --sla-ttft 500 --sla-tpot 50

# Add 4 instances
xpyd-plan what-if --benchmark bench.json --add-instances 4 --sla-ttft 500

# Multiple scenarios
xpyd-plan what-if --benchmark bench.json --scale-qps 0.5,1.5,2.0 --sla-ttft 500

# JSON output
xpyd-plan what-if --benchmark bench.json --scale-qps 2.0 --output-format json
```

Closes #27