### PR TITLE
feat(pareto): M21 — Pareto Frontier Analysis

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -259,3 +259,13 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `annotate` subcommand: `add`, `list`, `remove`, `filter`, `clear`
 - Programmatic `annotate_benchmark()` API
 - 26 new tests (456 total)
+
+### M21 — Pareto Frontier Analysis
+
+- `ParetoAnalyzer` class in `pareto.py`
+- `ParetoCandidate`, `ParetoFrontier`, `ParetoObjective` Pydantic models
+- Pareto dominance algorithm: identifies non-dominated P:D ratios across latency, cost, waste
+- Weighted scoring for ranking Pareto-optimal candidates
+- CLI `pareto` subcommand with table and JSON output
+- Programmatic `find_pareto_frontier()` API
+- ~26 new tests (482 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -56,6 +56,13 @@ from xpyd_plan.models import (
     PDConfig,
     SLAConfig,
 )
+from xpyd_plan.pareto import (
+    ParetoAnalyzer,
+    ParetoCandidate,
+    ParetoFrontier,
+    ParetoObjective,
+    find_pareto_frontier,
+)
 from xpyd_plan.trend import TrendEntry, TrendReport, TrendTracker, track_trend
 from xpyd_plan.validator import (
     DataQualityScore,
@@ -91,6 +98,11 @@ __all__ = [
     "DatasetStats",
     "GPUProfile",
     "PDConfig",
+    "ParetoAnalyzer",
+    "ParetoCandidate",
+    "ParetoFrontier",
+    "ParetoObjective",
+    "find_pareto_frontier",
     "RatioCandidate",
     "SLACheck",
     "SLAConfig",

--- a/src/xpyd_plan/cli.py
+++ b/src/xpyd_plan/cli.py
@@ -1162,6 +1162,109 @@ def _cmd_annotate(args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
+def _cmd_pareto(args: argparse.Namespace) -> None:
+    """Handle 'pareto' subcommand."""
+    import json as json_mod
+
+    from xpyd_plan.bench_adapter import load_benchmark_auto
+    from xpyd_plan.pareto import ParetoAnalyzer, ParetoObjective
+
+    console = Console()
+
+    # Load benchmark data
+    data = load_benchmark_auto(args.benchmark[0])
+
+    sla = SLAConfig(
+        ttft_ms=args.sla_ttft,
+        tpot_ms=args.sla_tpot,
+        max_latency_ms=args.sla_max_latency,
+        sla_percentile=args.sla_percentile,
+    )
+    total = args.total_instances or data.metadata.total_instances
+
+    analyzer = BenchmarkAnalyzer(data)
+    analysis = analyzer.find_optimal_ratio(total, sla)
+    measured_qps = data.metadata.measured_qps
+
+    # Cost config
+    cost_config = None
+    if args.cost_model:
+        from xpyd_plan.cost import CostConfig
+
+        cost_config = CostConfig.from_yaml(args.cost_model)
+
+    # Parse objectives
+    objectives = None
+    if args.objectives:
+        objectives = [ParetoObjective(o) for o in args.objectives]
+
+    # Parse weights
+    weights = None
+    if args.weights:
+        weights = {}
+        for pair in args.weights.split(","):
+            k, v = pair.strip().split("=")
+            weights[k.strip()] = float(v.strip())
+
+    pareto_analyzer = ParetoAnalyzer(cost_config=cost_config)
+    frontier = pareto_analyzer.analyze(
+        analysis,
+        measured_qps=measured_qps,
+        objectives=objectives,
+        weights=weights,
+    )
+
+    if args.output_format == "json":
+        console.print(json_mod.dumps(frontier.model_dump(), indent=2))
+        return
+
+    # Table output
+    if not frontier.frontier:
+        console.print("[yellow]No Pareto-optimal candidates found.[/yellow]")
+        return
+
+    count = len(frontier.frontier)
+    console.print(f"\n[bold]🎯 Pareto Frontier ({count} optimal candidates)[/bold]")
+    console.print(f"   Objectives: {', '.join(frontier.objectives_used)}")
+    console.print(f"   Weights: {frontier.weights}")
+
+    table = Table(title="Pareto-Optimal P:D Ratios")
+    table.add_column("Ratio", style="cyan")
+    table.add_column("Latency P95 (ms)", justify="right")
+    if "cost" in frontier.objectives_used:
+        table.add_column("Hourly Cost", justify="right")
+    table.add_column("Waste Rate", justify="right")
+    table.add_column("Score", justify="right", style="green")
+
+    for c in frontier.frontier:
+        row = [
+            c.ratio_str,
+            f"{c.latency_ms:.1f}",
+        ]
+        if "cost" in frontier.objectives_used:
+            row.append(f"{c.hourly_cost:.2f}" if c.hourly_cost is not None else "N/A")
+        row.extend([
+            f"{c.waste_rate:.3f}",
+            f"{c.weighted_score:.4f}" if c.weighted_score is not None else "N/A",
+        ])
+        table.add_row(*row)
+
+    console.print(table)
+
+    if frontier.best_weighted:
+        console.print(
+            f"\n   [bold green]✅ Best weighted:[/bold green] {frontier.best_weighted.ratio_str}"
+            f" (score: {frontier.best_weighted.weighted_score:.4f})"
+        )
+
+    if args.include_dominated and frontier.dominated:
+        console.print(f"\n[dim]Dominated candidates: {len(frontier.dominated)}[/dim]")
+        for c in frontier.dominated:
+            console.print(
+                f"   [dim]{c.ratio_str}  latency={c.latency_ms:.1f}ms"
+                f"  waste={c.waste_rate:.3f}[/dim]"
+            )
+
 def main(argv: list[str] | None = None) -> None:
     """Entry point for `xpyd-plan` command."""
     parser = argparse.ArgumentParser(
@@ -1557,6 +1660,55 @@ def main(argv: list[str] | None = None) -> None:
     ann_clear = annotate_sub.add_parser("clear", help="Remove all tags from a benchmark file")
     ann_clear.add_argument("--benchmark", required=True, help="Path to benchmark JSON file")
 
+    # pareto subcommand
+    pareto_parser = subparsers.add_parser(
+        "pareto",
+        help="Find Pareto-optimal P:D ratios across latency, cost, and waste",
+    )
+    _add_config_flag(pareto_parser)
+    pareto_parser.add_argument(
+        "--benchmark", type=str, nargs="+", required=True,
+        help="Benchmark JSON file(s)",
+    )
+    pareto_parser.add_argument(
+        "--sla-ttft", type=float, default=None, help="SLA: max TTFT P95 (ms)",
+    )
+    pareto_parser.add_argument(
+        "--sla-tpot", type=float, default=None, help="SLA: max TPOT P95 (ms)",
+    )
+    pareto_parser.add_argument(
+        "--sla-max-latency", type=float, default=None, help="SLA: max total latency P95 (ms)",
+    )
+    pareto_parser.add_argument(
+        "--sla-percentile", type=float, default=95.0,
+        help="SLA percentile for evaluation (default: 95.0, range: 1-100)",
+    )
+    pareto_parser.add_argument(
+        "--total-instances", type=int, default=None,
+        help="Total instances to optimize for",
+    )
+    pareto_parser.add_argument(
+        "--cost-model", type=str, default=None,
+        help="YAML file with GPU cost config",
+    )
+    pareto_parser.add_argument(
+        "--objectives", type=str, nargs="+", default=None,
+        choices=["latency", "cost", "waste"],
+        help="Objectives to optimize (default: latency waste; adds cost with --cost-model)",
+    )
+    pareto_parser.add_argument(
+        "--weights", type=str, default=None,
+        help="Objective weights as 'latency=1,cost=2,waste=1'",
+    )
+    pareto_parser.add_argument(
+        "--include-dominated", action="store_true", default=False,
+        help="Also show dominated (non-optimal) candidates",
+    )
+    pareto_parser.add_argument(
+        "--output-format", type=str, choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "config":
@@ -1587,6 +1739,9 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_alert(args)
     elif args.command == "annotate":
         _cmd_annotate(args)
+    elif args.command == "pareto":
+        _apply_config_defaults(args)
+        _cmd_pareto(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/pareto.py
+++ b/src/xpyd_plan/pareto.py
@@ -1,0 +1,284 @@
+"""Pareto frontier analysis for multi-objective P:D ratio optimization.
+
+Identifies non-dominated P:D ratio candidates across latency, cost,
+and utilization waste objectives, enabling informed trade-off decisions.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+from xpyd_plan.benchmark_models import AnalysisResult
+from xpyd_plan.cost import CostAnalyzer, CostConfig
+
+
+class ParetoObjective(str, Enum):
+    """Objectives for Pareto analysis (all minimized)."""
+
+    LATENCY = "latency"
+    COST = "cost"
+    WASTE = "waste"
+
+
+class ParetoCandidate(BaseModel):
+    """A P:D ratio candidate with objective values for Pareto analysis."""
+
+    num_prefill: int = Field(..., ge=1)
+    num_decode: int = Field(..., ge=1)
+    latency_ms: float = Field(..., ge=0, description="P95 total latency (ms)")
+    hourly_cost: float | None = Field(None, ge=0, description="Hourly GPU cost")
+    waste_rate: float = Field(..., ge=0, le=1, description="Utilization waste rate")
+    meets_sla: bool = True
+    is_dominated: bool = Field(False, description="True if dominated by another candidate")
+    weighted_score: float | None = Field(None, description="Weighted score (lower is better)")
+
+    @property
+    def ratio_str(self) -> str:
+        return f"{self.num_prefill}P:{self.num_decode}D"
+
+    @property
+    def total_instances(self) -> int:
+        return self.num_prefill + self.num_decode
+
+
+class ParetoFrontier(BaseModel):
+    """Result of Pareto frontier analysis."""
+
+    candidates: list[ParetoCandidate] = Field(default_factory=list)
+    frontier: list[ParetoCandidate] = Field(
+        default_factory=list, description="Non-dominated (Pareto-optimal) candidates"
+    )
+    dominated: list[ParetoCandidate] = Field(
+        default_factory=list, description="Dominated candidates"
+    )
+    best_weighted: ParetoCandidate | None = Field(
+        None, description="Best candidate by weighted score"
+    )
+    objectives_used: list[str] = Field(default_factory=list)
+    weights: dict[str, float] = Field(default_factory=dict)
+
+
+def _dominates(
+    a: ParetoCandidate,
+    b: ParetoCandidate,
+    objectives: list[ParetoObjective],
+) -> bool:
+    """Return True if candidate a dominates candidate b.
+
+    a dominates b if a is <= b on all objectives and < b on at least one.
+    All objectives are minimized.
+    """
+    values_a = _get_objective_values(a, objectives)
+    values_b = _get_objective_values(b, objectives)
+
+    at_least_one_better = False
+    for va, vb in zip(values_a, values_b):
+        if va > vb:
+            return False
+        if va < vb:
+            at_least_one_better = True
+    return at_least_one_better
+
+
+def _get_objective_values(
+    candidate: ParetoCandidate,
+    objectives: list[ParetoObjective],
+) -> list[float]:
+    """Extract objective values from a candidate."""
+    values: list[float] = []
+    for obj in objectives:
+        if obj == ParetoObjective.LATENCY:
+            values.append(candidate.latency_ms)
+        elif obj == ParetoObjective.COST:
+            values.append(candidate.hourly_cost if candidate.hourly_cost is not None else 0.0)
+        elif obj == ParetoObjective.WASTE:
+            values.append(candidate.waste_rate)
+    return values
+
+
+class ParetoAnalyzer:
+    """Analyze P:D ratio candidates using Pareto dominance."""
+
+    def __init__(
+        self,
+        cost_config: CostConfig | None = None,
+    ) -> None:
+        self._cost_analyzer = CostAnalyzer(cost_config) if cost_config else None
+
+    def analyze(
+        self,
+        analysis: AnalysisResult,
+        measured_qps: float | None = None,
+        objectives: list[ParetoObjective] | None = None,
+        weights: dict[str, float] | None = None,
+        sla_only: bool = True,
+    ) -> ParetoFrontier:
+        """Find the Pareto frontier across specified objectives.
+
+        Args:
+            analysis: AnalysisResult from BenchmarkAnalyzer.
+            measured_qps: Measured QPS for cost calculations.
+            objectives: Which objectives to use (default: latency + waste,
+                        adds cost if cost_config provided).
+            weights: Objective weights for scoring (default: equal).
+                     Keys: 'latency', 'cost', 'waste'. Values: relative weights.
+            sla_only: If True, only consider SLA-meeting candidates.
+
+        Returns:
+            ParetoFrontier with classified candidates.
+        """
+        if objectives is None:
+            objectives = [ParetoObjective.LATENCY, ParetoObjective.WASTE]
+            if self._cost_analyzer is not None:
+                objectives.append(ParetoObjective.COST)
+
+        if weights is None:
+            weights = {obj.value: 1.0 for obj in objectives}
+
+        # Build ParetoCandidate list from analysis
+        candidates = self._build_candidates(analysis, measured_qps, sla_only)
+
+        if not candidates:
+            return ParetoFrontier(
+                objectives_used=[o.value for o in objectives],
+                weights=weights,
+            )
+
+        # Compute Pareto dominance
+        frontier: list[ParetoCandidate] = []
+        dominated: list[ParetoCandidate] = []
+
+        for i, c in enumerate(candidates):
+            is_dominated = False
+            for j, other in enumerate(candidates):
+                if i != j and _dominates(other, c, objectives):
+                    is_dominated = True
+                    break
+            c_copy = c.model_copy(update={"is_dominated": is_dominated})
+            if is_dominated:
+                dominated.append(c_copy)
+            else:
+                frontier.append(c_copy)
+
+        # Compute weighted scores (normalize then weight)
+        all_classified = frontier + dominated
+        self._compute_weighted_scores(all_classified, objectives, weights)
+
+        # Sort frontier by weighted score
+        frontier.sort(key=lambda c: c.weighted_score or float("inf"))
+        dominated.sort(key=lambda c: c.weighted_score or float("inf"))
+
+        best_weighted = frontier[0] if frontier else None
+
+        return ParetoFrontier(
+            candidates=all_classified,
+            frontier=frontier,
+            dominated=dominated,
+            best_weighted=best_weighted,
+            objectives_used=[o.value for o in objectives],
+            weights=weights,
+        )
+
+    def _build_candidates(
+        self,
+        analysis: AnalysisResult,
+        measured_qps: float | None,
+        sla_only: bool,
+    ) -> list[ParetoCandidate]:
+        """Convert RatioCandidates to ParetoCandidates."""
+        candidates: list[ParetoCandidate] = []
+        for rc in analysis.candidates:
+            if sla_only and not rc.meets_sla:
+                continue
+
+            latency = 0.0
+            if rc.sla_check is not None:
+                latency = rc.sla_check.total_latency_p95_ms
+
+            hourly_cost = None
+            if self._cost_analyzer is not None:
+                cost_result = self._cost_analyzer.compute_cost(rc, measured_qps)
+                hourly_cost = cost_result.hourly_cost
+
+            candidates.append(
+                ParetoCandidate(
+                    num_prefill=rc.num_prefill,
+                    num_decode=rc.num_decode,
+                    latency_ms=latency,
+                    hourly_cost=hourly_cost,
+                    waste_rate=rc.waste_rate,
+                    meets_sla=rc.meets_sla,
+                )
+            )
+        return candidates
+
+    def _compute_weighted_scores(
+        self,
+        candidates: list[ParetoCandidate],
+        objectives: list[ParetoObjective],
+        weights: dict[str, float],
+    ) -> None:
+        """Normalize objectives to [0,1] and compute weighted scores in-place."""
+        if not candidates:
+            return
+
+        # Extract values per objective
+        obj_values: dict[ParetoObjective, list[float]] = {}
+        for obj in objectives:
+            obj_values[obj] = _get_all_values(candidates, obj)
+
+        # Compute min/max for normalization
+        for c in candidates:
+            score = 0.0
+            total_weight = sum(weights.get(obj.value, 1.0) for obj in objectives)
+            for obj in objectives:
+                vals = obj_values[obj]
+                min_v, max_v = min(vals), max(vals)
+                raw = _get_objective_values(c, [obj])[0]
+                normalized = (raw - min_v) / (max_v - min_v) if max_v > min_v else 0.0
+                w = weights.get(obj.value, 1.0) / total_weight
+                score += normalized * w
+            c.weighted_score = round(score, 6)
+
+
+def _get_all_values(
+    candidates: list[ParetoCandidate], obj: ParetoObjective
+) -> list[float]:
+    """Get all values for a single objective."""
+    return [_get_objective_values(c, [obj])[0] for c in candidates]
+
+
+def find_pareto_frontier(
+    analysis: AnalysisResult,
+    measured_qps: float | None = None,
+    cost_config: CostConfig | None = None,
+    objectives: list[str] | None = None,
+    weights: dict[str, float] | None = None,
+    sla_only: bool = True,
+) -> ParetoFrontier:
+    """Programmatic API: find the Pareto frontier for P:D ratio analysis.
+
+    Args:
+        analysis: AnalysisResult from BenchmarkAnalyzer.
+        measured_qps: Measured QPS for cost calculations.
+        cost_config: CostConfig for cost objective. If None, cost is excluded.
+        objectives: List of objective names ('latency', 'cost', 'waste').
+        weights: Objective weights (default: equal).
+        sla_only: Only consider SLA-meeting candidates.
+
+    Returns:
+        ParetoFrontier with classified candidates and recommendations.
+    """
+    analyzer = ParetoAnalyzer(cost_config=cost_config)
+    parsed_objectives = None
+    if objectives is not None:
+        parsed_objectives = [ParetoObjective(o) for o in objectives]
+    return analyzer.analyze(
+        analysis,
+        measured_qps=measured_qps,
+        objectives=parsed_objectives,
+        weights=weights,
+        sla_only=sla_only,
+    )

--- a/tests/test_pareto.py
+++ b/tests/test_pareto.py
@@ -1,0 +1,363 @@
+"""Tests for Pareto frontier analysis."""
+
+from __future__ import annotations
+
+from xpyd_plan.benchmark_models import (
+    AnalysisResult,
+    RatioCandidate,
+    SLACheck,
+)
+from xpyd_plan.cost import CostConfig
+from xpyd_plan.pareto import (
+    ParetoAnalyzer,
+    ParetoCandidate,
+    ParetoFrontier,
+    ParetoObjective,
+    _dominates,
+    find_pareto_frontier,
+)
+
+
+def _make_sla_check(
+    ttft_p95: float = 50.0,
+    tpot_p95: float = 20.0,
+    total_p95: float = 200.0,
+) -> SLACheck:
+    return SLACheck(
+        ttft_p95_ms=ttft_p95,
+        ttft_p99_ms=ttft_p95 * 1.2,
+        tpot_p95_ms=tpot_p95,
+        tpot_p99_ms=tpot_p95 * 1.2,
+        total_latency_p95_ms=total_p95,
+        total_latency_p99_ms=total_p95 * 1.2,
+        meets_ttft=True,
+        meets_tpot=True,
+        meets_total_latency=True,
+        meets_all=True,
+    )
+
+
+def _make_candidate(
+    p: int,
+    d: int,
+    waste: float,
+    meets_sla: bool = True,
+    total_p95: float = 200.0,
+) -> RatioCandidate:
+    return RatioCandidate(
+        num_prefill=p,
+        num_decode=d,
+        prefill_utilization=1 - waste,
+        decode_utilization=1 - waste,
+        waste_rate=waste,
+        meets_sla=meets_sla,
+        sla_check=_make_sla_check(total_p95=total_p95),
+    )
+
+
+def _make_analysis(candidates: list[RatioCandidate]) -> AnalysisResult:
+    best = None
+    sla_meeting = [c for c in candidates if c.meets_sla]
+    if sla_meeting:
+        best = min(sla_meeting, key=lambda c: c.waste_rate)
+    total = candidates[0].total if candidates else 8
+    return AnalysisResult(
+        best=best,
+        candidates=candidates,
+        total_instances=total,
+    )
+
+
+class TestDominance:
+    """Test Pareto dominance logic."""
+
+    def test_dominates_all_better(self):
+        a = ParetoCandidate(num_prefill=2, num_decode=6, latency_ms=100, waste_rate=0.1)
+        b = ParetoCandidate(num_prefill=3, num_decode=5, latency_ms=200, waste_rate=0.3)
+        assert _dominates(a, b, [ParetoObjective.LATENCY, ParetoObjective.WASTE])
+
+    def test_not_dominates_one_worse(self):
+        a = ParetoCandidate(num_prefill=2, num_decode=6, latency_ms=100, waste_rate=0.5)
+        b = ParetoCandidate(num_prefill=3, num_decode=5, latency_ms=200, waste_rate=0.1)
+        assert not _dominates(a, b, [ParetoObjective.LATENCY, ParetoObjective.WASTE])
+
+    def test_not_dominates_equal(self):
+        a = ParetoCandidate(num_prefill=2, num_decode=6, latency_ms=100, waste_rate=0.1)
+        b = ParetoCandidate(num_prefill=3, num_decode=5, latency_ms=100, waste_rate=0.1)
+        assert not _dominates(a, b, [ParetoObjective.LATENCY, ParetoObjective.WASTE])
+
+    def test_dominates_one_equal_one_better(self):
+        a = ParetoCandidate(num_prefill=2, num_decode=6, latency_ms=100, waste_rate=0.1)
+        b = ParetoCandidate(num_prefill=3, num_decode=5, latency_ms=100, waste_rate=0.3)
+        assert _dominates(a, b, [ParetoObjective.LATENCY, ParetoObjective.WASTE])
+
+
+class TestParetoAnalyzer:
+    """Test ParetoAnalyzer."""
+
+    def test_basic_frontier(self):
+        candidates = [
+            _make_candidate(2, 6, 0.1, total_p95=100.0),  # low waste, low latency
+            _make_candidate(3, 5, 0.3, total_p95=80.0),   # higher waste, lower latency
+            _make_candidate(4, 4, 0.5, total_p95=300.0),  # dominated
+        ]
+        analysis = _make_analysis(candidates)
+        analyzer = ParetoAnalyzer()
+        result = analyzer.analyze(analysis)
+
+        assert len(result.frontier) >= 1
+        assert len(result.dominated) + len(result.frontier) == len(candidates)
+        # c3 (4P:4D) should be dominated (worse latency AND worse waste)
+        dominated_ratios = {c.ratio_str for c in result.dominated}
+        assert "4P:4D" in dominated_ratios
+
+    def test_empty_candidates(self):
+        analysis = AnalysisResult(candidates=[], total_instances=8)
+        analyzer = ParetoAnalyzer()
+        result = analyzer.analyze(analysis)
+        assert result.frontier == []
+        assert result.best_weighted is None
+
+    def test_single_candidate(self):
+        candidates = [_make_candidate(2, 6, 0.1, total_p95=100.0)]
+        analysis = _make_analysis(candidates)
+        analyzer = ParetoAnalyzer()
+        result = analyzer.analyze(analysis)
+        assert len(result.frontier) == 1
+        assert len(result.dominated) == 0
+
+    def test_sla_only_filter(self):
+        candidates = [
+            _make_candidate(2, 6, 0.1, meets_sla=True, total_p95=100.0),
+            _make_candidate(3, 5, 0.3, meets_sla=False, total_p95=80.0),
+        ]
+        analysis = _make_analysis(candidates)
+        analyzer = ParetoAnalyzer()
+        result = analyzer.analyze(analysis, sla_only=True)
+        assert len(result.frontier) == 1
+        assert result.frontier[0].ratio_str == "2P:6D"
+
+    def test_sla_only_false_includes_all(self):
+        candidates = [
+            _make_candidate(2, 6, 0.1, meets_sla=True, total_p95=100.0),
+            _make_candidate(3, 5, 0.3, meets_sla=False, total_p95=80.0),
+        ]
+        analysis = _make_analysis(candidates)
+        analyzer = ParetoAnalyzer()
+        result = analyzer.analyze(analysis, sla_only=False)
+        assert len(result.candidates) == 2
+
+    def test_with_cost_objective(self):
+        candidates = [
+            _make_candidate(2, 6, 0.1, total_p95=100.0),
+            _make_candidate(3, 5, 0.3, total_p95=80.0),
+        ]
+        analysis = _make_analysis(candidates)
+        cost_config = CostConfig(gpu_hourly_rate=2.0, currency="USD")
+        analyzer = ParetoAnalyzer(cost_config=cost_config)
+        result = analyzer.analyze(
+            analysis,
+            measured_qps=10.0,
+            objectives=[ParetoObjective.LATENCY, ParetoObjective.COST, ParetoObjective.WASTE],
+        )
+        # Both have same total instances, so cost is equal → latency & waste determine frontier
+        assert len(result.candidates) >= 1
+        assert "cost" in result.objectives_used
+
+    def test_weighted_scoring(self):
+        candidates = [
+            _make_candidate(2, 6, 0.1, total_p95=200.0),  # low waste, high latency
+            _make_candidate(3, 5, 0.3, total_p95=80.0),   # high waste, low latency
+        ]
+        analysis = _make_analysis(candidates)
+        analyzer = ParetoAnalyzer()
+
+        # Weight latency heavily
+        result_latency = analyzer.analyze(
+            analysis, weights={"latency": 10.0, "waste": 1.0}
+        )
+        # Weight waste heavily
+        result_waste = analyzer.analyze(
+            analysis, weights={"latency": 1.0, "waste": 10.0}
+        )
+
+        # Both should be on frontier (they're non-dominated), but best_weighted should differ
+        assert result_latency.best_weighted is not None
+        assert result_waste.best_weighted is not None
+        # With latency heavily weighted, 3P:5D (lower latency) should score better
+        assert result_latency.best_weighted.ratio_str == "3P:5D"
+        # With waste heavily weighted, 2P:6D (lower waste) should score better
+        assert result_waste.best_weighted.ratio_str == "2P:6D"
+
+    def test_custom_objectives(self):
+        candidates = [
+            _make_candidate(2, 6, 0.1, total_p95=100.0),
+            _make_candidate(3, 5, 0.3, total_p95=80.0),
+        ]
+        analysis = _make_analysis(candidates)
+        analyzer = ParetoAnalyzer()
+        result = analyzer.analyze(
+            analysis, objectives=[ParetoObjective.WASTE]
+        )
+        assert result.objectives_used == ["waste"]
+        # With only waste objective, 2P:6D dominates 3P:5D
+        assert len(result.frontier) == 1
+        assert result.frontier[0].ratio_str == "2P:6D"
+
+    def test_all_non_dominated(self):
+        """When each candidate is best on some objective, none are dominated."""
+        candidates = [
+            _make_candidate(2, 6, 0.4, total_p95=80.0),   # best latency
+            _make_candidate(3, 5, 0.1, total_p95=200.0),  # best waste
+        ]
+        analysis = _make_analysis(candidates)
+        analyzer = ParetoAnalyzer()
+        result = analyzer.analyze(analysis)
+        assert len(result.frontier) == 2
+        assert len(result.dominated) == 0
+
+    def test_all_dominated_except_one(self):
+        candidates = [
+            _make_candidate(2, 6, 0.1, total_p95=80.0),   # dominates all others
+            _make_candidate(3, 5, 0.3, total_p95=200.0),
+            _make_candidate(4, 4, 0.5, total_p95=300.0),
+        ]
+        analysis = _make_analysis(candidates)
+        analyzer = ParetoAnalyzer()
+        result = analyzer.analyze(analysis)
+        assert len(result.frontier) == 1
+        assert result.frontier[0].ratio_str == "2P:6D"
+        assert len(result.dominated) == 2
+
+
+class TestParetoCandidate:
+    """Test ParetoCandidate model."""
+
+    def test_ratio_str(self):
+        c = ParetoCandidate(num_prefill=3, num_decode=5, latency_ms=100, waste_rate=0.2)
+        assert c.ratio_str == "3P:5D"
+
+    def test_total_instances(self):
+        c = ParetoCandidate(num_prefill=3, num_decode=5, latency_ms=100, waste_rate=0.2)
+        assert c.total_instances == 8
+
+    def test_defaults(self):
+        c = ParetoCandidate(num_prefill=2, num_decode=6, latency_ms=100, waste_rate=0.1)
+        assert c.is_dominated is False
+        assert c.weighted_score is None
+        assert c.meets_sla is True
+        assert c.hourly_cost is None
+
+
+class TestParetoFrontier:
+    """Test ParetoFrontier model."""
+
+    def test_empty_frontier(self):
+        f = ParetoFrontier()
+        assert f.frontier == []
+        assert f.dominated == []
+        assert f.best_weighted is None
+
+    def test_serialization(self):
+        c = ParetoCandidate(
+            num_prefill=2, num_decode=6, latency_ms=100,
+            waste_rate=0.1, weighted_score=0.25,
+        )
+        f = ParetoFrontier(
+            candidates=[c], frontier=[c], dominated=[],
+            best_weighted=c, objectives_used=["latency", "waste"],
+            weights={"latency": 1.0, "waste": 1.0},
+        )
+        d = f.model_dump()
+        assert d["objectives_used"] == ["latency", "waste"]
+        assert len(d["frontier"]) == 1
+
+
+class TestFindParetoFrontierAPI:
+    """Test the programmatic API."""
+
+    def test_basic_api(self):
+        candidates = [
+            _make_candidate(2, 6, 0.1, total_p95=100.0),
+            _make_candidate(3, 5, 0.3, total_p95=80.0),
+        ]
+        analysis = _make_analysis(candidates)
+        result = find_pareto_frontier(analysis)
+        assert isinstance(result, ParetoFrontier)
+        assert len(result.frontier) >= 1
+
+    def test_api_with_cost(self):
+        candidates = [
+            _make_candidate(2, 6, 0.1, total_p95=100.0),
+            _make_candidate(3, 5, 0.3, total_p95=80.0),
+        ]
+        analysis = _make_analysis(candidates)
+        cost_config = CostConfig(gpu_hourly_rate=3.0)
+        result = find_pareto_frontier(
+            analysis,
+            measured_qps=5.0,
+            cost_config=cost_config,
+            objectives=["latency", "cost", "waste"],
+        )
+        assert "cost" in result.objectives_used
+
+    def test_api_with_custom_weights(self):
+        candidates = [
+            _make_candidate(2, 6, 0.1, total_p95=200.0),
+            _make_candidate(3, 5, 0.3, total_p95=80.0),
+        ]
+        analysis = _make_analysis(candidates)
+        result = find_pareto_frontier(
+            analysis, weights={"latency": 5.0, "waste": 1.0}
+        )
+        assert result.best_weighted is not None
+
+    def test_api_sla_only(self):
+        candidates = [
+            _make_candidate(2, 6, 0.1, meets_sla=True, total_p95=100.0),
+            _make_candidate(3, 5, 0.3, meets_sla=False, total_p95=80.0),
+        ]
+        analysis = _make_analysis(candidates)
+        result_sla = find_pareto_frontier(analysis, sla_only=True)
+        result_all = find_pareto_frontier(analysis, sla_only=False)
+        assert len(result_sla.candidates) == 1
+        assert len(result_all.candidates) == 2
+
+
+class TestEdgeCases:
+    """Test edge cases."""
+
+    def test_identical_candidates(self):
+        """Two identical candidates — neither dominates the other."""
+        candidates = [
+            _make_candidate(2, 6, 0.1, total_p95=100.0),
+            _make_candidate(3, 5, 0.1, total_p95=100.0),
+        ]
+        analysis = _make_analysis(candidates)
+        analyzer = ParetoAnalyzer()
+        result = analyzer.analyze(analysis)
+        # Neither dominates the other (equal on all objectives)
+        assert len(result.frontier) == 2
+        assert len(result.dominated) == 0
+
+    def test_three_way_pareto(self):
+        """Three candidates forming a proper Pareto frontier."""
+        candidates = [
+            _make_candidate(1, 7, 0.5, total_p95=50.0),   # best latency, worst waste
+            _make_candidate(3, 5, 0.2, total_p95=150.0),   # middle
+            _make_candidate(4, 4, 0.05, total_p95=300.0),  # best waste, worst latency
+        ]
+        analysis = _make_analysis(candidates)
+        analyzer = ParetoAnalyzer()
+        result = analyzer.analyze(analysis)
+        # All three form the frontier (each best on some trade-off)
+        assert len(result.frontier) == 3
+        assert len(result.dominated) == 0
+
+    def test_cost_none_when_no_cost_config(self):
+        candidates = [_make_candidate(2, 6, 0.1, total_p95=100.0)]
+        analysis = _make_analysis(candidates)
+        analyzer = ParetoAnalyzer()
+        result = analyzer.analyze(analysis)
+        assert result.frontier[0].hourly_cost is None
+        assert "cost" not in result.objectives_used


### PR DESCRIPTION
## Summary

Add Pareto frontier analysis for multi-objective P:D ratio optimization.

### Changes
- `ParetoAnalyzer` class with dominance algorithm across latency, cost, and utilization waste
- `ParetoCandidate`, `ParetoFrontier`, `ParetoObjective` Pydantic models
- Weighted scoring for ranking Pareto-optimal candidates
- CLI `pareto` subcommand with table and JSON output
- Programmatic `find_pareto_frontier()` API
- Updated `__init__.py` exports
- 26 new tests (482 total, all passing)

Closes #51