### PR TITLE
feat: M14 — Benchmark Comparison & Regression Detection

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -170,3 +170,14 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Sensitivity and streaming analysis respect the configured percentile
 - Backward compatible — default P95 behavior unchanged
 - 34 new tests (288 total)
+
+### M14 — Benchmark Comparison & Regression Detection
+
+- `BenchmarkComparator` class in `comparator.py`
+- `MetricDelta` and `ComparisonResult` Pydantic models
+- Latency deltas at P50/P95/P99 for TTFT, TPOT, total latency
+- QPS delta (higher-is-better semantics)
+- Configurable regression threshold (default 10%)
+- CLI `compare` subcommand with table and JSON output
+- Programmatic `compare_benchmarks()` API
+- 23 new tests (311 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -12,6 +12,12 @@ from xpyd_plan.benchmark_models import (
     SLACheck,
     UtilizationResult,
 )
+from xpyd_plan.comparator import (
+    BenchmarkComparator,
+    ComparisonResult,
+    MetricDelta,
+    compare_benchmarks,
+)
 from xpyd_plan.config import ConfigProfile, load_config
 from xpyd_plan.gpu_profiles import get_gpu_profile, list_gpu_profiles
 from xpyd_plan.models import (
@@ -24,6 +30,10 @@ from xpyd_plan.models import (
 __all__ = [
     "AnalysisResult",
     "BenchmarkAnalyzer",
+    "BenchmarkComparator",
+    "ComparisonResult",
+    "MetricDelta",
+    "compare_benchmarks",
     "BenchmarkData",
     "BenchmarkMetadata",
     "BenchmarkRequest",

--- a/src/xpyd_plan/cli.py
+++ b/src/xpyd_plan/cli.py
@@ -661,6 +661,59 @@ def _cmd_config(args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
+def _cmd_compare(args: argparse.Namespace) -> None:
+    """Execute the compare subcommand."""
+
+    from xpyd_plan.comparator import compare_benchmarks
+
+    console = Console()
+    result = compare_benchmarks(args.baseline, args.current, threshold=args.threshold)
+
+    if args.output_format == "json":
+        console.print_json(result.model_dump_json(indent=2))
+        return
+
+    # Table output
+    console.print("\n[bold]📊 Benchmark Comparison[/bold]")
+    console.print(f"   Threshold: {result.threshold * 100:.0f}%")
+    console.print(f"   Baseline QPS: {result.baseline_qps:.1f}")
+    console.print(f"   Current QPS:  {result.current_qps:.1f}")
+
+    qps = result.qps_delta
+    qps_color = "red" if qps.is_regression else "green" if qps.relative_delta > 0 else "white"
+    console.print(
+        f"   QPS change: [{qps_color}]{qps.relative_delta:+.1%}[/{qps_color}]"
+        f"{'  ⚠️  REGRESSION' if qps.is_regression else ''}"
+    )
+
+    table = Table(title="\nLatency Comparison")
+    table.add_column("Metric", style="cyan")
+    table.add_column("Baseline", justify="right")
+    table.add_column("Current", justify="right")
+    table.add_column("Change", justify="right")
+    table.add_column("Status", justify="center")
+
+    for delta in result.latency_deltas:
+        color = "red" if delta.is_regression else "green" if delta.relative_delta < 0 else "white"
+        status = "⚠️  REGRESSED" if delta.is_regression else "✅"
+        table.add_row(
+            delta.metric,
+            f"{delta.baseline:.1f}",
+            f"{delta.current:.1f}",
+            f"[{color}]{delta.relative_delta:+.1%}[/{color}]",
+            status,
+        )
+
+    console.print(table)
+
+    if result.has_regression:
+        console.print(
+            f"\n[bold red]⚠️  {result.regression_count} regression(s) detected![/bold red]"
+        )
+    else:
+        console.print("\n[bold green]✅ No regressions detected.[/bold green]")
+
+
 def main(argv: list[str] | None = None) -> None:
     """Entry point for `xpyd-plan` command."""
     parser = argparse.ArgumentParser(
@@ -852,6 +905,27 @@ def main(argv: list[str] | None = None) -> None:
         help="Output format (default: table)",
     )
 
+    compare_parser = subparsers.add_parser(
+        "compare",
+        help="Compare two benchmark datasets and detect regressions",
+    )
+    compare_parser.add_argument(
+        "--baseline", type=str, required=True,
+        help="Path to baseline benchmark JSON file",
+    )
+    compare_parser.add_argument(
+        "--current", type=str, required=True,
+        help="Path to current benchmark JSON file",
+    )
+    compare_parser.add_argument(
+        "--threshold", type=float, default=0.1,
+        help="Regression threshold as fraction (default: 0.1 = 10%%)",
+    )
+    compare_parser.add_argument(
+        "--output-format", type=str, choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "config":
@@ -868,6 +942,8 @@ def main(argv: list[str] | None = None) -> None:
     elif args.command == "what-if":
         _apply_config_defaults(args)
         _cmd_what_if(args)
+    elif args.command == "compare":
+        _cmd_compare(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/comparator.py
+++ b/src/xpyd_plan/comparator.py
@@ -1,0 +1,169 @@
+"""Benchmark comparison and regression detection.
+
+Compare two benchmark datasets (baseline vs current) to detect performance
+regressions or improvements across latency and throughput metrics.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from xpyd_plan.benchmark_models import BenchmarkData
+
+
+class MetricDelta(BaseModel):
+    """Delta between baseline and current for a single metric."""
+
+    metric: str = Field(..., description="Metric name (e.g., ttft_p95_ms)")
+    baseline: float = Field(..., description="Baseline value")
+    current: float = Field(..., description="Current value")
+    absolute_delta: float = Field(..., description="current - baseline")
+    relative_delta: float = Field(
+        ..., description="Relative change: (current - baseline) / baseline, or 0.0 if baseline is 0"
+    )
+    is_regression: bool = Field(
+        False, description="True if metric degraded beyond threshold"
+    )
+
+
+class ComparisonResult(BaseModel):
+    """Result of comparing two benchmark datasets."""
+
+    baseline_qps: float
+    current_qps: float
+    qps_delta: MetricDelta
+    latency_deltas: list[MetricDelta] = Field(default_factory=list)
+    has_regression: bool = Field(False, description="True if any metric regressed")
+    regression_count: int = Field(0, description="Number of regressed metrics")
+    threshold: float = Field(0.1, description="Regression threshold used")
+
+
+def _percentile(values: list[float], p: float) -> float:
+    """Compute the p-th percentile."""
+    if not values:
+        return 0.0
+    return float(np.percentile(values, p))
+
+
+def _compute_delta(
+    metric: str,
+    baseline: float,
+    current: float,
+    threshold: float,
+    higher_is_worse: bool = True,
+) -> MetricDelta:
+    """Compute a metric delta and flag regression."""
+    absolute = current - baseline
+    if baseline > 0:
+        relative = absolute / baseline
+    else:
+        relative = 0.0
+
+    if higher_is_worse:
+        is_regression = relative > threshold
+    else:
+        # For QPS: lower is worse → regression if it dropped beyond threshold
+        is_regression = -relative > threshold
+
+    return MetricDelta(
+        metric=metric,
+        baseline=baseline,
+        current=current,
+        absolute_delta=absolute,
+        relative_delta=relative,
+        is_regression=is_regression,
+    )
+
+
+class BenchmarkComparator:
+    """Compare two benchmark datasets for regression detection.
+
+    Args:
+        threshold: Relative change threshold to flag as regression (default 0.1 = 10%).
+    """
+
+    def __init__(self, threshold: float = 0.1) -> None:
+        if threshold < 0:
+            raise ValueError("threshold must be >= 0")
+        self.threshold = threshold
+
+    def compare(self, baseline: BenchmarkData, current: BenchmarkData) -> ComparisonResult:
+        """Compare baseline and current benchmark data.
+
+        Args:
+            baseline: The reference benchmark dataset.
+            current: The new benchmark dataset to compare against baseline.
+
+        Returns:
+            ComparisonResult with per-metric deltas and regression flags.
+        """
+        # Extract latency lists
+        b_ttft = [r.ttft_ms for r in baseline.requests]
+        b_tpot = [r.tpot_ms for r in baseline.requests]
+        b_total = [r.total_latency_ms for r in baseline.requests]
+        c_ttft = [r.ttft_ms for r in current.requests]
+        c_tpot = [r.tpot_ms for r in current.requests]
+        c_total = [r.total_latency_ms for r in current.requests]
+
+        # Latency metrics at P50, P95, P99
+        latency_deltas: list[MetricDelta] = []
+        for name, b_vals, c_vals in [
+            ("ttft", b_ttft, c_ttft),
+            ("tpot", b_tpot, c_tpot),
+            ("total_latency", b_total, c_total),
+        ]:
+            for p in [50, 95, 99]:
+                metric_name = f"{name}_p{p}_ms"
+                b_val = _percentile(b_vals, p)
+                c_val = _percentile(c_vals, p)
+                delta = _compute_delta(metric_name, b_val, c_val, self.threshold)
+                latency_deltas.append(delta)
+
+        # QPS delta (higher is better)
+        qps_delta = _compute_delta(
+            "measured_qps",
+            baseline.metadata.measured_qps,
+            current.metadata.measured_qps,
+            self.threshold,
+            higher_is_worse=False,
+        )
+
+        all_deltas = latency_deltas + [qps_delta]
+        regression_count = sum(1 for d in all_deltas if d.is_regression)
+
+        return ComparisonResult(
+            baseline_qps=baseline.metadata.measured_qps,
+            current_qps=current.metadata.measured_qps,
+            qps_delta=qps_delta,
+            latency_deltas=latency_deltas,
+            has_regression=regression_count > 0,
+            regression_count=regression_count,
+            threshold=self.threshold,
+        )
+
+
+def compare_benchmarks(
+    baseline_path: str | Path,
+    current_path: str | Path,
+    threshold: float = 0.1,
+) -> ComparisonResult:
+    """Programmatic API: compare two benchmark files.
+
+    Args:
+        baseline_path: Path to baseline benchmark JSON file.
+        current_path: Path to current benchmark JSON file.
+        threshold: Regression threshold (default 0.1 = 10%).
+
+    Returns:
+        ComparisonResult with all metric deltas and regression flags.
+    """
+    baseline_data = json.loads(Path(baseline_path).read_text())
+    current_data = json.loads(Path(current_path).read_text())
+    baseline = BenchmarkData(**baseline_data)
+    current = BenchmarkData(**current_data)
+    comparator = BenchmarkComparator(threshold=threshold)
+    return comparator.compare(baseline, current)

--- a/tests/test_comparator.py
+++ b/tests/test_comparator.py
@@ -1,0 +1,306 @@
+"""Tests for benchmark comparison and regression detection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.comparator import (
+    BenchmarkComparator,
+    ComparisonResult,
+    MetricDelta,
+    compare_benchmarks,
+)
+
+
+def _make_requests(
+    n: int = 50,
+    ttft_base: float = 50.0,
+    tpot_base: float = 10.0,
+    total_base: float = 200.0,
+    spread: float = 0.2,
+) -> list[BenchmarkRequest]:
+    """Generate benchmark requests with controlled latency distribution."""
+    requests = []
+    for i in range(n):
+        factor = 1.0 + spread * (i / max(n - 1, 1))
+        requests.append(
+            BenchmarkRequest(
+                request_id=f"req-{i:04d}",
+                prompt_tokens=100,
+                output_tokens=50,
+                ttft_ms=ttft_base * factor,
+                tpot_ms=tpot_base * factor,
+                total_latency_ms=total_base * factor,
+                timestamp=1700000000.0 + i,
+            )
+        )
+    return requests
+
+
+def _make_benchmark(
+    qps: float = 10.0,
+    ttft_base: float = 50.0,
+    tpot_base: float = 10.0,
+    total_base: float = 200.0,
+    n: int = 50,
+    spread: float = 0.2,
+) -> BenchmarkData:
+    """Create a BenchmarkData object."""
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=2,
+            total_instances=4,
+            measured_qps=qps,
+        ),
+        requests=_make_requests(n, ttft_base, tpot_base, total_base, spread),
+    )
+
+
+class TestBenchmarkComparator:
+    """Tests for BenchmarkComparator."""
+
+    def test_no_regression_identical(self):
+        """Identical benchmarks should show no regression."""
+        data = _make_benchmark()
+        comparator = BenchmarkComparator(threshold=0.1)
+        result = comparator.compare(data, data)
+        assert not result.has_regression
+        assert result.regression_count == 0
+        for delta in result.latency_deltas:
+            assert delta.absolute_delta == 0.0
+            assert delta.relative_delta == 0.0
+
+    def test_regression_detected_latency(self):
+        """Higher latency beyond threshold should be flagged."""
+        baseline = _make_benchmark(ttft_base=50.0)
+        current = _make_benchmark(ttft_base=60.0)  # 20% worse
+        comparator = BenchmarkComparator(threshold=0.1)
+        result = comparator.compare(baseline, current)
+        assert result.has_regression
+        ttft_deltas = [d for d in result.latency_deltas if d.metric.startswith("ttft")]
+        assert any(d.is_regression for d in ttft_deltas)
+
+    def test_regression_detected_qps_drop(self):
+        """QPS drop beyond threshold should be flagged."""
+        baseline = _make_benchmark(qps=100.0)
+        current = _make_benchmark(qps=80.0)  # 20% drop
+        comparator = BenchmarkComparator(threshold=0.1)
+        result = comparator.compare(baseline, current)
+        assert result.has_regression
+        assert result.qps_delta.is_regression
+
+    def test_no_regression_qps_increase(self):
+        """QPS increase should not be a regression."""
+        baseline = _make_benchmark(qps=100.0)
+        current = _make_benchmark(qps=120.0)  # 20% better
+        comparator = BenchmarkComparator(threshold=0.1)
+        result = comparator.compare(baseline, current)
+        assert not result.qps_delta.is_regression
+
+    def test_improvement_detected(self):
+        """Lower latency should show negative delta, not regression."""
+        baseline = _make_benchmark(ttft_base=100.0)
+        current = _make_benchmark(ttft_base=80.0)  # 20% better
+        comparator = BenchmarkComparator(threshold=0.1)
+        result = comparator.compare(baseline, current)
+        ttft_deltas = [d for d in result.latency_deltas if d.metric.startswith("ttft")]
+        for d in ttft_deltas:
+            assert d.relative_delta < 0
+            assert not d.is_regression
+
+    def test_threshold_boundary_not_regression(self):
+        """Change exactly at threshold should not be flagged (need > threshold)."""
+        baseline = _make_benchmark(ttft_base=100.0)
+        # 10% worse = exactly at threshold
+        current = _make_benchmark(ttft_base=110.0)
+        comparator = BenchmarkComparator(threshold=0.1)
+        result = comparator.compare(baseline, current)
+        # P50 base values: 100*1.0 vs 110*1.0 → 10% exactly, not > 10%
+        ttft_p50 = [d for d in result.latency_deltas if d.metric == "ttft_p50_ms"][0]
+        assert not ttft_p50.is_regression
+
+    def test_threshold_zero(self):
+        """Threshold=0 should flag any degradation."""
+        baseline = _make_benchmark(ttft_base=100.0)
+        current = _make_benchmark(ttft_base=101.0)  # 1% worse
+        comparator = BenchmarkComparator(threshold=0.0)
+        result = comparator.compare(baseline, current)
+        assert result.has_regression
+
+    def test_invalid_threshold(self):
+        """Negative threshold should raise."""
+        with pytest.raises(ValueError, match="threshold must be >= 0"):
+            BenchmarkComparator(threshold=-0.1)
+
+    def test_regression_count(self):
+        """Count should reflect total regressions across all metrics."""
+        baseline = _make_benchmark(ttft_base=50.0, tpot_base=10.0, total_base=200.0, qps=100.0)
+        current = _make_benchmark(ttft_base=70.0, tpot_base=14.0, total_base=280.0, qps=70.0)
+        comparator = BenchmarkComparator(threshold=0.1)
+        result = comparator.compare(baseline, current)
+        # All 9 latency metrics + QPS = 10 potential regressions
+        assert result.regression_count == 10
+
+    def test_comparison_result_fields(self):
+        """ComparisonResult should have all expected fields."""
+        data = _make_benchmark(qps=50.0)
+        comparator = BenchmarkComparator()
+        result = comparator.compare(data, data)
+        assert result.baseline_qps == 50.0
+        assert result.current_qps == 50.0
+        assert result.threshold == 0.1
+        assert len(result.latency_deltas) == 9  # 3 metrics × 3 percentiles
+        assert isinstance(result.qps_delta, MetricDelta)
+
+    def test_metric_delta_fields(self):
+        """MetricDelta should compute correct values."""
+        baseline = _make_benchmark(ttft_base=100.0)
+        current = _make_benchmark(ttft_base=150.0)
+        comparator = BenchmarkComparator(threshold=0.1)
+        result = comparator.compare(baseline, current)
+        ttft_p50 = [d for d in result.latency_deltas if d.metric == "ttft_p50_ms"][0]
+        assert ttft_p50.baseline > 0
+        assert ttft_p50.current > ttft_p50.baseline
+        assert ttft_p50.absolute_delta > 0
+        assert ttft_p50.relative_delta > 0
+        assert ttft_p50.is_regression
+
+    def test_large_threshold_no_regression(self):
+        """Very large threshold should not flag anything."""
+        baseline = _make_benchmark(ttft_base=50.0)
+        current = _make_benchmark(ttft_base=90.0)  # 80% worse
+        comparator = BenchmarkComparator(threshold=1.0)  # 100% threshold
+        result = comparator.compare(baseline, current)
+        assert not result.has_regression
+
+    def test_mixed_regression(self):
+        """Some metrics regressed, others improved."""
+        baseline = _make_benchmark(ttft_base=100.0, tpot_base=20.0, qps=50.0)
+        current = _make_benchmark(ttft_base=120.0, tpot_base=15.0, qps=55.0)
+        comparator = BenchmarkComparator(threshold=0.1)
+        result = comparator.compare(baseline, current)
+        # TTFT regressed, TPOT improved, QPS improved
+        ttft_regressions = [
+            d for d in result.latency_deltas if d.metric.startswith("ttft") and d.is_regression
+        ]
+        tpot_regressions = [
+            d for d in result.latency_deltas if d.metric.startswith("tpot") and d.is_regression
+        ]
+        assert len(ttft_regressions) > 0
+        assert len(tpot_regressions) == 0
+        assert not result.qps_delta.is_regression
+
+    def test_default_threshold(self):
+        """Default threshold should be 0.1."""
+        comparator = BenchmarkComparator()
+        assert comparator.threshold == 0.1
+
+    def test_custom_threshold(self):
+        """Custom threshold should be respected."""
+        comparator = BenchmarkComparator(threshold=0.05)
+        assert comparator.threshold == 0.05
+
+
+class TestCompareBenchmarks:
+    """Tests for the compare_benchmarks() programmatic API."""
+
+    def test_compare_from_files(self, tmp_path: Path):
+        """Compare two benchmark files."""
+        baseline = _make_benchmark(qps=100.0, ttft_base=50.0)
+        current = _make_benchmark(qps=100.0, ttft_base=55.0)
+
+        baseline_path = tmp_path / "baseline.json"
+        current_path = tmp_path / "current.json"
+        baseline_path.write_text(baseline.model_dump_json(indent=2))
+        current_path.write_text(current.model_dump_json(indent=2))
+
+        result = compare_benchmarks(baseline_path, current_path, threshold=0.1)
+        assert isinstance(result, ComparisonResult)
+        assert result.baseline_qps == 100.0
+
+    def test_compare_with_regression(self, tmp_path: Path):
+        """File comparison should detect regressions."""
+        baseline = _make_benchmark(qps=100.0, ttft_base=50.0)
+        current = _make_benchmark(qps=100.0, ttft_base=80.0)
+
+        baseline_path = tmp_path / "baseline.json"
+        current_path = tmp_path / "current.json"
+        baseline_path.write_text(baseline.model_dump_json(indent=2))
+        current_path.write_text(current.model_dump_json(indent=2))
+
+        result = compare_benchmarks(baseline_path, current_path)
+        assert result.has_regression
+
+    def test_compare_invalid_file(self, tmp_path: Path):
+        """Invalid JSON should raise."""
+        baseline_path = tmp_path / "baseline.json"
+        baseline_path.write_text("not json")
+        current_path = tmp_path / "current.json"
+        current_path.write_text("{}")
+        with pytest.raises(Exception):
+            compare_benchmarks(baseline_path, current_path)
+
+    def test_compare_default_threshold(self, tmp_path: Path):
+        """Default threshold should be 0.1."""
+        data = _make_benchmark()
+        p = tmp_path / "data.json"
+        p.write_text(data.model_dump_json(indent=2))
+        result = compare_benchmarks(p, p)
+        assert result.threshold == 0.1
+
+    def test_compare_custom_threshold(self, tmp_path: Path):
+        """Custom threshold should be passed through."""
+        data = _make_benchmark()
+        p = tmp_path / "data.json"
+        p.write_text(data.model_dump_json(indent=2))
+        result = compare_benchmarks(p, p, threshold=0.05)
+        assert result.threshold == 0.05
+
+
+class TestCompareCLI:
+    """Tests for the compare CLI subcommand."""
+
+    def test_compare_table_output(self, tmp_path: Path, capsys):
+        """CLI compare should produce table output."""
+        from xpyd_plan.cli import main
+
+        baseline = _make_benchmark(qps=100.0, ttft_base=50.0)
+        current = _make_benchmark(qps=100.0, ttft_base=60.0)
+
+        (tmp_path / "baseline.json").write_text(baseline.model_dump_json(indent=2))
+        (tmp_path / "current.json").write_text(current.model_dump_json(indent=2))
+
+        main([
+            "compare",
+            "--baseline", str(tmp_path / "baseline.json"),
+            "--current", str(tmp_path / "current.json"),
+        ])
+
+    def test_compare_json_output(self, tmp_path: Path, capsys):
+        """CLI compare with --output-format json."""
+        from xpyd_plan.cli import main
+
+        data = _make_benchmark()
+        p = tmp_path / "data.json"
+        p.write_text(data.model_dump_json(indent=2))
+
+        main(["compare", "--baseline", str(p), "--current", str(p), "--output-format", "json"])
+
+    def test_compare_custom_threshold_cli(self, tmp_path: Path):
+        """CLI compare with custom threshold."""
+        from xpyd_plan.cli import main
+
+        data = _make_benchmark()
+        p = tmp_path / "data.json"
+        p.write_text(data.model_dump_json(indent=2))
+
+        main([
+            "compare",
+            "--baseline", str(p),
+            "--current", str(p),
+            "--threshold", "0.05",
+        ])


### PR DESCRIPTION
## Summary

Add benchmark comparison and regression detection capability.

**New files:**
- `src/xpyd_plan/comparator.py` — `BenchmarkComparator` class, `MetricDelta`/`ComparisonResult` models, `compare_benchmarks()` API
- `tests/test_comparator.py` — 23 new tests

**Changes:**
- `cli.py` — new `compare` subcommand with table/JSON output
- `__init__.py` — export new public API
- `ROADMAP.md` — add M14 milestone

**Features:**
- Compare two benchmark datasets (baseline vs current)
- Latency deltas at P50/P95/P99 for TTFT, TPOT, total latency
- QPS delta with higher-is-better semantics
- Configurable regression threshold (default 10%)
- CLI: `xpyd-plan compare --baseline a.json --current b.json [--threshold 0.1] [--output-format json]`
- Programmatic: `compare_benchmarks(baseline_path, current_path, threshold=0.1)`

**Tests:** 311 total (23 new), all passing. Lint clean.

Closes #34