### PR TITLE
feat(report): M25 — Markdown Report Generation

### DIFF
--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -58,6 +58,11 @@ from xpyd_plan.interpolator import (
     PredictedPerformance,
     interpolate_performance,
 )
+from xpyd_plan.md_report import (
+    MarkdownReportConfig,
+    MarkdownReporter,
+    generate_markdown_report,
+)
 from xpyd_plan.models import (
     DatasetStats,
     GPUProfile,
@@ -175,4 +180,7 @@ __all__ = [
     "StepType",
     "load_pipeline_config",
     "run_pipeline",
+    "MarkdownReportConfig",
+    "MarkdownReporter",
+    "generate_markdown_report",
 ]

--- a/src/xpyd_plan/cli.py
+++ b/src/xpyd_plan/cli.py
@@ -304,13 +304,22 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
             _print_sensitivity(console, analyzer, sla, total)
 
         if args.report:
-            from xpyd_plan.report import ReportGenerator
-
             result = analyzer.find_optimal_ratio(total, sla)
-            gen = ReportGenerator()
-            html = gen.generate_single(result, total_instances=total)
-            gen.write(html, args.report)
-            console.print(f"\n[dim]HTML report written to {args.report}[/dim]")
+            report_fmt = getattr(args, "report_format", "html")
+            if report_fmt == "markdown":
+                from xpyd_plan.md_report import MarkdownReporter
+
+                gen = MarkdownReporter()
+                md = gen.generate_single(result, total_instances=total)
+                gen.write(md, args.report)
+                console.print(f"\n[dim]Markdown report written to {args.report}[/dim]")
+            else:
+                from xpyd_plan.report import ReportGenerator
+
+                gen = ReportGenerator()
+                html = gen.generate_single(result, total_instances=total)
+                gen.write(html, args.report)
+                console.print(f"\n[dim]HTML report written to {args.report}[/dim]")
 
         if args.output:
             result = analyzer.find_optimal_ratio(total, sla)
@@ -400,12 +409,21 @@ def _cmd_analyze(args: argparse.Namespace) -> None:
             analyzer._data = analyzer.multi_data[0]
 
         if args.report:
-            from xpyd_plan.report import ReportGenerator
+            report_fmt = getattr(args, "report_format", "html")
+            if report_fmt == "markdown":
+                from xpyd_plan.md_report import MarkdownReporter
 
-            gen = ReportGenerator()
-            html = gen.generate_multi(multi_result)
-            gen.write(html, args.report)
-            console.print(f"\n[dim]HTML report written to {args.report}[/dim]")
+                gen = MarkdownReporter()
+                md = gen.generate_multi(multi_result)
+                gen.write(md, args.report)
+                console.print(f"\n[dim]Markdown report written to {args.report}[/dim]")
+            else:
+                from xpyd_plan.report import ReportGenerator
+
+                gen = ReportGenerator()
+                html = gen.generate_multi(multi_result)
+                gen.write(html, args.report)
+                console.print(f"\n[dim]HTML report written to {args.report}[/dim]")
 
         if args.output:
             Path(args.output).write_text(multi_result.model_dump_json(indent=2))
@@ -1569,7 +1587,11 @@ def main(argv: list[str] | None = None) -> None:
     analyze_parser.add_argument("--output", type=str, default=None, help="Output JSON path")
     analyze_parser.add_argument(
         "--report", type=str, default=None,
-        help="Generate HTML report to the given path (e.g. report.html)",
+        help="Generate report to the given path (e.g. report.html or report.md)",
+    )
+    analyze_parser.add_argument(
+        "--report-format", type=str, default="html", choices=["html", "markdown"],
+        help="Report format: html (default) or markdown",
     )
     analyze_parser.add_argument(
         "--cost-model", type=str, default=None,

--- a/src/xpyd_plan/md_report.py
+++ b/src/xpyd_plan/md_report.py
@@ -1,0 +1,334 @@
+"""Markdown report generation for xPyD-plan analysis results.
+
+Generates standalone Markdown reports suitable for GitHub PRs, wiki pages,
+and documentation. Complements the existing HTML report generator.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from xpyd_plan.benchmark_models import (
+    AnalysisResult,
+    MultiScenarioResult,
+    RatioCandidate,
+)
+
+
+class MarkdownReportConfig(BaseModel):
+    """Configuration for Markdown report generation."""
+
+    title: str = Field("xPyD-plan Analysis Report", description="Report title")
+    include_executive_summary: bool = Field(True, description="Include executive summary section")
+    include_sla_compliance: bool = Field(True, description="Include SLA compliance section")
+    include_cost_analysis: bool = Field(True, description="Include cost analysis section")
+    include_recommendations: bool = Field(True, description="Include recommendations section")
+    include_all_candidates: bool = Field(
+        False, description="Include full candidate table (not just top N)"
+    )
+    top_n: int = Field(5, ge=1, description="Number of top candidates to show")
+    timestamp: bool = Field(True, description="Include generation timestamp")
+
+
+class MarkdownReporter:
+    """Generate Markdown reports from analysis results."""
+
+    def __init__(self, config: MarkdownReportConfig | None = None) -> None:
+        self.config = config or MarkdownReportConfig()
+
+    def generate_single(
+        self,
+        result: AnalysisResult,
+        *,
+        total_instances: int | None = None,
+        cost_per_hour: float | None = None,
+        currency: str = "USD",
+    ) -> str:
+        """Generate a Markdown report for a single-scenario analysis."""
+        total = total_instances or result.total_instances
+        sections: list[str] = []
+
+        sections.append(f"# {self.config.title}\n")
+
+        if self.config.timestamp:
+            ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+            sections.append(f"*Generated: {ts}*\n")
+
+        if self.config.include_executive_summary:
+            sections.append(self._executive_summary(result, total))
+
+        if self.config.include_sla_compliance:
+            sections.append(self._sla_compliance(result))
+
+        candidates = result.candidates
+        if self.config.include_all_candidates:
+            top = candidates
+        else:
+            top = candidates[: self.config.top_n]
+        sections.append(self._candidates_table(top, result.best))
+
+        if self.config.include_cost_analysis and cost_per_hour is not None:
+            sections.append(self._cost_analysis(result, cost_per_hour, currency))
+
+        if self.config.include_recommendations:
+            sections.append(self._recommendations_single(result, total))
+
+        return "\n".join(sections)
+
+    def generate_multi(
+        self,
+        result: MultiScenarioResult,
+        *,
+        cost_per_hour: float | None = None,
+        currency: str = "USD",
+    ) -> str:
+        """Generate a Markdown report for a multi-scenario analysis."""
+        sections: list[str] = []
+
+        sections.append(f"# {self.config.title}\n")
+
+        if self.config.timestamp:
+            ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+            sections.append(f"*Generated: {ts}*\n")
+
+        if self.config.include_executive_summary:
+            sections.append(self._executive_summary_multi(result))
+
+        for i, scenario in enumerate(result.scenarios):
+            sections.append(f"## Scenario {i + 1}: QPS {scenario.qps:.1f}\n")
+            if self.config.include_sla_compliance:
+                sections.append(self._sla_compliance(scenario.analysis))
+            candidates = scenario.analysis.candidates
+            if self.config.include_all_candidates:
+                top = candidates
+            else:
+                top = candidates[: self.config.top_n]
+            sections.append(self._candidates_table(top, scenario.analysis.best))
+
+        if self.config.include_cost_analysis and cost_per_hour is not None:
+            # Use unified best for cost analysis
+            unified = result.unified_best
+            if unified:
+                total_cost = unified.total * cost_per_hour
+                sections.append("## Cost Analysis\n")
+                sections.append(
+                    f"| Metric | Value |\n|--------|-------|\n"
+                    f"| Unified Optimal | {unified.ratio_str} |\n"
+                    f"| Total Instances | {unified.total} |\n"
+                    f"| Hourly Cost | {currency} {total_cost:.2f} |\n"
+                )
+
+        if self.config.include_recommendations:
+            sections.append(self._recommendations_multi(result))
+
+        return "\n".join(sections)
+
+    def write(self, content: str, path: str | Path) -> Path:
+        """Write Markdown content to a file."""
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+        return p
+
+    # ── Private section builders ───────────────────────────────────────
+
+    def _executive_summary(self, result: AnalysisResult, total: int) -> str:
+        lines = ["## Executive Summary\n"]
+        if result.best:
+            b = result.best
+            lines.append(
+                f"**Optimal P:D Ratio:** {b.ratio_str} "
+                f"(waste {b.waste_rate:.1%})\n"
+            )
+            lines.append(f"- Total instances: {total}")
+            lines.append(f"- Prefill: {b.num_prefill}, Decode: {b.num_decode}")
+            lines.append(f"- SLA met: {'✅ Yes' if b.meets_sla else '❌ No'}")
+        else:
+            lines.append("**⚠️ No configuration meets all SLA constraints.**\n")
+            sla_pass = [c for c in result.candidates if c.meets_sla]
+            lines.append(f"- Candidates evaluated: {len(result.candidates)}")
+            lines.append(f"- Candidates meeting SLA: {len(sla_pass)}")
+        lines.append("")
+        return "\n".join(lines)
+
+    def _executive_summary_multi(self, result: MultiScenarioResult) -> str:
+        lines = ["## Executive Summary\n"]
+        lines.append(f"- Scenarios analyzed: {len(result.scenarios)}")
+        lines.append(f"- Total instances: {result.total_instances}")
+        if result.unified_best:
+            b = result.unified_best
+            lines.append(
+                f"- **Unified optimal:** {b.ratio_str} (waste {b.waste_rate:.1%})"
+            )
+        else:
+            lines.append("- **⚠️ No single ratio meets SLA across all scenarios.**")
+        lines.append("")
+        return "\n".join(lines)
+
+    def _sla_compliance(self, result: AnalysisResult) -> str:
+        lines = ["### SLA Compliance\n"]
+        if result.current_sla_check:
+            s = result.current_sla_check
+            lines.append(
+                f"| Metric | P95 (ms) | P99 (ms) | Status |\n"
+                f"|--------|----------|----------|--------|\n"
+                f"| TTFT | {s.ttft_p95_ms:.1f} | {s.ttft_p99_ms:.1f} | "
+                f"{'✅' if s.meets_ttft else '❌'} |\n"
+                f"| TPOT | {s.tpot_p95_ms:.1f} | {s.tpot_p99_ms:.1f} | "
+                f"{'✅' if s.meets_tpot else '❌'} |\n"
+                f"| Total Latency | {s.total_latency_p95_ms:.1f} | "
+                f"{s.total_latency_p99_ms:.1f} | "
+                f"{'✅' if s.meets_total_latency else '❌'} |\n"
+            )
+        elif result.best and result.best.sla_check:
+            s = result.best.sla_check
+            lines.append(
+                f"| Metric | P95 (ms) | P99 (ms) | Status |\n"
+                f"|--------|----------|----------|--------|\n"
+                f"| TTFT | {s.ttft_p95_ms:.1f} | {s.ttft_p99_ms:.1f} | "
+                f"{'✅' if s.meets_ttft else '❌'} |\n"
+                f"| TPOT | {s.tpot_p95_ms:.1f} | {s.tpot_p99_ms:.1f} | "
+                f"{'✅' if s.meets_tpot else '❌'} |\n"
+                f"| Total Latency | {s.total_latency_p95_ms:.1f} | "
+                f"{s.total_latency_p99_ms:.1f} | "
+                f"{'✅' if s.meets_total_latency else '❌'} |\n"
+            )
+        else:
+            lines.append("*No SLA data available for current configuration.*\n")
+        return "\n".join(lines)
+
+    def _candidates_table(
+        self,
+        candidates: list[RatioCandidate],
+        best: RatioCandidate | None,
+    ) -> str:
+        lines = ["### Candidate Ratios\n"]
+        if not candidates:
+            lines.append("*No candidates to display.*\n")
+            return "\n".join(lines)
+
+        lines.append(
+            "| Ratio | Prefill Util | Decode Util | Waste | SLA | Note |"
+        )
+        lines.append("|-------|-------------|-------------|-------|-----|------|")
+        for c in candidates:
+            is_best = (
+                best
+                and c.num_prefill == best.num_prefill
+                and c.num_decode == best.num_decode
+            )
+            note = "⭐ Best" if is_best else ""
+            sla = "✅" if c.meets_sla else "❌"
+            lines.append(
+                f"| {c.ratio_str} | {c.prefill_utilization:.1%} | "
+                f"{c.decode_utilization:.1%} | {c.waste_rate:.1%} | {sla} | {note} |"
+            )
+        lines.append("")
+        return "\n".join(lines)
+
+    def _cost_analysis(
+        self,
+        result: AnalysisResult,
+        cost_per_hour: float,
+        currency: str,
+    ) -> str:
+        lines = ["## Cost Analysis\n"]
+        if result.best:
+            b = result.best
+            total_cost = b.total * cost_per_hour
+            lines.append(
+                f"| Metric | Value |\n|--------|-------|\n"
+                f"| Optimal Ratio | {b.ratio_str} |\n"
+                f"| Total Instances | {b.total} |\n"
+                f"| Cost/Instance/Hour | {currency} {cost_per_hour:.2f} |\n"
+                f"| Total Hourly Cost | {currency} {total_cost:.2f} |\n"
+            )
+        else:
+            lines.append("*No optimal configuration found for cost analysis.*\n")
+        return "\n".join(lines)
+
+    def _recommendations_single(self, result: AnalysisResult, total: int) -> str:
+        lines = ["## Recommendations\n"]
+        if result.best:
+            b = result.best
+            lines.append(
+                f"1. **Deploy {b.ratio_str}** — lowest waste "
+                f"({b.waste_rate:.1%}) while meeting SLA."
+            )
+            if b.waste_rate > 0.3:
+                lines.append(
+                    f"2. ⚠️ Waste rate is high ({b.waste_rate:.1%}). "
+                    "Consider adjusting total instance count."
+                )
+            sla_candidates = [c for c in result.candidates if c.meets_sla]
+            if len(sla_candidates) > 1:
+                runner_up = [c for c in sla_candidates if c.ratio_str != b.ratio_str]
+                if runner_up:
+                    r = runner_up[0]
+                    lines.append(
+                        f"3. Runner-up: {r.ratio_str} (waste {r.waste_rate:.1%})."
+                    )
+        else:
+            lines.append(
+                "1. **No ratio meets SLA.** Consider:\n"
+                "   - Increasing total instance count\n"
+                "   - Relaxing SLA thresholds\n"
+                "   - Investigating bottlenecks in benchmark data"
+            )
+        lines.append("")
+        return "\n".join(lines)
+
+    def _recommendations_multi(self, result: MultiScenarioResult) -> str:
+        lines = ["## Recommendations\n"]
+        if result.unified_best:
+            b = result.unified_best
+            lines.append(
+                f"1. **Deploy {b.ratio_str}** — meets SLA across "
+                f"all {len(result.scenarios)} scenarios."
+            )
+            lines.append(f"2. Worst-case waste: {b.waste_rate:.1%}.")
+        else:
+            lines.append(
+                "1. **No single ratio meets SLA across all scenarios.** Consider:\n"
+                "   - Per-scenario tuning\n"
+                "   - Increasing total instance count\n"
+                "   - Relaxing SLA thresholds"
+            )
+        lines.append("")
+        return "\n".join(lines)
+
+
+def generate_markdown_report(
+    result: AnalysisResult | MultiScenarioResult,
+    *,
+    config: MarkdownReportConfig | None = None,
+    total_instances: int | None = None,
+    cost_per_hour: float | None = None,
+    currency: str = "USD",
+) -> str:
+    """Programmatic API: generate a Markdown report from analysis results.
+
+    Args:
+        result: Single or multi-scenario analysis result.
+        config: Optional report configuration.
+        total_instances: Override total instances (single-scenario only).
+        cost_per_hour: GPU cost per hour for cost section.
+        currency: Currency label for cost section.
+
+    Returns:
+        Markdown string.
+    """
+    reporter = MarkdownReporter(config)
+    if isinstance(result, MultiScenarioResult):
+        return reporter.generate_multi(
+            result, cost_per_hour=cost_per_hour, currency=currency
+        )
+    return reporter.generate_single(
+        result,
+        total_instances=total_instances,
+        cost_per_hour=cost_per_hour,
+        currency=currency,
+    )

--- a/tests/test_md_report.py
+++ b/tests/test_md_report.py
@@ -1,0 +1,332 @@
+"""Tests for Markdown report generation (M25)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from xpyd_plan.benchmark_models import (
+    AnalysisResult,
+    MultiScenarioResult,
+    RatioCandidate,
+    ScenarioResult,
+    SLACheck,
+)
+from xpyd_plan.md_report import (
+    MarkdownReportConfig,
+    MarkdownReporter,
+    generate_markdown_report,
+)
+
+# ── Fixtures ────────────────────────────────────────────────────────────
+
+
+def _sla_check(meets: bool = True) -> SLACheck:
+    return SLACheck(
+        ttft_p95_ms=50.0,
+        ttft_p99_ms=80.0,
+        tpot_p95_ms=10.0,
+        tpot_p99_ms=15.0,
+        total_latency_p95_ms=200.0,
+        total_latency_p99_ms=300.0,
+        meets_ttft=meets,
+        meets_tpot=meets,
+        meets_total_latency=meets,
+        meets_all=meets,
+    )
+
+
+def _candidate(p: int, d: int, waste: float, meets_sla: bool = True) -> RatioCandidate:
+    return RatioCandidate(
+        num_prefill=p,
+        num_decode=d,
+        prefill_utilization=0.8,
+        decode_utilization=0.7,
+        waste_rate=waste,
+        meets_sla=meets_sla,
+        sla_check=_sla_check(meets_sla),
+    )
+
+
+def _analysis_result(
+    best_pd: tuple[int, int] | None = (2, 6),
+    n_candidates: int = 3,
+    has_sla_check: bool = True,
+) -> AnalysisResult:
+    candidates = [
+        _candidate(2, 6, 0.05),
+        _candidate(3, 5, 0.12),
+        _candidate(4, 4, 0.25),
+    ][:n_candidates]
+    best = candidates[0] if best_pd else None
+    return AnalysisResult(
+        best=best,
+        candidates=candidates,
+        total_instances=8,
+        current_sla_check=_sla_check() if has_sla_check else None,
+    )
+
+
+def _multi_result() -> MultiScenarioResult:
+    s1 = ScenarioResult(qps=100.0, analysis=_analysis_result())
+    s2 = ScenarioResult(qps=200.0, analysis=_analysis_result())
+    return MultiScenarioResult(
+        scenarios=[s1, s2],
+        total_instances=8,
+        unified_best=_candidate(2, 6, 0.08),
+        per_scenario_best=[_candidate(2, 6, 0.05), _candidate(2, 6, 0.08)],
+    )
+
+
+# ── MarkdownReportConfig tests ─────────────────────────────────────────
+
+
+class TestMarkdownReportConfig:
+    def test_defaults(self):
+        cfg = MarkdownReportConfig()
+        assert cfg.title == "xPyD-plan Analysis Report"
+        assert cfg.include_executive_summary is True
+        assert cfg.include_sla_compliance is True
+        assert cfg.include_cost_analysis is True
+        assert cfg.include_recommendations is True
+        assert cfg.include_all_candidates is False
+        assert cfg.top_n == 5
+        assert cfg.timestamp is True
+
+    def test_custom_values(self):
+        cfg = MarkdownReportConfig(title="Custom", top_n=10, timestamp=False)
+        assert cfg.title == "Custom"
+        assert cfg.top_n == 10
+        assert cfg.timestamp is False
+
+    def test_top_n_min(self):
+        with pytest.raises(Exception):
+            MarkdownReportConfig(top_n=0)
+
+
+# ── MarkdownReporter single-scenario tests ─────────────────────────────
+
+
+class TestMarkdownReporterSingle:
+    def test_basic_report(self):
+        r = MarkdownReporter()
+        md = r.generate_single(_analysis_result(), total_instances=8)
+        assert "# xPyD-plan Analysis Report" in md
+        assert "2P:6D" in md
+        assert "Executive Summary" in md
+
+    def test_no_timestamp(self):
+        cfg = MarkdownReportConfig(timestamp=False)
+        r = MarkdownReporter(cfg)
+        md = r.generate_single(_analysis_result(), total_instances=8)
+        assert "Generated:" not in md
+
+    def test_with_timestamp(self):
+        r = MarkdownReporter()
+        md = r.generate_single(_analysis_result(), total_instances=8)
+        assert "Generated:" in md
+        assert "UTC" in md
+
+    def test_executive_summary_with_best(self):
+        r = MarkdownReporter()
+        md = r.generate_single(_analysis_result(), total_instances=8)
+        assert "Optimal P:D Ratio" in md
+        assert "2P:6D" in md
+        assert "✅ Yes" in md
+
+    def test_executive_summary_no_best(self):
+        result = AnalysisResult(
+            best=None,
+            candidates=[_candidate(2, 6, 0.05, meets_sla=False)],
+            total_instances=8,
+        )
+        r = MarkdownReporter()
+        md = r.generate_single(result, total_instances=8)
+        assert "No configuration meets all SLA" in md
+
+    def test_sla_compliance_table(self):
+        r = MarkdownReporter()
+        md = r.generate_single(_analysis_result(), total_instances=8)
+        assert "SLA Compliance" in md
+        assert "TTFT" in md
+        assert "TPOT" in md
+        assert "Total Latency" in md
+
+    def test_sla_from_best_when_no_current(self):
+        result = _analysis_result(has_sla_check=False)
+        r = MarkdownReporter()
+        md = r.generate_single(result, total_instances=8)
+        assert "TTFT" in md
+
+    def test_no_sla_data(self):
+        result = AnalysisResult(
+            best=None,
+            candidates=[],
+            total_instances=8,
+            current_sla_check=None,
+        )
+        r = MarkdownReporter()
+        md = r.generate_single(result, total_instances=8)
+        assert "No SLA data available" in md
+
+    def test_candidates_table(self):
+        r = MarkdownReporter()
+        md = r.generate_single(_analysis_result(), total_instances=8)
+        assert "Candidate Ratios" in md
+        assert "⭐ Best" in md
+        assert "3P:5D" in md
+
+    def test_top_n_limits(self):
+        cfg = MarkdownReportConfig(top_n=1)
+        r = MarkdownReporter(cfg)
+        md = r.generate_single(_analysis_result(), total_instances=8)
+        assert "2P:6D" in md
+        assert "4P:4D" not in md
+
+    def test_include_all_candidates(self):
+        cfg = MarkdownReportConfig(include_all_candidates=True)
+        r = MarkdownReporter(cfg)
+        md = r.generate_single(_analysis_result(), total_instances=8)
+        assert "4P:4D" in md
+
+    def test_cost_analysis(self):
+        r = MarkdownReporter()
+        md = r.generate_single(_analysis_result(), total_instances=8, cost_per_hour=3.5)
+        assert "Cost Analysis" in md
+        assert "USD" in md
+        assert "3.50" in md
+
+    def test_cost_analysis_custom_currency(self):
+        r = MarkdownReporter()
+        md = r.generate_single(
+            _analysis_result(), total_instances=8, cost_per_hour=2.0, currency="EUR"
+        )
+        assert "EUR" in md
+
+    def test_no_cost_without_param(self):
+        r = MarkdownReporter()
+        md = r.generate_single(_analysis_result(), total_instances=8)
+        assert "Cost Analysis" not in md
+
+    def test_recommendations_with_best(self):
+        r = MarkdownReporter()
+        md = r.generate_single(_analysis_result(), total_instances=8)
+        assert "Recommendations" in md
+        assert "Deploy 2P:6D" in md
+
+    def test_recommendations_high_waste(self):
+        result = AnalysisResult(
+            best=_candidate(2, 6, 0.4),
+            candidates=[_candidate(2, 6, 0.4)],
+            total_instances=8,
+        )
+        r = MarkdownReporter()
+        md = r.generate_single(result, total_instances=8)
+        assert "Waste rate is high" in md
+
+    def test_recommendations_no_best(self):
+        result = AnalysisResult(best=None, candidates=[], total_instances=8)
+        r = MarkdownReporter()
+        md = r.generate_single(result, total_instances=8)
+        assert "No ratio meets SLA" in md
+
+    def test_disable_sections(self):
+        cfg = MarkdownReportConfig(
+            include_executive_summary=False,
+            include_sla_compliance=False,
+            include_cost_analysis=False,
+            include_recommendations=False,
+        )
+        r = MarkdownReporter(cfg)
+        md = r.generate_single(_analysis_result(), total_instances=8, cost_per_hour=3.0)
+        assert "Executive Summary" not in md
+        assert "SLA Compliance" not in md
+        assert "Cost Analysis" not in md
+        assert "Recommendations" not in md
+
+
+# ── MarkdownReporter multi-scenario tests ──────────────────────────────
+
+
+class TestMarkdownReporterMulti:
+    def test_basic_multi(self):
+        r = MarkdownReporter()
+        md = r.generate_multi(_multi_result())
+        assert "Scenario 1" in md
+        assert "Scenario 2" in md
+        assert "QPS 100.0" in md
+        assert "QPS 200.0" in md
+
+    def test_unified_best(self):
+        r = MarkdownReporter()
+        md = r.generate_multi(_multi_result())
+        assert "Unified optimal" in md
+        assert "2P:6D" in md
+
+    def test_no_unified_best(self):
+        result = _multi_result()
+        result.unified_best = None
+        r = MarkdownReporter()
+        md = r.generate_multi(result)
+        assert "No single ratio meets SLA" in md
+
+    def test_multi_cost(self):
+        r = MarkdownReporter()
+        md = r.generate_multi(_multi_result(), cost_per_hour=4.0)
+        assert "Cost Analysis" in md
+
+    def test_multi_recommendations(self):
+        r = MarkdownReporter()
+        md = r.generate_multi(_multi_result())
+        assert "Recommendations" in md
+        assert "Deploy 2P:6D" in md
+
+
+# ── write() tests ──────────────────────────────────────────────────────
+
+
+class TestMarkdownReporterWrite:
+    def test_write_creates_file(self, tmp_path: Path):
+        r = MarkdownReporter()
+        md = r.generate_single(_analysis_result(), total_instances=8)
+        out = tmp_path / "report.md"
+        result_path = r.write(md, out)
+        assert result_path == out
+        assert out.read_text().startswith("# xPyD-plan")
+
+    def test_write_creates_parent_dirs(self, tmp_path: Path):
+        r = MarkdownReporter()
+        out = tmp_path / "sub" / "dir" / "report.md"
+        r.write("# Test", out)
+        assert out.exists()
+
+
+# ── Programmatic API tests ─────────────────────────────────────────────
+
+
+class TestGenerateMarkdownReport:
+    def test_single_scenario(self):
+        md = generate_markdown_report(_analysis_result(), total_instances=8)
+        assert "# xPyD-plan Analysis Report" in md
+        assert "2P:6D" in md
+
+    def test_multi_scenario(self):
+        md = generate_markdown_report(_multi_result())
+        assert "Scenario 1" in md
+
+    def test_custom_config(self):
+        cfg = MarkdownReportConfig(title="My Report")
+        md = generate_markdown_report(_analysis_result(), config=cfg, total_instances=8)
+        assert "# My Report" in md
+
+    def test_with_cost(self):
+        md = generate_markdown_report(
+            _analysis_result(), total_instances=8, cost_per_hour=5.0, currency="GBP"
+        )
+        assert "GBP" in md
+
+    def test_empty_candidates(self):
+        result = AnalysisResult(best=None, candidates=[], total_instances=4)
+        md = generate_markdown_report(result, total_instances=4)
+        assert "No candidates to display" in md


### PR DESCRIPTION
## Summary
Add Markdown report generation as an alternative to existing HTML reports.

## Changes
- **`md_report.py`**: `MarkdownReporter` class and `MarkdownReportConfig` Pydantic model
- **`cli.py`**: `--report-format markdown` option for analyze subcommand
- **`__init__.py`**: Export new public API
- **`test_md_report.py`**: 33 new tests

## Features
- Executive summary, SLA compliance, cost analysis, recommendations sections
- Configurable: toggle sections, set top-N candidates, custom title
- Single and multi-scenario support
- `generate_markdown_report()` programmatic API
- Embeddable in GitHub PRs and wiki pages

## Test Results
- 33 new tests, 587 total passing

Closes #60