### PR TITLE
feat: M18 Performance Interpolation Model

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -221,3 +221,14 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Keyboard shortcuts for switching views
 - CLI `dashboard` subcommand with `--refresh-interval`
 - ~34 new tests (385 total)
+
+### M18 — Performance Interpolation Model
+
+- `PerformanceInterpolator` class in `interpolator.py`
+- `PredictedPerformance` and `InterpolationResult` Pydantic models
+- Linear and cubic spline interpolation methods
+- Confidence classification: HIGH (interpolation), MEDIUM (near extrapolation ≤20%), LOW (far extrapolation)
+- CLI `interpolate` subcommand with `--benchmark`, `--method`, `--ratios`, table + JSON output
+- Programmatic `interpolate_performance()` API
+- scipy dependency for spline interpolation
+- 25 new tests (410 total)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "PyYAML>=6.0",
     "rich>=13.0.0",
+    "scipy>=1.11.0",
 ]
 
 [project.optional-dependencies]

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -26,6 +26,14 @@ from xpyd_plan.dashboard import (
     run_dashboard,
 )
 from xpyd_plan.gpu_profiles import get_gpu_profile, list_gpu_profiles
+from xpyd_plan.interpolator import (
+    InterpolationConfidence,
+    InterpolationMethod,
+    InterpolationResult,
+    PerformanceInterpolator,
+    PredictedPerformance,
+    interpolate_performance,
+)
 from xpyd_plan.models import (
     DatasetStats,
     GPUProfile,
@@ -71,6 +79,12 @@ __all__ = [
     "OutlierMethod",
     "ValidationResult",
     "validate_benchmark",
+    "InterpolationConfidence",
+    "InterpolationMethod",
+    "InterpolationResult",
+    "PerformanceInterpolator",
+    "PredictedPerformance",
+    "interpolate_performance",
     "Dashboard",
     "DashboardState",
     "DashboardView",

--- a/src/xpyd_plan/cli.py
+++ b/src/xpyd_plan/cli.py
@@ -877,6 +877,86 @@ def _cmd_dashboard(args: argparse.Namespace) -> None:
         dashboard.run(stream=sys.stdin, metadata=metadata, console=console)
 
 
+def _cmd_interpolate(args: argparse.Namespace) -> None:
+    """Run performance interpolation across P:D ratios."""
+    import json as json_mod
+
+    from xpyd_plan.interpolator import (
+        InterpolationMethod,
+        interpolate_performance,
+    )
+
+    console = Console()
+    paths = args.benchmark
+    if not paths or len(paths) < 2:
+        console.print("[red]Need at least 2 benchmark files for interpolation.[/red]")
+        sys.exit(1)
+
+    from xpyd_plan.analyzer import BenchmarkAnalyzer
+    analyzer = BenchmarkAnalyzer()
+    datasets = analyzer.load_multi_data(paths)
+
+    method = InterpolationMethod(args.method)
+
+    target_ratios = None
+    if args.ratios:
+        target_ratios = []
+        for r in args.ratios:
+            parts = r.replace("P", "").replace("D", "").replace("p", "").replace("d", "").split(":")
+            if len(parts) != 2:
+                console.print(f"[red]Invalid ratio format '{r}'. Use 'P:D' e.g. '2:6'.[/red]")
+                sys.exit(1)
+            target_ratios.append((int(parts[0]), int(parts[1])))
+
+    result = interpolate_performance(datasets, target_ratios=target_ratios, method=method)
+
+    output_format = getattr(args, "output_format", "table")
+
+    if output_format == "json":
+        console.print(json_mod.dumps(result.model_dump(), indent=2))
+        return
+
+    # Table output
+    table = Table(title="Performance Interpolation Results")
+    table.add_column("P:D Ratio", style="cyan")
+    table.add_column("TTFT P95 (ms)", justify="right")
+    table.add_column("TPOT P95 (ms)", justify="right")
+    table.add_column("Total Lat P95 (ms)", justify="right")
+    table.add_column("QPS", justify="right")
+    table.add_column("Confidence", justify="center")
+    table.add_column("Measured", justify="center")
+
+    for pred in result.predictions:
+        conf_style = {
+            "high": "green",
+            "medium": "yellow",
+            "low": "red",
+        }.get(pred.confidence.value, "white")
+        table.add_row(
+            f"{pred.num_prefill}P:{pred.num_decode}D",
+            f"{pred.ttft_p95_ms:.1f}",
+            f"{pred.tpot_p95_ms:.1f}",
+            f"{pred.total_latency_p95_ms:.1f}",
+            f"{pred.throughput_qps:.1f}",
+            f"[{conf_style}]{pred.confidence.value.upper()}[/{conf_style}]",
+            "✓" if pred.is_measured else "",
+        )
+
+    console.print(table)
+
+    if result.best_predicted:
+        bp = result.best_predicted
+        console.print(
+            f"\n[bold green]Best predicted:[/bold green] "
+            f"{bp.num_prefill}P:{bp.num_decode}D "
+            f"(QPS={bp.throughput_qps:.1f}, confidence={bp.confidence.value})"
+        )
+
+    if result.notes:
+        for note in result.notes:
+            console.print(f"[dim]Note: {note}[/dim]")
+
+
 def _cmd_compare(args: argparse.Namespace) -> None:
     """Execute the compare subcommand."""
 
@@ -1211,6 +1291,29 @@ def main(argv: list[str] | None = None) -> None:
         "dashboard",
         help="Interactive TUI dashboard for real-time benchmark monitoring",
     )
+
+    # --- interpolate subcommand ---
+    interp_parser = subparsers.add_parser(
+        "interpolate",
+        help="Predict performance at untested P:D ratios via interpolation",
+    )
+    interp_parser.add_argument(
+        "--benchmark", type=str, nargs="+", required=True,
+        help="Benchmark JSON files (at least 2, different P:D ratios, same total instances)",
+    )
+    interp_parser.add_argument(
+        "--method", type=str, default="linear", choices=["linear", "spline"],
+        help="Interpolation method (default: linear)",
+    )
+    interp_parser.add_argument(
+        "--ratios", type=str, nargs="*", default=None,
+        help="P:D ratios to predict, e.g. '2:6' '3:5'. Omit to predict all.",
+    )
+    interp_parser.add_argument(
+        "--output-format", type=str, default="table", choices=["table", "json"],
+        help="Output format (default: table)",
+    )
+
     dashboard_parser.add_argument(
         "--benchmark", type=str, default=None,
         help="Path to benchmark JSON file (static mode)",
@@ -1272,6 +1375,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_trend(args)
     elif args.command == "dashboard":
         _cmd_dashboard(args)
+    elif args.command == "interpolate":
+        _cmd_interpolate(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/interpolator.py
+++ b/src/xpyd_plan/interpolator.py
@@ -1,0 +1,322 @@
+"""Performance interpolation model for predicting untested P:D ratios.
+
+Given benchmark data at a few P:D configurations, fits a performance model
+per metric and predicts performance at untested ratios. Follows DESIGN_PRINCIPLES:
+  - Analyze data, fit/interpolate, build performance model
+  - Extrapolate predicted performance for all possible P:D ratios
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from xpyd_plan.benchmark_models import BenchmarkData
+
+
+class InterpolationMethod(str, Enum):
+    """Supported interpolation methods."""
+
+    LINEAR = "linear"
+    SPLINE = "spline"
+
+
+class InterpolationConfidence(str, Enum):
+    """Confidence level of an interpolated prediction."""
+
+    HIGH = "high"  # Within range of measured data (interpolation)
+    MEDIUM = "medium"  # Near extrapolation (≤20% beyond range)
+    LOW = "low"  # Far extrapolation (>20% beyond range)
+
+
+class PredictedPerformance(BaseModel):
+    """Predicted performance for a single P:D ratio."""
+
+    num_prefill: int = Field(..., ge=1)
+    num_decode: int = Field(..., ge=1)
+    total_instances: int = Field(..., ge=2)
+    prefill_fraction: float = Field(
+        ..., ge=0, le=1, description="Fraction of instances used for prefill"
+    )
+    ttft_p95_ms: float = Field(..., ge=0, description="Predicted TTFT P95 (ms)")
+    tpot_p95_ms: float = Field(..., ge=0, description="Predicted TPOT P95 (ms)")
+    total_latency_p95_ms: float = Field(
+        ..., ge=0, description="Predicted total latency P95 (ms)"
+    )
+    throughput_qps: float = Field(..., ge=0, description="Predicted throughput (QPS)")
+    confidence: InterpolationConfidence
+    is_measured: bool = Field(False, description="Whether this ratio was actually measured")
+
+
+class InterpolationResult(BaseModel):
+    """Result of performance interpolation across P:D ratios."""
+
+    method: InterpolationMethod
+    measured_points: int = Field(..., ge=2, description="Number of measured data points used")
+    total_instances: int
+    predictions: list[PredictedPerformance] = Field(default_factory=list)
+    best_predicted: PredictedPerformance | None = Field(
+        None, description="Ratio with best predicted throughput"
+    )
+    notes: list[str] = Field(default_factory=list)
+
+
+def _compute_percentile(values: list[float], p: float) -> float:
+    """Compute percentile from a list of values."""
+    if not values:
+        return 0.0
+    return float(np.percentile(values, p))
+
+
+def _classify_confidence(
+    x: float, x_min: float, x_max: float
+) -> InterpolationConfidence:
+    """Classify confidence based on how far x is from measured range."""
+    if x_min <= x <= x_max:
+        return InterpolationConfidence.HIGH
+    span = x_max - x_min
+    if span == 0:
+        return InterpolationConfidence.LOW
+    if x < x_min:
+        dist = x_min - x
+    else:
+        dist = x - x_max
+    ratio = dist / span
+    if ratio <= 0.2:
+        return InterpolationConfidence.MEDIUM
+    return InterpolationConfidence.LOW
+
+
+class PerformanceInterpolator:
+    """Interpolate performance for untested P:D ratios.
+
+    Fits per-metric models (TTFT P95, TPOT P95, total latency P95, QPS)
+    as functions of prefill_fraction = num_prefill / total_instances.
+
+    Usage:
+        interpolator = PerformanceInterpolator()
+        interpolator.fit(datasets)
+        result = interpolator.predict(
+            target_ratios=[(1, 3), (1, 5), (2, 6)],
+            method=InterpolationMethod.LINEAR,
+        )
+    """
+
+    def __init__(self) -> None:
+        self._points: list[dict[str, Any]] = []
+        self._total_instances: int | None = None
+        self._fitted = False
+
+    @property
+    def fitted(self) -> bool:
+        return self._fitted
+
+    def fit(self, datasets: list[BenchmarkData]) -> None:
+        """Fit the interpolation model from benchmark datasets.
+
+        All datasets must have the same total_instances count.
+        Need at least 2 datasets at different P:D ratios.
+
+        Args:
+            datasets: List of benchmark datasets at different P:D ratios.
+
+        Raises:
+            ValueError: If fewer than 2 datasets or inconsistent total instances.
+        """
+        if len(datasets) < 2:
+            raise ValueError("Need at least 2 benchmark datasets for interpolation.")
+
+        total_set = {d.metadata.total_instances for d in datasets}
+        if len(total_set) > 1:
+            raise ValueError(
+                f"All datasets must have the same total_instances. Got: {sorted(total_set)}"
+            )
+
+        self._total_instances = datasets[0].metadata.total_instances
+        self._points = []
+
+        for ds in datasets:
+            meta = ds.metadata
+            frac = meta.num_prefill_instances / meta.total_instances
+            ttfts = [r.ttft_ms for r in ds.requests]
+            tpots = [r.tpot_ms for r in ds.requests]
+            totals = [r.total_latency_ms for r in ds.requests]
+
+            self._points.append(
+                {
+                    "prefill_fraction": frac,
+                    "num_prefill": meta.num_prefill_instances,
+                    "num_decode": meta.num_decode_instances,
+                    "ttft_p95": _compute_percentile(ttfts, 95),
+                    "tpot_p95": _compute_percentile(tpots, 95),
+                    "total_latency_p95": _compute_percentile(totals, 95),
+                    "qps": meta.measured_qps,
+                }
+            )
+
+        # Sort by prefill fraction for interpolation
+        self._points.sort(key=lambda p: p["prefill_fraction"])
+
+        # Deduplicate by fraction (take last if duplicates)
+        seen: dict[float, int] = {}
+        for i, pt in enumerate(self._points):
+            seen[pt["prefill_fraction"]] = i
+        self._points = [self._points[i] for i in sorted(seen.values())]
+
+        if len(self._points) < 2:
+            raise ValueError(
+                "Need at least 2 datasets at different P:D ratios after deduplication."
+            )
+
+        self._fitted = True
+
+    def predict(
+        self,
+        target_ratios: list[tuple[int, int]],
+        method: InterpolationMethod = InterpolationMethod.LINEAR,
+    ) -> InterpolationResult:
+        """Predict performance at target P:D ratios.
+
+        Args:
+            target_ratios: List of (num_prefill, num_decode) tuples to predict.
+            method: Interpolation method (linear or spline).
+
+        Returns:
+            InterpolationResult with predictions for each requested ratio.
+
+        Raises:
+            RuntimeError: If fit() has not been called.
+            ValueError: If target ratios have inconsistent total instances.
+        """
+        if not self._fitted:
+            raise RuntimeError("Call fit() before predict().")
+
+        assert self._total_instances is not None
+
+        # Validate target ratios
+        for p, d in target_ratios:
+            if p + d != self._total_instances:
+                raise ValueError(
+                    f"Ratio ({p}, {d}) has total {p + d}, "
+                    f"but fitted data has total_instances={self._total_instances}."
+                )
+
+        fracs = np.array([pt["prefill_fraction"] for pt in self._points])
+        frac_min, frac_max = float(fracs.min()), float(fracs.max())
+
+        metrics = ["ttft_p95", "tpot_p95", "total_latency_p95", "qps"]
+        metric_arrays = {m: np.array([pt[m] for pt in self._points]) for m in metrics}
+
+        # Build measured fraction set for is_measured check
+        measured_fracs = {pt["prefill_fraction"] for pt in self._points}
+
+        predictions: list[PredictedPerformance] = []
+        notes: list[str] = []
+
+        if method == InterpolationMethod.SPLINE and len(self._points) < 4:
+            notes.append(
+                "Spline requires ≥4 data points; falling back to linear interpolation."
+            )
+            method = InterpolationMethod.LINEAR
+
+        for num_p, num_d in target_ratios:
+            target_frac = num_p / self._total_instances
+            confidence = _classify_confidence(target_frac, frac_min, frac_max)
+            is_measured = target_frac in measured_fracs
+
+            predicted: dict[str, float] = {}
+            for metric_name in metrics:
+                y = metric_arrays[metric_name]
+                predicted[metric_name] = float(
+                    self._interpolate_1d(fracs, y, target_frac, method)
+                )
+
+            # Clamp latencies to >= 0
+            for key in ["ttft_p95", "tpot_p95", "total_latency_p95", "qps"]:
+                if predicted[key] < 0:
+                    predicted[key] = 0.0
+
+            predictions.append(
+                PredictedPerformance(
+                    num_prefill=num_p,
+                    num_decode=num_d,
+                    total_instances=self._total_instances,
+                    prefill_fraction=target_frac,
+                    ttft_p95_ms=predicted["ttft_p95"],
+                    tpot_p95_ms=predicted["tpot_p95"],
+                    total_latency_p95_ms=predicted["total_latency_p95"],
+                    throughput_qps=predicted["qps"],
+                    confidence=confidence,
+                    is_measured=is_measured,
+                )
+            )
+
+        # Find best throughput
+        best = None
+        if predictions:
+            best = max(predictions, key=lambda p: p.throughput_qps)
+
+        return InterpolationResult(
+            method=method,
+            measured_points=len(self._points),
+            total_instances=self._total_instances,
+            predictions=predictions,
+            best_predicted=best,
+            notes=notes,
+        )
+
+    @staticmethod
+    def _interpolate_1d(
+        x: np.ndarray,
+        y: np.ndarray,
+        target: float,
+        method: InterpolationMethod,
+    ) -> float:
+        """Interpolate/extrapolate a single value.
+
+        Args:
+            x: Known x values (sorted).
+            y: Known y values.
+            target: Target x to predict.
+            method: Interpolation method.
+
+        Returns:
+            Predicted y value.
+        """
+        if method == InterpolationMethod.SPLINE and len(x) >= 4:
+            from scipy.interpolate import CubicSpline
+
+            cs = CubicSpline(x, y, extrapolate=True)
+            return float(cs(target))
+        else:
+            # Linear interpolation / extrapolation
+            return float(np.interp(target, x, y))
+
+
+def interpolate_performance(
+    datasets: list[BenchmarkData],
+    target_ratios: list[tuple[int, int]] | None = None,
+    method: InterpolationMethod = InterpolationMethod.LINEAR,
+) -> InterpolationResult:
+    """Programmatic API for performance interpolation.
+
+    Args:
+        datasets: Benchmark datasets at different P:D ratios (same total instances).
+        target_ratios: P:D ratios to predict. If None, predicts all integer ratios.
+        method: Interpolation method.
+
+    Returns:
+        InterpolationResult with predictions.
+    """
+    interpolator = PerformanceInterpolator()
+    interpolator.fit(datasets)
+
+    total = datasets[0].metadata.total_instances
+    if target_ratios is None:
+        # Generate all possible integer P:D ratios
+        target_ratios = [(p, total - p) for p in range(1, total)]
+
+    return interpolator.predict(target_ratios, method=method)

--- a/tests/test_interpolator.py
+++ b/tests/test_interpolator.py
@@ -1,0 +1,289 @@
+"""Tests for the performance interpolation module."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.interpolator import (
+    InterpolationConfidence,
+    InterpolationMethod,
+    InterpolationResult,
+    PerformanceInterpolator,
+    PredictedPerformance,
+    _classify_confidence,
+    interpolate_performance,
+)
+
+
+def _make_dataset(
+    num_prefill: int,
+    num_decode: int,
+    qps: float,
+    ttft_base: float = 50.0,
+    tpot_base: float = 10.0,
+    n_requests: int = 100,
+) -> BenchmarkData:
+    """Create a synthetic benchmark dataset."""
+    total = num_prefill + num_decode
+    rng = np.random.RandomState(num_prefill * 100 + num_decode)
+    requests = []
+    for i in range(n_requests):
+        ttft = ttft_base + rng.exponential(ttft_base * 0.3)
+        tpot = tpot_base + rng.exponential(tpot_base * 0.2)
+        output_tokens = rng.randint(10, 200)
+        total_lat = ttft + tpot * output_tokens
+        requests.append(
+            BenchmarkRequest(
+                request_id=f"req-{i}",
+                prompt_tokens=rng.randint(50, 500),
+                output_tokens=output_tokens,
+                ttft_ms=ttft,
+                tpot_ms=tpot,
+                total_latency_ms=total_lat,
+                timestamp=1700000000.0 + i,
+            )
+        )
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=num_prefill,
+            num_decode_instances=num_decode,
+            total_instances=total,
+            measured_qps=qps,
+        ),
+        requests=requests,
+    )
+
+
+# --- PerformanceInterpolator tests ---
+
+
+class TestPerformanceInterpolator:
+    def test_fit_requires_at_least_2_datasets(self):
+        interp = PerformanceInterpolator()
+        ds = _make_dataset(2, 6, qps=100)
+        with pytest.raises(ValueError, match="at least 2"):
+            interp.fit([ds])
+
+    def test_fit_requires_same_total_instances(self):
+        interp = PerformanceInterpolator()
+        ds1 = _make_dataset(2, 6, qps=100)  # total=8
+        ds2 = _make_dataset(3, 7, qps=120)  # total=10
+        with pytest.raises(ValueError, match="same total_instances"):
+            interp.fit([ds1, ds2])
+
+    def test_fit_and_predict_basic(self):
+        interp = PerformanceInterpolator()
+        ds1 = _make_dataset(2, 6, qps=100)
+        ds2 = _make_dataset(4, 4, qps=80)
+        interp.fit([ds1, ds2])
+        assert interp.fitted
+
+        result = interp.predict([(3, 5)], method=InterpolationMethod.LINEAR)
+        assert isinstance(result, InterpolationResult)
+        assert len(result.predictions) == 1
+        pred = result.predictions[0]
+        assert pred.num_prefill == 3
+        assert pred.num_decode == 5
+        assert pred.confidence == InterpolationConfidence.HIGH
+        assert pred.ttft_p95_ms > 0
+        assert pred.tpot_p95_ms > 0
+        assert pred.throughput_qps > 0
+
+    def test_predict_before_fit_raises(self):
+        interp = PerformanceInterpolator()
+        with pytest.raises(RuntimeError, match="Call fit"):
+            interp.predict([(3, 5)])
+
+    def test_predict_wrong_total_raises(self):
+        interp = PerformanceInterpolator()
+        interp.fit([_make_dataset(2, 6, qps=100), _make_dataset(4, 4, qps=80)])
+        with pytest.raises(ValueError, match="total"):
+            interp.predict([(3, 3)])  # total=6, expected 8
+
+    def test_measured_point_is_marked(self):
+        interp = PerformanceInterpolator()
+        interp.fit([_make_dataset(2, 6, qps=100), _make_dataset(4, 4, qps=80)])
+        result = interp.predict([(2, 6), (3, 5)])
+        assert result.predictions[0].is_measured is True
+        assert result.predictions[1].is_measured is False
+
+    def test_extrapolation_confidence_medium(self):
+        interp = PerformanceInterpolator()
+        # fractions: 2/8=0.25, 4/8=0.5
+        interp.fit([_make_dataset(2, 6, qps=100), _make_dataset(4, 4, qps=80)])
+        # 5/8=0.625, range is 0.25..0.5, span=0.25, dist=0.125, ratio=0.5 => LOW
+        # 1/8=0.125, dist from 0.25 = 0.125, ratio=0.5 => LOW
+        # Actually for MEDIUM need ≤20%: dist/span ≤ 0.2
+        # With range 0.25..0.5, span=0.25, need dist ≤ 0.05
+        # That's fraction 0.20..0.25 or 0.50..0.55 — not integer ratios on 8 total
+        # Let's use more data points to get a wider range
+        pass  # Tested via _classify_confidence directly below
+
+    def test_extrapolation_confidence_low(self):
+        interp = PerformanceInterpolator()
+        interp.fit([_make_dataset(3, 5, qps=100), _make_dataset(4, 4, qps=80)])
+        # range: 3/8=0.375 .. 4/8=0.5, span=0.125
+        # 1/8=0.125 => dist=0.25, ratio=2.0 => LOW
+        result = interp.predict([(1, 7)])
+        assert result.predictions[0].confidence == InterpolationConfidence.LOW
+
+    def test_multiple_predictions(self):
+        interp = PerformanceInterpolator()
+        interp.fit([_make_dataset(1, 7, qps=120), _make_dataset(4, 4, qps=80)])
+        result = interp.predict([(2, 6), (3, 5)])
+        assert len(result.predictions) == 2
+        assert result.best_predicted is not None
+
+    def test_best_predicted_highest_throughput(self):
+        interp = PerformanceInterpolator()
+        interp.fit([_make_dataset(1, 7, qps=120), _make_dataset(4, 4, qps=80)])
+        result = interp.predict([(1, 7), (2, 6), (3, 5), (4, 4)])
+        # Best should be highest QPS
+        qps_values = [p.throughput_qps for p in result.predictions]
+        assert result.best_predicted is not None
+        assert result.best_predicted.throughput_qps == max(qps_values)
+
+    def test_spline_fallback_with_few_points(self):
+        interp = PerformanceInterpolator()
+        interp.fit([_make_dataset(2, 6, qps=100), _make_dataset(4, 4, qps=80)])
+        result = interp.predict([(3, 5)], method=InterpolationMethod.SPLINE)
+        # Should fall back to linear and note it
+        assert result.method == InterpolationMethod.LINEAR
+        assert any("fallback" in n.lower() or "spline" in n.lower() for n in result.notes)
+
+    def test_spline_with_enough_points(self):
+        interp = PerformanceInterpolator()
+        datasets = [
+            _make_dataset(1, 7, qps=120),
+            _make_dataset(2, 6, qps=110),
+            _make_dataset(3, 5, qps=95),
+            _make_dataset(4, 4, qps=80),
+        ]
+        interp.fit(datasets)
+        result = interp.predict([(1, 7), (2, 6)], method=InterpolationMethod.SPLINE)
+        assert result.method == InterpolationMethod.SPLINE
+        assert len(result.predictions) == 2
+
+    def test_latencies_clamped_nonnegative(self):
+        """Even with extrapolation, latencies should not go negative."""
+        interp = PerformanceInterpolator()
+        interp.fit([_make_dataset(3, 5, qps=100), _make_dataset(4, 4, qps=80)])
+        # Extreme extrapolation
+        result = interp.predict([(1, 7)])
+        for pred in result.predictions:
+            assert pred.ttft_p95_ms >= 0
+            assert pred.tpot_p95_ms >= 0
+            assert pred.total_latency_p95_ms >= 0
+            assert pred.throughput_qps >= 0
+
+    def test_duplicate_fraction_deduplication(self):
+        """Two datasets with same P:D ratio should be deduplicated."""
+        interp = PerformanceInterpolator()
+        ds1 = _make_dataset(2, 6, qps=100)
+        ds2 = _make_dataset(2, 6, qps=110)  # Same ratio, different QPS
+        ds3 = _make_dataset(4, 4, qps=80)
+        interp.fit([ds1, ds2, ds3])
+        assert interp.fitted
+
+    def test_predict_all_integer_ratios(self):
+        interp = PerformanceInterpolator()
+        interp.fit([_make_dataset(2, 6, qps=100), _make_dataset(6, 2, qps=80)])
+        # Predict all 7 possible ratios for total=8
+        ratios = [(p, 8 - p) for p in range(1, 8)]
+        result = interp.predict(ratios)
+        assert len(result.predictions) == 7
+
+
+# --- _classify_confidence tests ---
+
+
+class TestClassifyConfidence:
+    def test_within_range(self):
+        assert _classify_confidence(0.5, 0.25, 0.75) == InterpolationConfidence.HIGH
+
+    def test_at_boundary(self):
+        assert _classify_confidence(0.25, 0.25, 0.75) == InterpolationConfidence.HIGH
+        assert _classify_confidence(0.75, 0.25, 0.75) == InterpolationConfidence.HIGH
+
+    def test_near_extrapolation(self):
+        # span=0.5, 20% of span=0.1
+        assert _classify_confidence(0.15, 0.25, 0.75) == InterpolationConfidence.MEDIUM
+        assert _classify_confidence(0.85, 0.25, 0.75) == InterpolationConfidence.MEDIUM
+
+    def test_far_extrapolation(self):
+        # span=0.5, >20% of span => >0.1 distance
+        assert _classify_confidence(0.0, 0.25, 0.75) == InterpolationConfidence.LOW
+        assert _classify_confidence(1.0, 0.25, 0.75) == InterpolationConfidence.LOW
+
+    def test_zero_span(self):
+        # All same x -> LOW for any different point
+        assert _classify_confidence(0.5, 0.3, 0.3) == InterpolationConfidence.LOW
+
+
+# --- interpolate_performance API tests ---
+
+
+class TestInterpolatePerformance:
+    def test_basic_api(self):
+        datasets = [_make_dataset(2, 6, qps=100), _make_dataset(4, 4, qps=80)]
+        result = interpolate_performance(datasets, target_ratios=[(3, 5)])
+        assert isinstance(result, InterpolationResult)
+        assert len(result.predictions) == 1
+        assert result.measured_points == 2
+
+    def test_auto_generate_all_ratios(self):
+        datasets = [_make_dataset(2, 6, qps=100), _make_dataset(4, 4, qps=80)]
+        result = interpolate_performance(datasets, target_ratios=None)
+        # total=8, should generate 1:7 through 7:1 = 7 ratios
+        assert len(result.predictions) == 7
+
+    def test_with_spline(self):
+        datasets = [
+            _make_dataset(1, 7, qps=120),
+            _make_dataset(2, 6, qps=110),
+            _make_dataset(3, 5, qps=95),
+            _make_dataset(4, 4, qps=80),
+        ]
+        result = interpolate_performance(
+            datasets,
+            target_ratios=[(2, 6), (3, 5)],
+            method=InterpolationMethod.SPLINE,
+        )
+        assert result.method == InterpolationMethod.SPLINE
+        assert len(result.predictions) == 2
+
+
+# --- Pydantic model tests ---
+
+
+class TestModels:
+    def test_predicted_performance_serialization(self):
+        pred = PredictedPerformance(
+            num_prefill=2,
+            num_decode=6,
+            total_instances=8,
+            prefill_fraction=0.25,
+            ttft_p95_ms=65.0,
+            tpot_p95_ms=12.0,
+            total_latency_p95_ms=300.0,
+            throughput_qps=100.0,
+            confidence=InterpolationConfidence.HIGH,
+            is_measured=True,
+        )
+        data = pred.model_dump()
+        assert data["confidence"] == "high"
+        assert data["is_measured"] is True
+
+    def test_interpolation_result_serialization(self):
+        result = InterpolationResult(
+            method=InterpolationMethod.LINEAR,
+            measured_points=3,
+            total_instances=8,
+            predictions=[],
+            notes=["test note"],
+        )
+        data = result.model_dump()
+        assert data["method"] == "linear"
+        assert data["notes"] == ["test note"]


### PR DESCRIPTION
## Summary

Add performance interpolation model that predicts latency and throughput at untested P:D ratios, fulfilling DESIGN_PRINCIPLES.md methodology steps 3-4:
> 3. Analyze data, fit/interpolate, build performance model
> 4. Extrapolate predicted performance for all possible P:D ratios

## Changes

- **`PerformanceInterpolator`** class in `interpolator.py`: fits per-metric models from benchmark data at different P:D ratios, predicts performance at untested ratios
- **Linear & cubic spline** interpolation methods (spline requires ≥4 data points, falls back to linear)
- **Confidence classification**: HIGH (interpolation), MEDIUM (≤20% extrapolation), LOW (far extrapolation)
- **`PredictedPerformance`** and **`InterpolationResult`** Pydantic models
- **CLI `interpolate` subcommand**: `--benchmark` (multiple files), `--method linear|spline`, `--ratios`, `--output-format table|json`
- **Programmatic API**: `interpolate_performance()`
- **scipy** added as dependency for spline interpolation
- **25 new tests** (410 total, all passing)
- Updated ROADMAP.md with M18

## Test Results
- 410 tests passing
- Lint clean: `ruff check src tests && isort --check src tests`

Closes #44