### PR TITLE
feat: configurable SLA percentile threshold (P90/P95/P99)

### DIFF
--- a/src/xpyd_plan/analyzer.py
+++ b/src/xpyd_plan/analyzer.py
@@ -237,7 +237,8 @@ class BenchmarkAnalyzer:
     def check_sla(self, sla: SLAConfig) -> SLACheck:
         """Check SLA compliance based on measured latency distributions.
 
-        Uses P95 for SLA pass/fail determination and also reports P99.
+        Uses the configured ``sla.sla_percentile`` (default P95) for SLA
+        pass/fail determination and also reports P95 and P99 values.
 
         Args:
             sla: SLA configuration with thresholds.
@@ -250,6 +251,8 @@ class BenchmarkAnalyzer:
         tpots = [r.tpot_ms for r in reqs]
         total_lats = [r.total_latency_ms for r in reqs]
 
+        pctl = sla.sla_percentile
+
         ttft_p95 = _percentile(ttfts, 95)
         ttft_p99 = _percentile(ttfts, 99)
         tpot_p95 = _percentile(tpots, 95)
@@ -257,9 +260,14 @@ class BenchmarkAnalyzer:
         total_p95 = _percentile(total_lats, 95)
         total_p99 = _percentile(total_lats, 99)
 
-        meets_ttft = sla.ttft_ms is None or ttft_p95 <= sla.ttft_ms
-        meets_tpot = sla.tpot_ms is None or tpot_p95 <= sla.tpot_ms
-        meets_total = sla.max_latency_ms is None or total_p95 <= sla.max_latency_ms
+        # Evaluate SLA against the configured percentile
+        ttft_eval = _percentile(ttfts, pctl)
+        tpot_eval = _percentile(tpots, pctl)
+        total_eval = _percentile(total_lats, pctl)
+
+        meets_ttft = sla.ttft_ms is None or ttft_eval <= sla.ttft_ms
+        meets_tpot = sla.tpot_ms is None or tpot_eval <= sla.tpot_ms
+        meets_total = sla.max_latency_ms is None or total_eval <= sla.max_latency_ms
 
         return SLACheck(
             ttft_p95_ms=ttft_p95,
@@ -272,6 +280,10 @@ class BenchmarkAnalyzer:
             meets_tpot=meets_tpot,
             meets_total_latency=meets_total,
             meets_all=meets_ttft and meets_tpot and meets_total,
+            evaluated_percentile=pctl,
+            ttft_evaluated_ms=ttft_eval,
+            tpot_evaluated_ms=tpot_eval,
+            total_latency_evaluated_ms=total_eval,
         )
 
     def compute_utilization(self) -> UtilizationResult:
@@ -344,6 +356,8 @@ class BenchmarkAnalyzer:
             for r in reqs
         ]
 
+        pctl = sla.sla_percentile
+
         ttft_p95 = _percentile(scaled_ttfts, 95)
         ttft_p99 = _percentile(scaled_ttfts, 99)
         tpot_p95 = _percentile(scaled_tpots, 95)
@@ -351,9 +365,14 @@ class BenchmarkAnalyzer:
         total_p95 = _percentile(scaled_totals, 95)
         total_p99 = _percentile(scaled_totals, 99)
 
-        meets_ttft = sla.ttft_ms is None or ttft_p95 <= sla.ttft_ms
-        meets_tpot = sla.tpot_ms is None or tpot_p95 <= sla.tpot_ms
-        meets_total = sla.max_latency_ms is None or total_p95 <= sla.max_latency_ms
+        # Evaluate SLA against the configured percentile
+        ttft_eval = _percentile(scaled_ttfts, pctl)
+        tpot_eval = _percentile(scaled_tpots, pctl)
+        total_eval = _percentile(scaled_totals, pctl)
+
+        meets_ttft = sla.ttft_ms is None or ttft_eval <= sla.ttft_ms
+        meets_tpot = sla.tpot_ms is None or tpot_eval <= sla.tpot_ms
+        meets_total = sla.max_latency_ms is None or total_eval <= sla.max_latency_ms
         meets_all = meets_ttft and meets_tpot and meets_total
 
         sla_check = SLACheck(
@@ -367,6 +386,10 @@ class BenchmarkAnalyzer:
             meets_tpot=meets_tpot,
             meets_total_latency=meets_total,
             meets_all=meets_all,
+            evaluated_percentile=pctl,
+            ttft_evaluated_ms=ttft_eval,
+            tpot_evaluated_ms=tpot_eval,
+            total_latency_evaluated_ms=total_eval,
         )
 
         # Compute utilization at this ratio

--- a/src/xpyd_plan/benchmark_models.py
+++ b/src/xpyd_plan/benchmark_models.py
@@ -46,6 +46,18 @@ class SLACheck(BaseModel):
     meets_tpot: bool
     meets_total_latency: bool
     meets_all: bool
+    evaluated_percentile: float = Field(
+        95.0, description="The percentile used for SLA pass/fail evaluation"
+    )
+    ttft_evaluated_ms: float | None = Field(
+        None, description="TTFT at the evaluated percentile (None falls back to P95)"
+    )
+    tpot_evaluated_ms: float | None = Field(
+        None, description="TPOT at the evaluated percentile (None falls back to P95)"
+    )
+    total_latency_evaluated_ms: float | None = Field(
+        None, description="Total latency at the evaluated percentile (None falls back to P95)"
+    )
 
 
 class UtilizationResult(BaseModel):

--- a/src/xpyd_plan/cli.py
+++ b/src/xpyd_plan/cli.py
@@ -236,6 +236,7 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
         ttft_ms=args.sla_ttft,
         tpot_ms=args.sla_tpot,
         max_latency_ms=args.sla_max_latency,
+        sla_percentile=args.sla_percentile,
     )
 
     # Handle streaming mode
@@ -409,6 +410,7 @@ def _cmd_export(args: argparse.Namespace) -> None:
         ttft_ms=args.sla_ttft,
         tpot_ms=args.sla_tpot,
         max_latency_ms=args.sla_max_latency,
+        sla_percentile=args.sla_percentile,
     )
     output = export_batch(
         benchmark_dir=args.dir,
@@ -430,6 +432,7 @@ def _cmd_plan_capacity(args: argparse.Namespace) -> None:
         ttft_ms=args.sla_ttft,
         tpot_ms=args.sla_tpot,
         max_latency_ms=args.sla_max_latency,
+        sla_percentile=args.sla_percentile,
     )
 
     datasets = [load_benchmark_auto(b) for b in args.benchmark]
@@ -492,6 +495,7 @@ def _cmd_what_if(args: argparse.Namespace) -> None:
         ttft_ms=args.sla_ttft,
         tpot_ms=args.sla_tpot,
         max_latency_ms=args.sla_max_latency,
+        sla_percentile=args.sla_percentile,
     )
 
     data = load_benchmark_auto(args.benchmark)
@@ -615,6 +619,8 @@ def _apply_config_defaults(args: argparse.Namespace) -> None:
         args.sla_tpot = cfg.sla.tpot_ms
     if getattr(args, "sla_max_latency", None) is None and cfg.sla.max_latency_ms is not None:
         args.sla_max_latency = cfg.sla.max_latency_ms
+    if getattr(args, "sla_percentile", None) == 95.0 and cfg.sla.percentile is not None:
+        args.sla_percentile = cfg.sla.percentile
 
     # Output defaults
     if hasattr(args, "output_format") and args.output_format == "table":
@@ -711,6 +717,10 @@ def main(argv: list[str] | None = None) -> None:
         "--sla-max-latency", type=float, default=None, help="SLA: max total latency P95 (ms)"
     )
     analyze_parser.add_argument(
+        "--sla-percentile", type=float, default=95.0,
+        help="SLA percentile for evaluation (default: 95.0, range: 1-100)",
+    )
+    analyze_parser.add_argument(
         "--total-instances", type=int, default=None,
         help="Total instances to optimize for (default: same as benchmark)",
     )
@@ -762,6 +772,10 @@ def main(argv: list[str] | None = None) -> None:
         "--sla-max-latency", type=float, default=None, help="SLA: max total latency P95 (ms)",
     )
     export_parser.add_argument(
+        "--sla-percentile", type=float, default=95.0,
+        help="SLA percentile for evaluation (default: 95.0, range: 1-100)",
+    )
+    export_parser.add_argument(
         "--total-instances", type=int, default=None,
         help="Total instances to optimize for",
     )
@@ -788,6 +802,10 @@ def main(argv: list[str] | None = None) -> None:
     )
     cap_parser.add_argument(
         "--sla-max-latency", type=float, default=None, help="SLA: max total latency P95 (ms)",
+    )
+    cap_parser.add_argument(
+        "--sla-percentile", type=float, default=95.0,
+        help="SLA percentile for evaluation (default: 95.0, range: 1-100)",
     )
     cap_parser.add_argument(
         "--max-instances", type=int, default=64,
@@ -824,6 +842,10 @@ def main(argv: list[str] | None = None) -> None:
     )
     whatif_parser.add_argument(
         "--sla-max-latency", type=float, default=None, help="SLA: max total latency P95 (ms)",
+    )
+    whatif_parser.add_argument(
+        "--sla-percentile", type=float, default=95.0,
+        help="SLA percentile for evaluation (default: 95.0, range: 1-100)",
     )
     whatif_parser.add_argument(
         "--output-format", type=str, choices=["table", "json"], default="table",

--- a/src/xpyd_plan/config.py
+++ b/src/xpyd_plan/config.py
@@ -20,9 +20,10 @@ STARTER_CONFIG = """\
 # CLI flags always override these defaults.
 
 sla:
-  # ttft_ms: 200.0       # Max TTFT P95 (ms)
-  # tpot_ms: 50.0        # Max TPOT P95 (ms)
-  # max_latency_ms: 5000.0  # Max total latency P95 (ms)
+  # ttft_ms: 200.0       # Max TTFT (ms)
+  # tpot_ms: 50.0        # Max TPOT (ms)
+  # max_latency_ms: 5000.0  # Max total latency (ms)
+  # percentile: 95.0     # Percentile for SLA evaluation (90, 95, 99)
 
 cost:
   # gpu_hourly_rate: 2.50
@@ -45,6 +46,7 @@ class SLAProfile(BaseModel):
     ttft_ms: Optional[float] = None
     tpot_ms: Optional[float] = None
     max_latency_ms: Optional[float] = None
+    percentile: Optional[float] = Field(None, ge=1.0, le=100.0)
 
 
 class CostProfile(BaseModel):

--- a/src/xpyd_plan/models.py
+++ b/src/xpyd_plan/models.py
@@ -11,6 +11,12 @@ class SLAConfig(BaseModel):
     ttft_ms: float | None = Field(None, description="Max Time To First Token (ms)")
     tpot_ms: float | None = Field(None, description="Max Time Per Output Token (ms)")
     max_latency_ms: float | None = Field(None, description="Max end-to-end latency (ms)")
+    sla_percentile: float = Field(
+        95.0,
+        ge=1.0,
+        le=100.0,
+        description="Percentile used for SLA evaluation (e.g. 90, 95, 99)",
+    )
 
     def has_constraints(self) -> bool:
         """Return True if at least one SLA constraint is set."""

--- a/src/xpyd_plan/sensitivity.py
+++ b/src/xpyd_plan/sensitivity.py
@@ -80,27 +80,46 @@ class SensitivityResult(BaseModel):
 def _compute_margins(
     sla_check: SLACheck, sla: SLAConfig
 ) -> dict[str, float | None]:
-    """Compute absolute and percentage margins for each SLA metric."""
+    """Compute absolute and percentage margins for each SLA metric.
+
+    Uses the evaluated percentile values from the SLA check (which respects
+    the configured ``sla_percentile``), falling back to P95 when the
+    evaluated values are not available (backward compatibility).
+    """
     margins: dict[str, float | None] = {}
 
+    ttft_val = (
+        sla_check.ttft_evaluated_ms
+        if sla_check.ttft_evaluated_ms is not None
+        else sla_check.ttft_p95_ms
+    )
+    tpot_val = (
+        sla_check.tpot_evaluated_ms
+        if sla_check.tpot_evaluated_ms is not None
+        else sla_check.tpot_p95_ms
+    )
+    total_val = (
+        sla_check.total_latency_evaluated_ms
+        if sla_check.total_latency_evaluated_ms is not None
+        else sla_check.total_latency_p95_ms
+    )
+
     if sla.ttft_ms is not None:
-        margins["ttft_margin_ms"] = sla.ttft_ms - sla_check.ttft_p95_ms
+        margins["ttft_margin_ms"] = sla.ttft_ms - ttft_val
         margins["ttft_margin_pct"] = margins["ttft_margin_ms"] / sla.ttft_ms
     else:
         margins["ttft_margin_ms"] = None
         margins["ttft_margin_pct"] = None
 
     if sla.tpot_ms is not None:
-        margins["tpot_margin_ms"] = sla.tpot_ms - sla_check.tpot_p95_ms
+        margins["tpot_margin_ms"] = sla.tpot_ms - tpot_val
         margins["tpot_margin_pct"] = margins["tpot_margin_ms"] / sla.tpot_ms
     else:
         margins["tpot_margin_ms"] = None
         margins["tpot_margin_pct"] = None
 
     if sla.max_latency_ms is not None:
-        margins["total_latency_margin_ms"] = (
-            sla.max_latency_ms - sla_check.total_latency_p95_ms
-        )
+        margins["total_latency_margin_ms"] = sla.max_latency_ms - total_val
         margins["total_latency_margin_pct"] = (
             margins["total_latency_margin_ms"] / sla.max_latency_ms
         )

--- a/src/xpyd_plan/streaming.py
+++ b/src/xpyd_plan/streaming.py
@@ -149,9 +149,14 @@ class StreamingAnalyzer:
         total_p95 = _percentile(total_lats, 95)
         total_p99 = _percentile(total_lats, 99)
 
-        meets_ttft = self.sla.ttft_ms is None or ttft_p95 <= self.sla.ttft_ms
-        meets_tpot = self.sla.tpot_ms is None or tpot_p95 <= self.sla.tpot_ms
-        meets_total = self.sla.max_latency_ms is None or total_p95 <= self.sla.max_latency_ms
+        pctl = self.sla.sla_percentile
+        ttft_eval = _percentile(ttfts, pctl)
+        tpot_eval = _percentile(tpots, pctl)
+        total_eval = _percentile(total_lats, pctl)
+
+        meets_ttft = self.sla.ttft_ms is None or ttft_eval <= self.sla.ttft_ms
+        meets_tpot = self.sla.tpot_ms is None or tpot_eval <= self.sla.tpot_ms
+        meets_total = self.sla.max_latency_ms is None or total_eval <= self.sla.max_latency_ms
         meets_all = meets_ttft and meets_tpot and meets_total
 
         timestamps = [r.timestamp for r in self._requests]

--- a/tests/test_sla_percentile.py
+++ b/tests/test_sla_percentile.py
@@ -1,0 +1,430 @@
+"""Tests for configurable SLA percentile threshold (issue #32)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_plan.analyzer import BenchmarkAnalyzer
+from xpyd_plan.benchmark_models import SLACheck
+from xpyd_plan.config import ConfigProfile, SLAProfile
+from xpyd_plan.models import SLAConfig
+from xpyd_plan.sensitivity import analyze_sensitivity
+from xpyd_plan.streaming import StreamingAnalyzer
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_benchmark_data(n: int = 100) -> dict:
+    """Generate benchmark data with linearly increasing latencies.
+
+    Request i has ttft = i+1, tpot = (i+1)*0.5, total = (i+1)*10.
+    This makes percentile values predictable.
+    """
+    requests = []
+    for i in range(n):
+        requests.append({
+            "request_id": f"req-{i}",
+            "prompt_tokens": 100,
+            "output_tokens": 50,
+            "ttft_ms": float(i + 1),         # 1..100
+            "tpot_ms": float(i + 1) * 0.5,   # 0.5..50
+            "total_latency_ms": float(i + 1) * 10.0,  # 10..1000
+            "timestamp": 1000.0 + i,
+        })
+    return {
+        "metadata": {
+            "num_prefill_instances": 4,
+            "num_decode_instances": 4,
+            "total_instances": 8,
+            "measured_qps": 10.0,
+        },
+        "requests": requests,
+    }
+
+
+def _write_benchmark(tmp_path: Path, data: dict | None = None) -> Path:
+    p = tmp_path / "bench.json"
+    p.write_text(json.dumps(data or _make_benchmark_data()))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# SLAConfig validation tests
+# ---------------------------------------------------------------------------
+
+class TestSLAConfigPercentile:
+    def test_default_percentile_is_95(self):
+        sla = SLAConfig(ttft_ms=100.0)
+        assert sla.sla_percentile == 95.0
+
+    def test_custom_percentile(self):
+        sla = SLAConfig(ttft_ms=100.0, sla_percentile=99.0)
+        assert sla.sla_percentile == 99.0
+
+    def test_percentile_90(self):
+        sla = SLAConfig(sla_percentile=90.0)
+        assert sla.sla_percentile == 90.0
+
+    def test_percentile_lower_bound(self):
+        sla = SLAConfig(sla_percentile=1.0)
+        assert sla.sla_percentile == 1.0
+
+    def test_percentile_upper_bound(self):
+        sla = SLAConfig(sla_percentile=100.0)
+        assert sla.sla_percentile == 100.0
+
+    def test_percentile_below_range_rejected(self):
+        with pytest.raises(Exception):
+            SLAConfig(sla_percentile=0.5)
+
+    def test_percentile_above_range_rejected(self):
+        with pytest.raises(Exception):
+            SLAConfig(sla_percentile=100.1)
+
+
+# ---------------------------------------------------------------------------
+# SLACheck.evaluated_percentile tests
+# ---------------------------------------------------------------------------
+
+class TestSLACheckEvaluatedPercentile:
+    def test_default_evaluated_percentile(self):
+        check = SLACheck(
+            ttft_p95_ms=10.0, ttft_p99_ms=20.0,
+            tpot_p95_ms=5.0, tpot_p99_ms=8.0,
+            total_latency_p95_ms=100.0, total_latency_p99_ms=200.0,
+            meets_ttft=True, meets_tpot=True, meets_total_latency=True,
+            meets_all=True,
+        )
+        assert check.evaluated_percentile == 95.0
+
+    def test_custom_evaluated_percentile(self):
+        check = SLACheck(
+            ttft_p95_ms=10.0, ttft_p99_ms=20.0,
+            tpot_p95_ms=5.0, tpot_p99_ms=8.0,
+            total_latency_p95_ms=100.0, total_latency_p99_ms=200.0,
+            meets_ttft=True, meets_tpot=True, meets_total_latency=True,
+            meets_all=True,
+            evaluated_percentile=99.0,
+        )
+        assert check.evaluated_percentile == 99.0
+
+    def test_evaluated_values_present(self):
+        check = SLACheck(
+            ttft_p95_ms=10.0, ttft_p99_ms=20.0,
+            tpot_p95_ms=5.0, tpot_p99_ms=8.0,
+            total_latency_p95_ms=100.0, total_latency_p99_ms=200.0,
+            meets_ttft=True, meets_tpot=True, meets_total_latency=True,
+            meets_all=True,
+            evaluated_percentile=90.0,
+            ttft_evaluated_ms=8.0,
+            tpot_evaluated_ms=4.0,
+            total_latency_evaluated_ms=80.0,
+        )
+        assert check.ttft_evaluated_ms == 8.0
+        assert check.tpot_evaluated_ms == 4.0
+        assert check.total_latency_evaluated_ms == 80.0
+
+
+# ---------------------------------------------------------------------------
+# BenchmarkAnalyzer.check_sla with different percentiles
+# ---------------------------------------------------------------------------
+
+class TestCheckSLAPercentile:
+    def setup_method(self):
+        self.analyzer = BenchmarkAnalyzer()
+        self.analyzer.load_data_from_dict(_make_benchmark_data())
+
+    def test_check_sla_default_p95(self):
+        """Default P95 evaluation — backward compatible."""
+        sla = SLAConfig(ttft_ms=200.0)
+        result = self.analyzer.check_sla(sla)
+        assert result.evaluated_percentile == 95.0
+        assert result.meets_ttft is True
+
+    def test_check_sla_p90_relaxed_passes(self):
+        """P90 is more relaxed than P95 — should pass with a tighter threshold."""
+        # P90 of ttft (1..100) ≈ 90.1, P95 ≈ 95.05
+        sla = SLAConfig(ttft_ms=92.0, sla_percentile=90.0)
+        result = self.analyzer.check_sla(sla)
+        assert result.evaluated_percentile == 90.0
+        assert result.meets_ttft is True
+
+    def test_check_sla_p95_same_threshold_fails(self):
+        """Same threshold that passes P90 should fail at P95."""
+        sla = SLAConfig(ttft_ms=92.0, sla_percentile=95.0)
+        result = self.analyzer.check_sla(sla)
+        assert result.meets_ttft is False
+
+    def test_check_sla_p99_strict(self):
+        """P99 is stricter — needs higher threshold to pass."""
+        sla = SLAConfig(ttft_ms=98.0, sla_percentile=99.0)
+        result = self.analyzer.check_sla(sla)
+        assert result.evaluated_percentile == 99.0
+        # P99 of 1..100 ≈ 99.01 → 98 threshold should fail
+        assert result.meets_ttft is False
+
+    def test_check_sla_p99_passes_with_high_threshold(self):
+        sla = SLAConfig(ttft_ms=200.0, sla_percentile=99.0)
+        result = self.analyzer.check_sla(sla)
+        assert result.meets_ttft is True
+
+    def test_check_sla_evaluated_values_populated(self):
+        sla = SLAConfig(ttft_ms=200.0, sla_percentile=90.0)
+        result = self.analyzer.check_sla(sla)
+        assert result.ttft_evaluated_ms is not None
+        assert result.tpot_evaluated_ms is not None
+        assert result.total_latency_evaluated_ms is not None
+        # Evaluated value should be <= P95 for P90
+        assert result.ttft_evaluated_ms <= result.ttft_p95_ms
+
+    def test_p95_and_p99_always_reported(self):
+        """P95 and P99 values should always be reported regardless of eval percentile."""
+        sla = SLAConfig(ttft_ms=200.0, sla_percentile=90.0)
+        result = self.analyzer.check_sla(sla)
+        assert result.ttft_p95_ms > 0
+        assert result.ttft_p99_ms > 0
+        assert result.ttft_p99_ms >= result.ttft_p95_ms
+
+
+# ---------------------------------------------------------------------------
+# _estimate_ratio_performance with different percentiles
+# ---------------------------------------------------------------------------
+
+class TestEstimateRatioPercentile:
+    def setup_method(self):
+        self.analyzer = BenchmarkAnalyzer()
+        self.analyzer.load_data_from_dict(_make_benchmark_data())
+
+    def test_estimate_p90_passes_where_p95_fails(self):
+        """A tight SLA that passes at P90 but fails at P95."""
+        # Find a threshold between P90 and P95 of scaled values
+        sla_p90 = SLAConfig(ttft_ms=92.0, sla_percentile=90.0)
+        sla_p95 = SLAConfig(ttft_ms=92.0, sla_percentile=95.0)
+
+        result_p90 = self.analyzer._estimate_ratio_performance(4, 4, sla_p90)
+        result_p95 = self.analyzer._estimate_ratio_performance(4, 4, sla_p95)
+
+        assert result_p90.sla_check.evaluated_percentile == 90.0
+        assert result_p95.sla_check.evaluated_percentile == 95.0
+        # P90 should be more lenient
+        assert result_p90.meets_sla is True
+        assert result_p95.meets_sla is False
+
+    def test_estimate_evaluated_percentile_in_sla_check(self):
+        sla = SLAConfig(ttft_ms=200.0, sla_percentile=99.0)
+        result = self.analyzer._estimate_ratio_performance(4, 4, sla)
+        assert result.sla_check.evaluated_percentile == 99.0
+
+    def test_estimate_evaluated_values_populated(self):
+        sla = SLAConfig(ttft_ms=200.0, sla_percentile=90.0)
+        result = self.analyzer._estimate_ratio_performance(4, 4, sla)
+        assert result.sla_check.ttft_evaluated_ms is not None
+
+
+# ---------------------------------------------------------------------------
+# find_optimal_ratio with different percentiles
+# ---------------------------------------------------------------------------
+
+class TestFindOptimalRatioPercentile:
+    def setup_method(self):
+        self.analyzer = BenchmarkAnalyzer()
+        self.analyzer.load_data_from_dict(_make_benchmark_data())
+
+    def test_p90_finds_optimal(self):
+        sla = SLAConfig(ttft_ms=200.0, tpot_ms=100.0, sla_percentile=90.0)
+        result = self.analyzer.find_optimal_ratio(8, sla)
+        assert result.best is not None
+        assert result.best.sla_check.evaluated_percentile == 90.0
+
+    def test_p99_may_reject_more_candidates(self):
+        """With P99, fewer candidates should meet SLA than with P90."""
+        sla_p90 = SLAConfig(ttft_ms=200.0, tpot_ms=100.0, sla_percentile=90.0)
+        sla_p99 = SLAConfig(ttft_ms=200.0, tpot_ms=100.0, sla_percentile=99.0)
+
+        result_p90 = self.analyzer.find_optimal_ratio(8, sla_p90)
+        result_p99 = self.analyzer.find_optimal_ratio(8, sla_p99)
+
+        passing_p90 = sum(1 for c in result_p90.candidates if c.meets_sla)
+        passing_p99 = sum(1 for c in result_p99.candidates if c.meets_sla)
+        assert passing_p90 >= passing_p99
+
+
+# ---------------------------------------------------------------------------
+# Config profile sla.percentile
+# ---------------------------------------------------------------------------
+
+class TestConfigProfilePercentile:
+    def test_sla_profile_percentile_default(self):
+        profile = SLAProfile()
+        assert profile.percentile is None
+
+    def test_sla_profile_percentile_set(self):
+        profile = SLAProfile(percentile=99.0)
+        assert profile.percentile == 99.0
+
+    def test_config_profile_from_yaml(self, tmp_path):
+        config_yaml = tmp_path / "config.yaml"
+        config_yaml.write_text("sla:\n  percentile: 90.0\n  ttft_ms: 200.0\n")
+        cfg = ConfigProfile.from_yaml(config_yaml)
+        assert cfg.sla.percentile == 90.0
+        assert cfg.sla.ttft_ms == 200.0
+
+    def test_config_profile_percentile_in_yaml_output(self):
+        cfg = ConfigProfile(sla=SLAProfile(percentile=99.0))
+        yaml_str = cfg.to_yaml()
+        assert "percentile" in yaml_str
+
+
+# ---------------------------------------------------------------------------
+# CLI --sla-percentile flag
+# ---------------------------------------------------------------------------
+
+class TestCLISlaPercentile:
+    def test_analyze_sla_percentile_flag(self, tmp_path):
+        bench = _write_benchmark(tmp_path)
+        output_file = tmp_path / "result.json"
+        from xpyd_plan.cli import main
+
+        main([
+            "analyze",
+            "--benchmark", str(bench),
+            "--sla-ttft", "200",
+            "--sla-percentile", "90",
+            "--output", str(output_file),
+        ])
+        data = json.loads(output_file.read_text())
+        # Check that candidates have the evaluated percentile
+        if data.get("candidates"):
+            first = data["candidates"][0]
+            if first.get("sla_check"):
+                assert first["sla_check"]["evaluated_percentile"] == 90.0
+
+    def test_analyze_default_percentile_is_95(self, tmp_path):
+        bench = _write_benchmark(tmp_path)
+        output_file = tmp_path / "result.json"
+        from xpyd_plan.cli import main
+
+        main([
+            "analyze",
+            "--benchmark", str(bench),
+            "--sla-ttft", "200",
+            "--output", str(output_file),
+        ])
+        data = json.loads(output_file.read_text())
+        if data.get("candidates"):
+            first = data["candidates"][0]
+            if first.get("sla_check"):
+                assert first["sla_check"]["evaluated_percentile"] == 95.0
+
+
+# ---------------------------------------------------------------------------
+# Sensitivity analysis with percentile
+# ---------------------------------------------------------------------------
+
+class TestSensitivityPercentile:
+    def setup_method(self):
+        self.analyzer = BenchmarkAnalyzer()
+        self.analyzer.load_data_from_dict(_make_benchmark_data())
+
+    def test_sensitivity_respects_p90(self):
+        sla = SLAConfig(ttft_ms=200.0, sla_percentile=90.0)
+        result = analyze_sensitivity(self.analyzer, 8, sla)
+        assert len(result.points) > 0
+        # All SLA checks should use the configured percentile
+        for p in result.points:
+            assert p.sla_check.evaluated_percentile == 90.0
+
+    def test_sensitivity_p99_fewer_passing(self):
+        sla_p90 = SLAConfig(ttft_ms=200.0, tpot_ms=100.0, sla_percentile=90.0)
+        sla_p99 = SLAConfig(ttft_ms=200.0, tpot_ms=100.0, sla_percentile=99.0)
+
+        result_p90 = analyze_sensitivity(self.analyzer, 8, sla_p90)
+        result_p99 = analyze_sensitivity(self.analyzer, 8, sla_p99)
+
+        passing_p90 = sum(1 for p in result_p90.points if p.meets_sla)
+        passing_p99 = sum(1 for p in result_p99.points if p.meets_sla)
+        assert passing_p90 >= passing_p99
+
+
+# ---------------------------------------------------------------------------
+# Streaming analyzer with percentile
+# ---------------------------------------------------------------------------
+
+class TestStreamingPercentile:
+    def test_streaming_respects_sla_percentile(self):
+        sla = SLAConfig(ttft_ms=200.0, sla_percentile=90.0)
+        sa = StreamingAnalyzer(sla=sla, snapshot_interval=5)
+
+        for i in range(10):
+            sa.add_request({
+                "request_id": f"req-{i}",
+                "prompt_tokens": 100,
+                "output_tokens": 50,
+                "ttft_ms": float(i + 1) * 10,
+                "tpot_ms": float(i + 1),
+                "total_latency_ms": float(i + 1) * 100,
+                "timestamp": 1000.0 + i,
+            })
+
+        snapshot = sa.finalize()
+        # With P90 evaluation and ttft_ms=200, should pass
+        assert snapshot.meets_sla is True
+
+    def test_streaming_p99_stricter(self):
+        """Same data, P99 should be stricter."""
+        sla_p90 = SLAConfig(ttft_ms=95.0, sla_percentile=90.0)
+        sla_p99 = SLAConfig(ttft_ms=95.0, sla_percentile=99.0)
+
+        records = [
+            {
+                "request_id": f"req-{i}",
+                "prompt_tokens": 100,
+                "output_tokens": 50,
+                "ttft_ms": float(i + 1),
+                "tpot_ms": float(i + 1) * 0.5,
+                "total_latency_ms": float(i + 1) * 10,
+                "timestamp": 1000.0 + i,
+            }
+            for i in range(100)
+        ]
+
+        sa90 = StreamingAnalyzer(sla=sla_p90, snapshot_interval=200)
+        for r in records:
+            sa90.add_request(r)
+        snap90 = sa90.finalize()
+
+        sa99 = StreamingAnalyzer(sla=sla_p99, snapshot_interval=200)
+        for r in records:
+            sa99.add_request(r)
+        snap99 = sa99.finalize()
+
+        # P90 should pass (P90 ≈ 90.1 < 95), P99 should fail (P99 ≈ 99.01 > 95)
+        assert snap90.meets_sla is True
+        assert snap99.meets_sla is False
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility
+# ---------------------------------------------------------------------------
+
+class TestBackwardCompatibility:
+    def test_sla_config_without_percentile(self):
+        """SLAConfig without explicit percentile defaults to 95."""
+        sla = SLAConfig(ttft_ms=100.0)
+        assert sla.sla_percentile == 95.0
+
+    def test_sla_check_without_evaluated_percentile(self):
+        """SLACheck without explicit evaluated_percentile defaults to 95."""
+        check = SLACheck(
+            ttft_p95_ms=10.0, ttft_p99_ms=20.0,
+            tpot_p95_ms=5.0, tpot_p99_ms=8.0,
+            total_latency_p95_ms=100.0, total_latency_p99_ms=200.0,
+            meets_ttft=True, meets_tpot=True, meets_total_latency=True,
+            meets_all=True,
+        )
+        assert check.evaluated_percentile == 95.0
+        assert check.ttft_evaluated_ms is None  # None when not explicitly set


### PR DESCRIPTION
## Summary

Add configurable SLA percentile threshold so users can choose P90 (relaxed), P95 (default), or P99 (strict) for SLA evaluation.

## Changes

- **`SLAConfig.sla_percentile`** — new field (default: 95.0, range: 1-100)
- **`SLACheck.evaluated_percentile`** — reports which percentile was used
- **`SLACheck.{ttft,tpot,total_latency}_evaluated_ms`** — actual values at the evaluated percentile
- **`check_sla()`** and **`_estimate_ratio_performance()`** — use configured percentile for pass/fail
- **CLI `--sla-percentile`** flag on analyze, export, plan-capacity, what-if subcommands
- **Config profile `sla.percentile`** support in YAML config
- **Sensitivity analysis** — margins computed from evaluated percentile values
- **Streaming analyzer** — respects configured percentile

## Tests

34 new tests covering:
- SLAConfig validation (range, default, boundaries)
- SLACheck evaluated_percentile and evaluated values
- check_sla with P90, P95, P99
- _estimate_ratio_performance with different percentiles
- find_optimal_ratio comparing P90 vs P99 candidate counts
- Config profile YAML round-trip
- CLI --sla-percentile flag integration
- Sensitivity analysis percentile propagation
- Streaming analyzer percentile behavior
- Backward compatibility (all 254 existing tests unchanged)

**288 total tests, all passing.**

Closes #32