### PR TITLE
feat: M20 Benchmark Annotation & Tagging system

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -235,9 +235,9 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - scipy dependency for spline interpolation
 - 25 new tests (410 total)
 
-### M19 ⏳ Alert Rules Engine
+### M19 ✅ Alert Rules Engine
 
-*In progress — PR #47*
+*Completed — PR #47*
 
 - `AlertEngine` class in `alerting.py`
 - `AlertRule`, `AlertResult`, `AlertReport`, `AlertSeverity`, `Comparator` Pydantic models
@@ -247,3 +247,15 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Non-zero exit code on critical alerts (CI/CD pipeline friendly)
 - Programmatic `evaluate_alerts()` API
 - 20 new tests (430 total)
+
+### M20 ⏳ Benchmark Annotation & Tagging
+
+*In progress — PR #TBD*
+
+- `AnnotationManager` class in `annotation.py`
+- `Annotation`, `AnnotatedBenchmark`, `FilterResult` Pydantic models
+- Sidecar `.tags.yaml` files (non-destructive, preserves original benchmark JSON)
+- Add, remove, clear, list, and filter tags on benchmark files
+- CLI `annotate` subcommand: `add`, `list`, `remove`, `filter`, `clear`
+- Programmatic `annotate_benchmark()` API
+- 26 new tests (456 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -12,6 +12,13 @@ from xpyd_plan.alerting import (
     evaluate_alerts,
 )
 from xpyd_plan.analyzer import BenchmarkAnalyzer
+from xpyd_plan.annotation import (
+    AnnotatedBenchmark,
+    Annotation,
+    AnnotationManager,
+    FilterResult,
+    annotate_benchmark,
+)
 from xpyd_plan.benchmark_models import (
     AnalysisResult,
     BenchmarkData,
@@ -59,6 +66,11 @@ from xpyd_plan.validator import (
 )
 
 __all__ = [
+    "AnnotatedBenchmark",
+    "Annotation",
+    "AnnotationManager",
+    "FilterResult",
+    "annotate_benchmark",
     "AlertEngine",
     "AlertReport",
     "AlertResult",

--- a/src/xpyd_plan/annotation.py
+++ b/src/xpyd_plan/annotation.py
@@ -1,0 +1,234 @@
+"""Benchmark annotation and tagging system.
+
+Attach structured key-value metadata to benchmark files using sidecar
+.tags.yaml files. Supports filtering and grouping benchmarks by tags.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+class Annotation(BaseModel):
+    """A set of key-value tags for a benchmark file."""
+
+    benchmark_path: str = Field(..., description="Path to the benchmark file")
+    tags: dict[str, str] = Field(default_factory=dict, description="Key-value tag pairs")
+
+    @property
+    def tags_path(self) -> Path:
+        """Sidecar file path for storing tags."""
+        p = Path(self.benchmark_path)
+        return p.parent / f"{p.stem}.tags.yaml"
+
+
+class AnnotatedBenchmark(BaseModel):
+    """A benchmark file with its associated annotations."""
+
+    benchmark_path: str
+    tags: dict[str, str] = Field(default_factory=dict)
+    exists: bool = True
+
+
+class FilterResult(BaseModel):
+    """Result of filtering benchmarks by tags."""
+
+    query_tags: dict[str, str]
+    matched: list[AnnotatedBenchmark] = Field(default_factory=list)
+    total_scanned: int = 0
+
+
+class AnnotationManager:
+    """Manage tags on benchmark files via sidecar .tags.yaml files."""
+
+    @staticmethod
+    def _sidecar_path(benchmark_path: str | Path) -> Path:
+        """Get the sidecar tags file path for a benchmark."""
+        p = Path(benchmark_path)
+        return p.parent / f"{p.stem}.tags.yaml"
+
+    def add_tags(self, benchmark_path: str | Path, tags: dict[str, str]) -> Annotation:
+        """Add or update tags on a benchmark file.
+
+        Args:
+            benchmark_path: Path to the benchmark JSON file.
+            tags: Key-value pairs to add/update.
+
+        Returns:
+            Updated Annotation with all current tags.
+
+        Raises:
+            FileNotFoundError: If the benchmark file doesn't exist.
+        """
+        bp = Path(benchmark_path)
+        if not bp.exists():
+            msg = f"Benchmark file not found: {bp}"
+            raise FileNotFoundError(msg)
+
+        existing = self.get_tags(benchmark_path)
+        existing.tags.update(tags)
+        self._save(existing)
+        return existing
+
+    def remove_tags(self, benchmark_path: str | Path, keys: list[str]) -> Annotation:
+        """Remove specific tag keys from a benchmark.
+
+        Args:
+            benchmark_path: Path to the benchmark JSON file.
+            keys: Tag keys to remove.
+
+        Returns:
+            Updated Annotation after removal.
+
+        Raises:
+            FileNotFoundError: If the benchmark file doesn't exist.
+        """
+        bp = Path(benchmark_path)
+        if not bp.exists():
+            msg = f"Benchmark file not found: {bp}"
+            raise FileNotFoundError(msg)
+
+        annotation = self.get_tags(benchmark_path)
+        for key in keys:
+            annotation.tags.pop(key, None)
+        self._save(annotation)
+        return annotation
+
+    def get_tags(self, benchmark_path: str | Path) -> Annotation:
+        """Get all tags for a benchmark file.
+
+        Args:
+            benchmark_path: Path to the benchmark JSON file.
+
+        Returns:
+            Annotation with current tags (empty if no sidecar exists).
+        """
+        bp = Path(benchmark_path)
+        sidecar = self._sidecar_path(bp)
+        tags: dict[str, str] = {}
+        if sidecar.exists():
+            with open(sidecar) as f:
+                data = yaml.safe_load(f)
+                if isinstance(data, dict) and "tags" in data:
+                    tags = {str(k): str(v) for k, v in data["tags"].items()}
+        return Annotation(benchmark_path=str(bp), tags=tags)
+
+    def clear_tags(self, benchmark_path: str | Path) -> Annotation:
+        """Remove all tags from a benchmark file.
+
+        Args:
+            benchmark_path: Path to the benchmark JSON file.
+
+        Returns:
+            Empty Annotation.
+        """
+        bp = Path(benchmark_path)
+        sidecar = self._sidecar_path(bp)
+        if sidecar.exists():
+            sidecar.unlink()
+        return Annotation(benchmark_path=str(bp), tags={})
+
+    def filter_by_tags(
+        self,
+        directory: str | Path,
+        tags: dict[str, str],
+        pattern: str = "*.json",
+    ) -> FilterResult:
+        """Find benchmark files matching all specified tags.
+
+        Args:
+            directory: Directory to scan for benchmark files.
+            tags: Required key-value pairs (all must match).
+            pattern: Glob pattern for benchmark files.
+
+        Returns:
+            FilterResult with matched benchmarks.
+        """
+        dirp = Path(directory)
+        matched: list[AnnotatedBenchmark] = []
+        scanned = 0
+
+        for bp in sorted(dirp.glob(pattern)):
+            if bp.name.endswith(".tags.yaml"):
+                continue
+            scanned += 1
+            annotation = self.get_tags(bp)
+            if all(annotation.tags.get(k) == v for k, v in tags.items()):
+                matched.append(
+                    AnnotatedBenchmark(
+                        benchmark_path=str(bp),
+                        tags=annotation.tags,
+                    )
+                )
+
+        return FilterResult(query_tags=tags, matched=matched, total_scanned=scanned)
+
+    def list_all_tags(
+        self,
+        directory: str | Path,
+        pattern: str = "*.json",
+    ) -> list[AnnotatedBenchmark]:
+        """List all benchmark files with their tags in a directory.
+
+        Args:
+            directory: Directory to scan.
+            pattern: Glob pattern for benchmark files.
+
+        Returns:
+            List of AnnotatedBenchmark for each file found.
+        """
+        dirp = Path(directory)
+        results: list[AnnotatedBenchmark] = []
+
+        for bp in sorted(dirp.glob(pattern)):
+            if bp.name.endswith(".tags.yaml"):
+                continue
+            annotation = self.get_tags(bp)
+            results.append(
+                AnnotatedBenchmark(
+                    benchmark_path=str(bp),
+                    tags=annotation.tags,
+                )
+            )
+
+        return results
+
+    def _save(self, annotation: Annotation) -> None:
+        """Save annotation to sidecar file."""
+        sidecar = self._sidecar_path(annotation.benchmark_path)
+        if not annotation.tags:
+            if sidecar.exists():
+                sidecar.unlink()
+            return
+        with open(sidecar, "w") as f:
+            yaml.dump({"tags": annotation.tags}, f, default_flow_style=False, sort_keys=True)
+
+
+def annotate_benchmark(
+    benchmark_path: str | Path,
+    tags: Optional[dict[str, str]] = None,
+    remove_keys: Optional[list[str]] = None,
+) -> Annotation:
+    """Programmatic API: add/remove tags on a benchmark file.
+
+    Args:
+        benchmark_path: Path to the benchmark JSON file.
+        tags: Key-value pairs to add (optional).
+        remove_keys: Tag keys to remove (optional).
+
+    Returns:
+        Updated Annotation.
+    """
+    manager = AnnotationManager()
+
+    if remove_keys:
+        manager.remove_tags(benchmark_path, remove_keys)
+
+    if tags:
+        return manager.add_tags(benchmark_path, tags)
+
+    return manager.get_tags(benchmark_path)

--- a/src/xpyd_plan/cli.py
+++ b/src/xpyd_plan/cli.py
@@ -1069,6 +1069,99 @@ def _cmd_alert(args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
+def _parse_tags(tag_list: list[str]) -> dict[str, str]:
+    """Parse KEY=VALUE tag arguments into a dict."""
+    tags: dict[str, str] = {}
+    for item in tag_list:
+        if "=" not in item:
+            Console().print(f"[red]Invalid tag format: {item} (expected KEY=VALUE)[/red]")
+            sys.exit(1)
+        key, value = item.split("=", 1)
+        tags[key.strip()] = value.strip()
+    return tags
+
+
+def _cmd_annotate(args: argparse.Namespace) -> None:
+    """Handle annotate subcommand."""
+    from xpyd_plan.annotation import AnnotationManager
+
+    manager = AnnotationManager()
+    console = Console()
+
+    if args.annotate_action == "add":
+        tags = _parse_tags(args.tag)
+        result = manager.add_tags(args.benchmark, tags)
+        console.print(f"[green]Added {len(tags)} tag(s) to {args.benchmark}[/green]")
+        for k, v in sorted(result.tags.items()):
+            console.print(f"  {k} = {v}")
+
+    elif args.annotate_action == "remove":
+        result = manager.remove_tags(args.benchmark, args.key)
+        console.print(f"[green]Removed tag(s) from {args.benchmark}[/green]")
+        if result.tags:
+            for k, v in sorted(result.tags.items()):
+                console.print(f"  {k} = {v}")
+        else:
+            console.print("  (no tags remaining)")
+
+    elif args.annotate_action == "clear":
+        manager.clear_tags(args.benchmark)
+        console.print(f"[green]Cleared all tags from {args.benchmark}[/green]")
+
+    elif args.annotate_action == "list":
+        result = manager.get_tags(args.benchmark)
+        if getattr(args, "output_format", "table") == "json":
+            import json as json_mod
+
+            console.print(json_mod.dumps({"tags": result.tags}, indent=2))
+        elif result.tags:
+            table = Table(title=f"Tags: {args.benchmark}")
+            table.add_column("Key", style="cyan")
+            table.add_column("Value", style="green")
+            for k, v in sorted(result.tags.items()):
+                table.add_row(k, v)
+            console.print(table)
+        else:
+            console.print(f"No tags on {args.benchmark}")
+
+    elif args.annotate_action == "filter":
+        tags = _parse_tags(args.tag)
+        result = manager.filter_by_tags(args.dir, tags)
+        if getattr(args, "output_format", "table") == "json":
+            import json as json_mod
+
+            console.print(
+                json_mod.dumps(
+                    {
+                        "query_tags": result.query_tags,
+                        "matched": [
+                            {"path": m.benchmark_path, "tags": m.tags}
+                            for m in result.matched
+                        ],
+                        "total_scanned": result.total_scanned,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            console.print(
+                f"Scanned {result.total_scanned} file(s), "
+                f"{len(result.matched)} matched"
+            )
+            if result.matched:
+                table = Table(title="Matching Benchmarks")
+                table.add_column("File", style="cyan")
+                table.add_column("Tags", style="green")
+                for m in result.matched:
+                    tag_str = ", ".join(f"{k}={v}" for k, v in sorted(m.tags.items()))
+                    table.add_row(m.benchmark_path, tag_str)
+                console.print(table)
+
+    else:
+        console.print("[red]Usage: xpyd-plan annotate {add|list|remove|filter|clear}[/red]")
+        sys.exit(1)
+
+
 def main(argv: list[str] | None = None) -> None:
     """Entry point for `xpyd-plan` command."""
     parser = argparse.ArgumentParser(
@@ -1424,6 +1517,46 @@ def main(argv: list[str] | None = None) -> None:
         help="Output format (default: table)",
     )
 
+    # -- annotate subcommand --
+    annotate_parser = subparsers.add_parser(
+        "annotate", help="Manage benchmark annotations and tags",
+    )
+    annotate_sub = annotate_parser.add_subparsers(dest="annotate_action", help="Annotation actions")
+
+    ann_add = annotate_sub.add_parser("add", help="Add tags to a benchmark file")
+    ann_add.add_argument("--benchmark", required=True, help="Path to benchmark JSON file")
+    ann_add.add_argument(
+        "--tag", action="append", required=True, metavar="KEY=VALUE",
+        help="Tag to add (can be repeated)",
+    )
+
+    ann_list = annotate_sub.add_parser("list", help="List tags on a benchmark file")
+    ann_list.add_argument("--benchmark", required=True, help="Path to benchmark JSON file")
+    ann_list.add_argument(
+        "--output-format", choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
+
+    ann_remove = annotate_sub.add_parser("remove", help="Remove tags from a benchmark file")
+    ann_remove.add_argument("--benchmark", required=True, help="Path to benchmark JSON file")
+    ann_remove.add_argument(
+        "--key", action="append", required=True, help="Tag key to remove (can be repeated)",
+    )
+
+    ann_filter = annotate_sub.add_parser("filter", help="Filter benchmarks by tags")
+    ann_filter.add_argument("--dir", required=True, help="Directory to scan")
+    ann_filter.add_argument(
+        "--tag", action="append", required=True, metavar="KEY=VALUE",
+        help="Required tag (can be repeated, all must match)",
+    )
+    ann_filter.add_argument(
+        "--output-format", choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
+
+    ann_clear = annotate_sub.add_parser("clear", help="Remove all tags from a benchmark file")
+    ann_clear.add_argument("--benchmark", required=True, help="Path to benchmark JSON file")
+
     args = parser.parse_args(argv)
 
     if args.command == "config":
@@ -1452,6 +1585,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_interpolate(args)
     elif args.command == "alert":
         _cmd_alert(args)
+    elif args.command == "annotate":
+        _cmd_annotate(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -1,0 +1,207 @@
+"""Tests for benchmark annotation and tagging system."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from xpyd_plan.annotation import (
+    AnnotatedBenchmark,
+    Annotation,
+    AnnotationManager,
+    FilterResult,
+    annotate_benchmark,
+)
+
+
+@pytest.fixture()
+def bench_dir(tmp_path: Path) -> Path:
+    """Create a directory with sample benchmark files."""
+    for i in range(3):
+        p = tmp_path / f"bench_{i}.json"
+        p.write_text(json.dumps({"id": i}))
+    return tmp_path
+
+
+@pytest.fixture()
+def bench_file(bench_dir: Path) -> Path:
+    """Return path to first benchmark file."""
+    return bench_dir / "bench_0.json"
+
+
+class TestAnnotation:
+    """Test Annotation model."""
+
+    def test_tags_path(self) -> None:
+        a = Annotation(benchmark_path="/data/bench.json", tags={"model": "llama"})
+        assert a.tags_path == Path("/data/bench.tags.yaml")
+
+    def test_tags_path_nested(self) -> None:
+        a = Annotation(benchmark_path="/data/sub/run.json", tags={})
+        assert a.tags_path == Path("/data/sub/run.tags.yaml")
+
+    def test_empty_tags(self) -> None:
+        a = Annotation(benchmark_path="test.json")
+        assert a.tags == {}
+
+
+class TestAnnotationManager:
+    """Test AnnotationManager operations."""
+
+    def test_add_tags(self, bench_file: Path) -> None:
+        mgr = AnnotationManager()
+        result = mgr.add_tags(bench_file, {"model": "llama3-70b", "gpu": "H100"})
+        assert result.tags == {"model": "llama3-70b", "gpu": "H100"}
+        # Verify sidecar exists
+        sidecar = bench_file.parent / "bench_0.tags.yaml"
+        assert sidecar.exists()
+
+    def test_add_tags_file_not_found(self, tmp_path: Path) -> None:
+        mgr = AnnotationManager()
+        with pytest.raises(FileNotFoundError):
+            mgr.add_tags(tmp_path / "nonexistent.json", {"key": "val"})
+
+    def test_add_tags_merge(self, bench_file: Path) -> None:
+        mgr = AnnotationManager()
+        mgr.add_tags(bench_file, {"model": "llama"})
+        result = mgr.add_tags(bench_file, {"gpu": "H100"})
+        assert result.tags == {"model": "llama", "gpu": "H100"}
+
+    def test_add_tags_overwrite(self, bench_file: Path) -> None:
+        mgr = AnnotationManager()
+        mgr.add_tags(bench_file, {"model": "llama"})
+        result = mgr.add_tags(bench_file, {"model": "mistral"})
+        assert result.tags["model"] == "mistral"
+
+    def test_get_tags_no_sidecar(self, bench_file: Path) -> None:
+        mgr = AnnotationManager()
+        result = mgr.get_tags(bench_file)
+        assert result.tags == {}
+
+    def test_get_tags_with_sidecar(self, bench_file: Path) -> None:
+        mgr = AnnotationManager()
+        mgr.add_tags(bench_file, {"env": "prod"})
+        result = mgr.get_tags(bench_file)
+        assert result.tags == {"env": "prod"}
+
+    def test_remove_tags(self, bench_file: Path) -> None:
+        mgr = AnnotationManager()
+        mgr.add_tags(bench_file, {"a": "1", "b": "2", "c": "3"})
+        result = mgr.remove_tags(bench_file, ["b"])
+        assert result.tags == {"a": "1", "c": "3"}
+
+    def test_remove_tags_nonexistent_key(self, bench_file: Path) -> None:
+        mgr = AnnotationManager()
+        mgr.add_tags(bench_file, {"a": "1"})
+        result = mgr.remove_tags(bench_file, ["z"])
+        assert result.tags == {"a": "1"}
+
+    def test_remove_tags_file_not_found(self, tmp_path: Path) -> None:
+        mgr = AnnotationManager()
+        with pytest.raises(FileNotFoundError):
+            mgr.remove_tags(tmp_path / "nope.json", ["key"])
+
+    def test_clear_tags(self, bench_file: Path) -> None:
+        mgr = AnnotationManager()
+        mgr.add_tags(bench_file, {"a": "1"})
+        sidecar = bench_file.parent / "bench_0.tags.yaml"
+        assert sidecar.exists()
+        result = mgr.clear_tags(bench_file)
+        assert result.tags == {}
+        assert not sidecar.exists()
+
+    def test_clear_tags_no_sidecar(self, bench_file: Path) -> None:
+        mgr = AnnotationManager()
+        result = mgr.clear_tags(bench_file)
+        assert result.tags == {}
+
+    def test_filter_by_tags_match(self, bench_dir: Path) -> None:
+        mgr = AnnotationManager()
+        mgr.add_tags(bench_dir / "bench_0.json", {"model": "llama", "gpu": "H100"})
+        mgr.add_tags(bench_dir / "bench_1.json", {"model": "llama", "gpu": "A100"})
+        mgr.add_tags(bench_dir / "bench_2.json", {"model": "mistral", "gpu": "H100"})
+
+        result = mgr.filter_by_tags(bench_dir, {"model": "llama"})
+        assert len(result.matched) == 2
+        assert result.total_scanned == 3
+
+    def test_filter_by_tags_multi_match(self, bench_dir: Path) -> None:
+        mgr = AnnotationManager()
+        mgr.add_tags(bench_dir / "bench_0.json", {"model": "llama", "gpu": "H100"})
+        mgr.add_tags(bench_dir / "bench_1.json", {"model": "llama", "gpu": "A100"})
+
+        result = mgr.filter_by_tags(bench_dir, {"model": "llama", "gpu": "H100"})
+        assert len(result.matched) == 1
+
+    def test_filter_by_tags_no_match(self, bench_dir: Path) -> None:
+        mgr = AnnotationManager()
+        result = mgr.filter_by_tags(bench_dir, {"model": "gpt4"})
+        assert len(result.matched) == 0
+        assert result.total_scanned == 3
+
+    def test_list_all_tags(self, bench_dir: Path) -> None:
+        mgr = AnnotationManager()
+        mgr.add_tags(bench_dir / "bench_0.json", {"env": "prod"})
+        results = mgr.list_all_tags(bench_dir)
+        assert len(results) == 3
+        tagged = [r for r in results if r.tags]
+        assert len(tagged) == 1
+
+    def test_sidecar_yaml_format(self, bench_file: Path) -> None:
+        mgr = AnnotationManager()
+        mgr.add_tags(bench_file, {"model": "llama"})
+        sidecar = bench_file.parent / "bench_0.tags.yaml"
+        data = yaml.safe_load(sidecar.read_text())
+        assert data == {"tags": {"model": "llama"}}
+
+    def test_remove_all_tags_cleans_sidecar(self, bench_file: Path) -> None:
+        mgr = AnnotationManager()
+        mgr.add_tags(bench_file, {"a": "1"})
+        sidecar = bench_file.parent / "bench_0.tags.yaml"
+        assert sidecar.exists()
+        mgr.remove_tags(bench_file, ["a"])
+        assert not sidecar.exists()
+
+
+class TestAnnotateBenchmarkAPI:
+    """Test programmatic annotate_benchmark() API."""
+
+    def test_add_tags(self, bench_file: Path) -> None:
+        result = annotate_benchmark(bench_file, tags={"model": "llama"})
+        assert result.tags == {"model": "llama"}
+
+    def test_remove_keys(self, bench_file: Path) -> None:
+        annotate_benchmark(bench_file, tags={"a": "1", "b": "2"})
+        result = annotate_benchmark(bench_file, remove_keys=["a"])
+        assert result.tags == {"b": "2"}
+
+    def test_add_and_remove(self, bench_file: Path) -> None:
+        annotate_benchmark(bench_file, tags={"a": "1", "b": "2"})
+        result = annotate_benchmark(bench_file, tags={"c": "3"}, remove_keys=["a"])
+        assert "a" not in result.tags
+        assert result.tags["c"] == "3"
+
+    def test_get_only(self, bench_file: Path) -> None:
+        result = annotate_benchmark(bench_file)
+        assert result.tags == {}
+
+
+class TestFilterResult:
+    """Test FilterResult model."""
+
+    def test_model_fields(self) -> None:
+        fr = FilterResult(query_tags={"k": "v"}, total_scanned=5)
+        assert fr.matched == []
+        assert fr.total_scanned == 5
+
+
+class TestAnnotatedBenchmark:
+    """Test AnnotatedBenchmark model."""
+
+    def test_defaults(self) -> None:
+        ab = AnnotatedBenchmark(benchmark_path="test.json")
+        assert ab.tags == {}
+        assert ab.exists is True


### PR DESCRIPTION
## Summary

Add a benchmark annotation and tagging system that lets users attach structured key-value metadata to benchmark files using non-destructive sidecar `.tags.yaml` files. Supports filtering and grouping benchmarks by tags.

## Changes

- **`annotation.py`**: `AnnotationManager`, `Annotation`, `AnnotatedBenchmark`, `FilterResult` models, `annotate_benchmark()` API
- **CLI `annotate` subcommand**: `add`, `list`, `remove`, `filter`, `clear` actions with table/JSON output
- **`__init__.py`**: Export all new public types
- **26 new tests** (456 total, all passing)

## Example

```bash
# Add tags
xpyd-plan annotate add --benchmark bench.json --tag model=llama3-70b --tag gpu=H100

# List tags
xpyd-plan annotate list --benchmark bench.json

# Filter by tags
xpyd-plan annotate filter --dir ./benchmarks --tag model=llama3-70b

# Remove tags
xpyd-plan annotate remove --benchmark bench.json --key gpu

# Clear all tags
xpyd-plan annotate clear --benchmark bench.json
```

Closes #48