### PR TITLE
feat(config): Configuration Profile Support (M12)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,3 +143,14 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Side-by-side comparison table output, JSON output format support
 - Programmatic API: `what_if()` function
 - 20 new tests (223 total)
+
+### M12 — Configuration Profile Support
+
+- `ConfigProfile` Pydantic model with `SLAProfile`, `CostProfile`, `OutputProfile`, `DefaultsProfile`
+- YAML config file loading with fallback chain: `--config` → `./xpyd-plan.yaml` → `~/.config/xpyd-plan/config.yaml`
+- CLI flags override config file values
+- `xpyd-plan config init` generates commented starter YAML
+- `xpyd-plan config show` displays resolved configuration
+- All subcommands (`analyze`, `export`, `plan-capacity`, `what-if`) respect config defaults
+- Backward compatible — works exactly as before when no config file exists
+- 31 new tests (254 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -12,6 +12,7 @@ from xpyd_plan.benchmark_models import (
     SLACheck,
     UtilizationResult,
 )
+from xpyd_plan.config import ConfigProfile, load_config
 from xpyd_plan.gpu_profiles import get_gpu_profile, list_gpu_profiles
 from xpyd_plan.models import (
     DatasetStats,
@@ -26,6 +27,7 @@ __all__ = [
     "BenchmarkData",
     "BenchmarkMetadata",
     "BenchmarkRequest",
+    "ConfigProfile",
     "DatasetStats",
     "GPUProfile",
     "PDConfig",
@@ -35,4 +37,5 @@ __all__ = [
     "UtilizationResult",
     "get_gpu_profile",
     "list_gpu_profiles",
+    "load_config",
 ]

--- a/src/xpyd_plan/cli.py
+++ b/src/xpyd_plan/cli.py
@@ -593,6 +593,68 @@ def _cmd_what_if(args: argparse.Namespace) -> None:
     console.print(table)
 
 
+def _add_config_flag(parser: argparse.ArgumentParser) -> None:
+    """Add --config flag to a subparser."""
+    parser.add_argument(
+        "--config", type=str, default=None, dest="config_file",
+        help="Path to YAML config profile (default: auto-detect xpyd-plan.yaml)",
+    )
+
+
+def _apply_config_defaults(args: argparse.Namespace) -> None:
+    """Apply config profile defaults to args where CLI didn't set a value."""
+    from xpyd_plan.config import load_config
+
+    config_path = getattr(args, "config_file", None)
+    cfg = load_config(config_path)
+
+    # SLA defaults
+    if getattr(args, "sla_ttft", None) is None and cfg.sla.ttft_ms is not None:
+        args.sla_ttft = cfg.sla.ttft_ms
+    if getattr(args, "sla_tpot", None) is None and cfg.sla.tpot_ms is not None:
+        args.sla_tpot = cfg.sla.tpot_ms
+    if getattr(args, "sla_max_latency", None) is None and cfg.sla.max_latency_ms is not None:
+        args.sla_max_latency = cfg.sla.max_latency_ms
+
+    # Output defaults
+    if hasattr(args, "output_format") and args.output_format == "table":
+        args.output_format = cfg.output.format
+    if hasattr(args, "top") and args.top == 5:
+        args.top = cfg.output.top
+
+    # Defaults
+    if getattr(args, "total_instances", None) is None and cfg.defaults.total_instances is not None:
+        args.total_instances = cfg.defaults.total_instances
+    if hasattr(args, "format") and args.format == "auto":
+        args.format = cfg.defaults.benchmark_format
+
+    # Cost defaults
+    if getattr(args, "budget_ceiling", None) is None and cfg.cost.budget_ceiling is not None:
+        args.budget_ceiling = cfg.cost.budget_ceiling
+
+    # Store resolved config for potential use
+    args._resolved_config = cfg
+
+
+def _cmd_config(args: argparse.Namespace) -> None:
+    """Handle the 'config' subcommand."""
+    from xpyd_plan.config import init_config, load_config
+
+    console = Console()
+
+    if args.config_action == "init":
+        path = init_config(args.output_path)
+        console.print(f"[green]✅ Config file created: {path}[/green]")
+    elif args.config_action == "show":
+        config_path = getattr(args, "config_file", None)
+        cfg = load_config(config_path)
+        console.print("[bold]Resolved configuration:[/bold]\n")
+        console.print(cfg.to_yaml())
+    else:
+        console.print("[red]Error: specify 'init' or 'show'[/red]")
+        sys.exit(1)
+
+
 def main(argv: list[str] | None = None) -> None:
     """Entry point for `xpyd-plan` command."""
     parser = argparse.ArgumentParser(
@@ -601,11 +663,27 @@ def main(argv: list[str] | None = None) -> None:
     )
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
+    # config subcommand
+    config_parser = subparsers.add_parser(
+        "config",
+        help="Manage configuration profiles",
+    )
+    config_parser.add_argument(
+        "config_action", choices=["init", "show"],
+        help="'init' creates a starter config; 'show' displays resolved config",
+    )
+    config_parser.add_argument(
+        "--output-path", type=str, default=None,
+        help="Path for 'init' output (default: ./xpyd-plan.yaml)",
+    )
+    _add_config_flag(config_parser)
+
     # analyze subcommand (primary)
     analyze_parser = subparsers.add_parser(
         "analyze",
         help="Analyze benchmark data to find optimal P:D ratio",
     )
+    _add_config_flag(analyze_parser)
     analyze_parser.add_argument(
         "--benchmark", type=str, nargs="+", default=None,
         help="Path(s) to benchmark JSON file(s). Multiple files enable multi-scenario analysis.",
@@ -665,6 +743,7 @@ def main(argv: list[str] | None = None) -> None:
         "export",
         help="Batch export benchmark analysis results from a directory",
     )
+    _add_config_flag(export_parser)
     export_parser.add_argument(
         "--dir", type=str, required=True,
         help="Directory containing benchmark JSON files",
@@ -692,6 +771,7 @@ def main(argv: list[str] | None = None) -> None:
         "plan-capacity",
         help="Recommend minimum instances and P:D ratio for a target QPS",
     )
+    _add_config_flag(cap_parser)
     cap_parser.add_argument(
         "--benchmark", type=str, nargs="+", required=True,
         help="Benchmark JSON files at different cluster sizes/QPS levels",
@@ -723,6 +803,7 @@ def main(argv: list[str] | None = None) -> None:
         "what-if",
         help="Simulate what-if scenarios: scale QPS or change instance count",
     )
+    _add_config_flag(whatif_parser)
     whatif_parser.add_argument(
         "--benchmark", type=str, required=True,
         help="Path to benchmark JSON file",
@@ -751,13 +832,19 @@ def main(argv: list[str] | None = None) -> None:
 
     args = parser.parse_args(argv)
 
-    if args.command == "analyze":
+    if args.command == "config":
+        _cmd_config(args)
+    elif args.command == "analyze":
+        _apply_config_defaults(args)
         _cmd_analyze(args)
     elif args.command == "export":
+        _apply_config_defaults(args)
         _cmd_export(args)
     elif args.command == "plan-capacity":
+        _apply_config_defaults(args)
         _cmd_plan_capacity(args)
     elif args.command == "what-if":
+        _apply_config_defaults(args)
         _cmd_what_if(args)
     else:
         parser.print_help()

--- a/src/xpyd_plan/config.py
+++ b/src/xpyd_plan/config.py
@@ -1,0 +1,139 @@
+"""Configuration profile support for xpyd-plan.
+
+Loads defaults from YAML config files so users don't need to repeat CLI flags.
+Resolution order: --config flag → ./xpyd-plan.yaml → ~/.config/xpyd-plan/config.yaml
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from pydantic import BaseModel, Field
+
+_DEFAULT_CONFIG_FILENAME = "xpyd-plan.yaml"
+_USER_CONFIG_DIR = Path.home() / ".config" / "xpyd-plan"
+
+STARTER_CONFIG = """\
+# xpyd-plan configuration profile
+# CLI flags always override these defaults.
+
+sla:
+  # ttft_ms: 200.0       # Max TTFT P95 (ms)
+  # tpot_ms: 50.0        # Max TPOT P95 (ms)
+  # max_latency_ms: 5000.0  # Max total latency P95 (ms)
+
+cost:
+  # gpu_hourly_rate: 2.50
+  # currency: USD
+  # budget_ceiling: 100.0
+
+output:
+  format: table          # table | json | csv
+  top: 5
+
+defaults:
+  # total_instances: 16
+  benchmark_format: auto  # auto | native | xpyd-bench
+"""
+
+
+class SLAProfile(BaseModel):
+    """SLA defaults from config file."""
+
+    ttft_ms: Optional[float] = None
+    tpot_ms: Optional[float] = None
+    max_latency_ms: Optional[float] = None
+
+
+class CostProfile(BaseModel):
+    """Cost defaults from config file."""
+
+    gpu_hourly_rate: Optional[float] = None
+    currency: str = "USD"
+    budget_ceiling: Optional[float] = None
+
+
+class OutputProfile(BaseModel):
+    """Output preferences from config file."""
+
+    format: str = Field(default="table", pattern="^(table|json|csv)$")
+    top: int = Field(default=5, ge=1)
+
+
+class DefaultsProfile(BaseModel):
+    """Default values for common parameters."""
+
+    total_instances: Optional[int] = Field(default=None, ge=2)
+    benchmark_format: str = Field(default="auto", pattern="^(auto|native|xpyd-bench)$")
+
+
+class ConfigProfile(BaseModel):
+    """Top-level configuration profile."""
+
+    sla: SLAProfile = Field(default_factory=SLAProfile)
+    cost: CostProfile = Field(default_factory=CostProfile)
+    output: OutputProfile = Field(default_factory=OutputProfile)
+    defaults: DefaultsProfile = Field(default_factory=DefaultsProfile)
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> ConfigProfile:
+        """Load config from a YAML file."""
+        path = Path(path)
+        if not path.exists():
+            raise FileNotFoundError(f"Config file not found: {path}")
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        if data is None:
+            return cls()
+        return cls.model_validate(data)
+
+    def to_yaml(self) -> str:
+        """Serialize config to YAML string."""
+        data = self.model_dump(exclude_none=True)
+        return yaml.dump(data, default_flow_style=False, sort_keys=False)
+
+
+def resolve_config_path(explicit: str | None = None) -> Path | None:
+    """Find the config file using the resolution chain.
+
+    Order: explicit --config → ./xpyd-plan.yaml → ~/.config/xpyd-plan/config.yaml
+    Returns None if no config file is found.
+    """
+    if explicit is not None:
+        p = Path(explicit)
+        if p.exists():
+            return p
+        raise FileNotFoundError(f"Config file not found: {p}")
+
+    # Check current directory
+    local = Path.cwd() / _DEFAULT_CONFIG_FILENAME
+    if local.exists():
+        return local
+
+    # Check user config directory
+    user = _USER_CONFIG_DIR / "config.yaml"
+    if user.exists():
+        return user
+
+    return None
+
+
+def load_config(explicit: str | None = None) -> ConfigProfile:
+    """Load configuration profile, falling back to defaults if no file found."""
+    path = resolve_config_path(explicit)
+    if path is None:
+        return ConfigProfile()
+    return ConfigProfile.from_yaml(path)
+
+
+def init_config(path: str | Path | None = None) -> Path:
+    """Write a starter config file. Returns the path written."""
+    if path is None:
+        path = Path.cwd() / _DEFAULT_CONFIG_FILENAME
+    else:
+        path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(STARTER_CONFIG)
+    return path

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,318 @@
+"""Tests for configuration profile support (M12)."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from xpyd_plan.config import (
+    STARTER_CONFIG,
+    ConfigProfile,
+    CostProfile,
+    DefaultsProfile,
+    OutputProfile,
+    SLAProfile,
+    init_config,
+    load_config,
+    resolve_config_path,
+)
+
+# --- ConfigProfile model tests ---
+
+
+class TestConfigProfile:
+    def test_default_profile(self):
+        cfg = ConfigProfile()
+        assert cfg.sla.ttft_ms is None
+        assert cfg.sla.tpot_ms is None
+        assert cfg.output.format == "table"
+        assert cfg.output.top == 5
+        assert cfg.defaults.benchmark_format == "auto"
+        assert cfg.cost.currency == "USD"
+
+    def test_full_profile(self):
+        cfg = ConfigProfile(
+            sla=SLAProfile(ttft_ms=200.0, tpot_ms=50.0, max_latency_ms=5000.0),
+            cost=CostProfile(gpu_hourly_rate=2.5, currency="EUR", budget_ceiling=100.0),
+            output=OutputProfile(format="json", top=10),
+            defaults=DefaultsProfile(total_instances=16, benchmark_format="xpyd-bench"),
+        )
+        assert cfg.sla.ttft_ms == 200.0
+        assert cfg.cost.gpu_hourly_rate == 2.5
+        assert cfg.output.format == "json"
+        assert cfg.defaults.total_instances == 16
+
+    def test_from_yaml(self, tmp_path):
+        config_data = {
+            "sla": {"ttft_ms": 150.0, "tpot_ms": 40.0},
+            "output": {"format": "csv", "top": 8},
+        }
+        path = tmp_path / "config.yaml"
+        path.write_text(yaml.dump(config_data))
+
+        cfg = ConfigProfile.from_yaml(path)
+        assert cfg.sla.ttft_ms == 150.0
+        assert cfg.sla.tpot_ms == 40.0
+        assert cfg.sla.max_latency_ms is None
+        assert cfg.output.format == "csv"
+        assert cfg.output.top == 8
+
+    def test_from_yaml_empty(self, tmp_path):
+        path = tmp_path / "empty.yaml"
+        path.write_text("")
+        cfg = ConfigProfile.from_yaml(path)
+        assert cfg.sla.ttft_ms is None
+
+    def test_from_yaml_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            ConfigProfile.from_yaml(tmp_path / "nope.yaml")
+
+    def test_to_yaml(self):
+        cfg = ConfigProfile(
+            sla=SLAProfile(ttft_ms=200.0),
+            output=OutputProfile(format="json", top=10),
+        )
+        text = cfg.to_yaml()
+        loaded = yaml.safe_load(text)
+        assert loaded["sla"]["ttft_ms"] == 200.0
+        assert loaded["output"]["format"] == "json"
+
+    def test_partial_sections(self, tmp_path):
+        """Only some sections present in YAML."""
+        path = tmp_path / "partial.yaml"
+        path.write_text(yaml.dump({"cost": {"gpu_hourly_rate": 3.0}}))
+        cfg = ConfigProfile.from_yaml(path)
+        assert cfg.cost.gpu_hourly_rate == 3.0
+        assert cfg.sla.ttft_ms is None  # default
+
+
+class TestSLAProfile:
+    def test_all_none(self):
+        sla = SLAProfile()
+        assert sla.ttft_ms is None
+        assert sla.tpot_ms is None
+        assert sla.max_latency_ms is None
+
+    def test_partial(self):
+        sla = SLAProfile(ttft_ms=100.0)
+        assert sla.ttft_ms == 100.0
+        assert sla.tpot_ms is None
+
+
+class TestOutputProfile:
+    def test_defaults(self):
+        out = OutputProfile()
+        assert out.format == "table"
+        assert out.top == 5
+
+    def test_validation_format(self):
+        with pytest.raises(Exception):
+            OutputProfile(format="xml")
+
+    def test_validation_top(self):
+        with pytest.raises(Exception):
+            OutputProfile(top=0)
+
+
+class TestDefaultsProfile:
+    def test_validation_instances(self):
+        with pytest.raises(Exception):
+            DefaultsProfile(total_instances=1)
+
+    def test_validation_format(self):
+        with pytest.raises(Exception):
+            DefaultsProfile(benchmark_format="parquet")
+
+
+# --- resolve_config_path tests ---
+
+
+class TestResolveConfigPath:
+    def test_explicit_found(self, tmp_path):
+        path = tmp_path / "my.yaml"
+        path.write_text("sla: {}")
+        assert resolve_config_path(str(path)) == path
+
+    def test_explicit_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            resolve_config_path(str(tmp_path / "nope.yaml"))
+
+    def test_no_file_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        # Ensure no user config either
+        monkeypatch.setattr(
+            "xpyd_plan.config._USER_CONFIG_DIR", tmp_path / "nonexistent"
+        )
+        assert resolve_config_path() is None
+
+    def test_local_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        local = tmp_path / "xpyd-plan.yaml"
+        local.write_text("sla: {}")
+        assert resolve_config_path() == local
+
+    def test_user_config(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        user_dir = tmp_path / "user_config"
+        user_dir.mkdir()
+        user_cfg = user_dir / "config.yaml"
+        user_cfg.write_text("sla: {}")
+        monkeypatch.setattr("xpyd_plan.config._USER_CONFIG_DIR", user_dir)
+        assert resolve_config_path() == user_cfg
+
+    def test_local_takes_priority(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        local = tmp_path / "xpyd-plan.yaml"
+        local.write_text("output: {format: json}")
+        user_dir = tmp_path / "user_config"
+        user_dir.mkdir()
+        (user_dir / "config.yaml").write_text("output: {format: csv}")
+        monkeypatch.setattr("xpyd_plan.config._USER_CONFIG_DIR", user_dir)
+        assert resolve_config_path() == local
+
+
+# --- load_config tests ---
+
+
+class TestLoadConfig:
+    def test_no_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            "xpyd_plan.config._USER_CONFIG_DIR", tmp_path / "nonexistent"
+        )
+        cfg = load_config()
+        assert cfg.sla.ttft_ms is None
+
+    def test_explicit_file(self, tmp_path):
+        path = tmp_path / "cfg.yaml"
+        path.write_text(yaml.dump({"sla": {"ttft_ms": 300.0}}))
+        cfg = load_config(str(path))
+        assert cfg.sla.ttft_ms == 300.0
+
+
+# --- init_config tests ---
+
+
+class TestInitConfig:
+    def test_default_path(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        result = init_config()
+        assert result == tmp_path / "xpyd-plan.yaml"
+        assert result.exists()
+        content = result.read_text()
+        assert "sla:" in content
+
+    def test_custom_path(self, tmp_path):
+        custom = tmp_path / "sub" / "my-config.yaml"
+        result = init_config(custom)
+        assert result == custom
+        assert custom.exists()
+
+    def test_starter_is_valid_yaml(self):
+        data = yaml.safe_load(STARTER_CONFIG)
+        assert data is not None
+        assert "sla" in data or "output" in data
+
+
+# --- CLI integration tests ---
+
+
+class TestCLIConfigIntegration:
+    def test_config_init(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        from xpyd_plan.cli import main
+
+        main(["config", "init"])
+        assert (tmp_path / "xpyd-plan.yaml").exists()
+
+    def test_config_init_custom_path(self, tmp_path):
+        from xpyd_plan.cli import main
+
+        out = tmp_path / "custom.yaml"
+        main(["config", "init", "--output-path", str(out)])
+        assert out.exists()
+
+    def test_config_show(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "xpyd-plan.yaml").write_text(
+            yaml.dump({"sla": {"ttft_ms": 250.0}})
+        )
+        from xpyd_plan.cli import main
+
+        main(["config", "show"])
+        captured = capsys.readouterr()
+        assert "250" in captured.out
+
+    def test_analyze_picks_up_config_sla(self, tmp_path, monkeypatch):
+        """Config SLA defaults are applied when CLI flags not given."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "xpyd-plan.yaml").write_text(
+            yaml.dump({"sla": {"ttft_ms": 999.0, "tpot_ms": 88.0}})
+        )
+
+        import argparse
+
+        from xpyd_plan.cli import _apply_config_defaults
+
+        args = argparse.Namespace(
+            config_file=None,
+            sla_ttft=None,
+            sla_tpot=None,
+            sla_max_latency=None,
+            output_format="table",
+            top=5,
+            total_instances=None,
+            format="auto",
+            budget_ceiling=None,
+        )
+        _apply_config_defaults(args)
+        assert args.sla_ttft == 999.0
+        assert args.sla_tpot == 88.0
+
+    def test_cli_flags_override_config(self, tmp_path, monkeypatch):
+        """CLI flags take priority over config file."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "xpyd-plan.yaml").write_text(
+            yaml.dump({"sla": {"ttft_ms": 999.0}})
+        )
+
+        import argparse
+
+        from xpyd_plan.cli import _apply_config_defaults
+
+        args = argparse.Namespace(
+            config_file=None,
+            sla_ttft=100.0,  # CLI explicitly set
+            sla_tpot=None,
+            sla_max_latency=None,
+            output_format="table",
+            top=5,
+            total_instances=None,
+            format="auto",
+            budget_ceiling=None,
+        )
+        _apply_config_defaults(args)
+        assert args.sla_ttft == 100.0  # CLI wins
+
+    def test_explicit_config_flag(self, tmp_path):
+        """--config flag points to specific file."""
+        import argparse
+
+        from xpyd_plan.cli import _apply_config_defaults
+
+        cfg_path = tmp_path / "special.yaml"
+        cfg_path.write_text(yaml.dump({"defaults": {"total_instances": 32}}))
+
+        args = argparse.Namespace(
+            config_file=str(cfg_path),
+            sla_ttft=None,
+            sla_tpot=None,
+            sla_max_latency=None,
+            output_format="table",
+            top=5,
+            total_instances=None,
+            format="auto",
+            budget_ceiling=None,
+        )
+        _apply_config_defaults(args)
+        assert args.total_instances == 32


### PR DESCRIPTION
## Summary

Add YAML configuration profile support so users don't need to repeat verbose CLI flags on every invocation.

## Changes

- **`ConfigProfile` Pydantic model** with `SLAProfile`, `CostProfile`, `OutputProfile`, `DefaultsProfile` sections
- **Config file resolution chain**: `--config` flag → `./xpyd-plan.yaml` → `~/.config/xpyd-plan/config.yaml`
- **CLI `--config` flag** added to all subcommands (`analyze`, `export`, `plan-capacity`, `what-if`)
- **`xpyd-plan config init`** generates a commented starter YAML config
- **`xpyd-plan config show`** displays the resolved (merged) configuration
- **Merge logic**: CLI flags always override config file values
- **Backward compatible**: works exactly as before when no config file exists
- **31 new tests** (254 total, all passing)

## Files

- `src/xpyd_plan/config.py` — new module
- `src/xpyd_plan/cli.py` — config integration
- `src/xpyd_plan/__init__.py` — export new classes
- `tests/test_config.py` — 31 tests
- `ROADMAP.md` — M12 entry

Closes #30