### PR TITLE
feat: M27 — SLA Budget Allocation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -336,3 +336,14 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `generate` subcommand with `--config gen.yaml` and `--output benchmark.json`
 - Programmatic `generate_benchmark()` API
 - 33 new tests (620 total)
+
+### M27 — SLA Budget Allocation
+
+- `BudgetAllocator` class in `budget.py`
+- `BudgetAllocation`, `StageBudget`, `AllocationStrategy` Pydantic models
+- Analyze TTFT/TPOT contribution ratios from benchmark data at configurable percentiles
+- 4 allocation strategies: proportional, balanced, ttft-priority, tpot-priority
+- Feasibility check with headroom calculation
+- CLI `budget` subcommand with `--benchmark`, `--total-budget-ms`, `--strategy`, table + JSON output
+- Programmatic `allocate_budget()` API
+- 23 new tests (643 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -28,6 +28,13 @@ from xpyd_plan.benchmark_models import (
     SLACheck,
     UtilizationResult,
 )
+from xpyd_plan.budget import (
+    AllocationStrategy,
+    BudgetAllocation,
+    BudgetAllocator,
+    StageBudget,
+    allocate_budget,
+)
 from xpyd_plan.comparator import (
     BenchmarkComparator,
     ComparisonResult,
@@ -201,4 +208,9 @@ __all__ = [
     "LatencyProfile",
     "generate_benchmark",
     "load_generator_config",
+    "AllocationStrategy",
+    "BudgetAllocation",
+    "BudgetAllocator",
+    "StageBudget",
+    "allocate_budget",
 ]

--- a/src/xpyd_plan/budget.py
+++ b/src/xpyd_plan/budget.py
@@ -1,0 +1,165 @@
+"""SLA budget allocation across prefill and decode stages.
+
+Given a total latency budget, analyze benchmark data to determine how TTFT
+and TPOT contribute to total latency, then recommend per-stage SLA targets.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from xpyd_plan.benchmark_models import BenchmarkData
+
+
+class AllocationStrategy(str, Enum):
+    """Strategy for splitting total budget between TTFT and TPOT."""
+
+    PROPORTIONAL = "proportional"  # Match observed TTFT:TPOT ratio
+    BALANCED = "balanced"  # Equal split
+    TTFT_PRIORITY = "ttft-priority"  # Allocate more budget to TTFT
+    TPOT_PRIORITY = "tpot-priority"  # Allocate more budget to TPOT
+
+
+class StageBudget(BaseModel):
+    """Budget allocated to a single stage."""
+
+    stage: str = Field(..., description="Stage name (ttft or tpot)")
+    budget_ms: float = Field(..., ge=0, description="Allocated budget in ms")
+    share: float = Field(
+        ..., ge=0, le=1, description="Fraction of total budget"
+    )
+    observed_ms: float = Field(
+        ..., ge=0, description="Observed value at analysis percentile"
+    )
+    headroom_ms: float = Field(
+        ..., description="budget_ms - observed_ms (positive = slack)"
+    )
+
+
+class BudgetAllocation(BaseModel):
+    """Complete budget allocation result."""
+
+    total_budget_ms: float = Field(..., gt=0)
+    strategy: AllocationStrategy
+    percentile: float = Field(95.0, description="Percentile used for analysis")
+    ttft: StageBudget
+    tpot: StageBudget
+    observed_ratio: float = Field(
+        ..., description="Observed TTFT share of (TTFT+TPOT) at percentile"
+    )
+    feasible: bool = Field(
+        ...,
+        description="True if both stages have non-negative headroom",
+    )
+
+
+class BudgetAllocator:
+    """Allocate a total SLA budget across prefill and decode stages.
+
+    Analyzes benchmark data to determine the natural TTFT:TPOT ratio,
+    then splits the budget according to the chosen strategy.
+    """
+
+    def __init__(self, benchmark: BenchmarkData) -> None:
+        self._benchmark = benchmark
+        self._ttft_values = [r.ttft_ms for r in benchmark.requests]
+        self._tpot_values = [r.tpot_ms for r in benchmark.requests]
+
+    def _percentile(self, values: list[float], p: float) -> float:
+        if not values:
+            return 0.0
+        return float(np.percentile(values, p))
+
+    def allocate(
+        self,
+        total_budget_ms: float,
+        strategy: AllocationStrategy = AllocationStrategy.PROPORTIONAL,
+        percentile: float = 95.0,
+    ) -> BudgetAllocation:
+        """Allocate total_budget_ms between TTFT and TPOT.
+
+        Args:
+            total_budget_ms: Total latency budget in milliseconds.
+            strategy: Allocation strategy to use.
+            percentile: Percentile for analyzing observed latencies.
+
+        Returns:
+            BudgetAllocation with per-stage budgets.
+        """
+        ttft_obs = self._percentile(self._ttft_values, percentile)
+        tpot_obs = self._percentile(self._tpot_values, percentile)
+        total_obs = ttft_obs + tpot_obs
+
+        # Observed ratio (TTFT share)
+        observed_ratio = ttft_obs / total_obs if total_obs > 0 else 0.5
+
+        # Compute shares based on strategy
+        if strategy == AllocationStrategy.PROPORTIONAL:
+            ttft_share = observed_ratio
+        elif strategy == AllocationStrategy.BALANCED:
+            ttft_share = 0.5
+        elif strategy == AllocationStrategy.TTFT_PRIORITY:
+            # Give TTFT 70% of the budget
+            ttft_share = 0.7
+        elif strategy == AllocationStrategy.TPOT_PRIORITY:
+            # Give TTFT only 30% of the budget
+            ttft_share = 0.3
+        else:
+            ttft_share = observed_ratio
+
+        tpot_share = 1.0 - ttft_share
+        ttft_budget = total_budget_ms * ttft_share
+        tpot_budget = total_budget_ms * tpot_share
+
+        ttft_stage = StageBudget(
+            stage="ttft",
+            budget_ms=round(ttft_budget, 2),
+            share=round(ttft_share, 4),
+            observed_ms=round(ttft_obs, 2),
+            headroom_ms=round(ttft_budget - ttft_obs, 2),
+        )
+        tpot_stage = StageBudget(
+            stage="tpot",
+            budget_ms=round(tpot_budget, 2),
+            share=round(tpot_share, 4),
+            observed_ms=round(tpot_obs, 2),
+            headroom_ms=round(tpot_budget - tpot_obs, 2),
+        )
+
+        feasible = ttft_stage.headroom_ms >= 0 and tpot_stage.headroom_ms >= 0
+
+        return BudgetAllocation(
+            total_budget_ms=total_budget_ms,
+            strategy=strategy,
+            percentile=percentile,
+            ttft=ttft_stage,
+            tpot=tpot_stage,
+            observed_ratio=round(observed_ratio, 4),
+            feasible=feasible,
+        )
+
+
+def allocate_budget(
+    benchmark: BenchmarkData,
+    total_budget_ms: float,
+    strategy: str = "proportional",
+    percentile: float = 95.0,
+) -> dict:
+    """Programmatic API for SLA budget allocation.
+
+    Args:
+        benchmark: Loaded benchmark data.
+        total_budget_ms: Total latency budget in ms.
+        strategy: One of proportional, balanced, ttft-priority, tpot-priority.
+        percentile: Percentile for observed latency analysis.
+
+    Returns:
+        Dict with allocation results.
+    """
+    alloc_strategy = AllocationStrategy(strategy)
+    allocator = BudgetAllocator(benchmark)
+    result = allocator.allocate(total_budget_ms, alloc_strategy, percentile)
+    return result.model_dump()

--- a/src/xpyd_plan/cli.py
+++ b/src/xpyd_plan/cli.py
@@ -1575,6 +1575,55 @@ def _cmd_generate(args: argparse.Namespace) -> None:
         console.print(table)
 
 
+def _cmd_budget(args: argparse.Namespace) -> None:
+    """Handle 'budget' subcommand."""
+    import json as json_mod
+
+    from rich.console import Console
+    from rich.table import Table
+
+    from xpyd_plan.benchmark_models import BenchmarkData
+    from xpyd_plan.budget import AllocationStrategy, BudgetAllocator
+
+    console = Console()
+
+    bench_path = args.benchmark
+    with open(bench_path) as f:
+        data = json_mod.load(f)
+    benchmark = BenchmarkData.model_validate(data)
+
+    strategy = AllocationStrategy(args.strategy)
+    allocator = BudgetAllocator(benchmark)
+    result = allocator.allocate(
+        total_budget_ms=args.total_budget_ms,
+        strategy=strategy,
+        percentile=getattr(args, "sla_percentile", 95.0),
+    )
+
+    if args.output_format == "json":
+        console.print_json(json_mod.dumps(result.model_dump()))
+    else:
+        table = Table(title="SLA Budget Allocation")
+        table.add_column("Property", style="cyan")
+        table.add_column("Value", style="green")
+        table.add_row("Total budget", f"{result.total_budget_ms} ms")
+        table.add_row("Strategy", result.strategy.value)
+        table.add_row("Percentile", f"P{result.percentile}")
+        table.add_row("Observed TTFT:TPOT ratio", f"{result.observed_ratio:.2%}")
+        table.add_row("Feasible", "✅" if result.feasible else "❌")
+        table.add_row("", "")
+        table.add_row("TTFT budget", f"{result.ttft.budget_ms} ms ({result.ttft.share:.0%})")
+        table.add_row("TTFT observed", f"{result.ttft.observed_ms} ms")
+        table.add_row("TTFT headroom", f"{result.ttft.headroom_ms} ms")
+        table.add_row("", "")
+        table.add_row("TPOT budget", f"{result.tpot.budget_ms} ms ({result.tpot.share:.0%})")
+        table.add_row("TPOT observed", f"{result.tpot.observed_ms} ms")
+        table.add_row("TPOT headroom", f"{result.tpot.headroom_ms} ms")
+        console.print(table)
+
+    raise SystemExit(0)
+
+
 def main(argv: list[str] | None = None) -> None:
     """Entry point for `xpyd-plan` command."""
     parser = argparse.ArgumentParser(
@@ -2151,6 +2200,33 @@ def main(argv: list[str] | None = None) -> None:
         help="Output format (default: table)",
     )
 
+    # budget subcommand
+    budget_parser = subparsers.add_parser(
+        "budget",
+        help="Allocate SLA budget across prefill and decode stages",
+    )
+    budget_parser.add_argument(
+        "--benchmark", type=str, required=True,
+        help="Benchmark JSON file",
+    )
+    budget_parser.add_argument(
+        "--total-budget-ms", type=float, required=True,
+        help="Total latency budget in milliseconds",
+    )
+    budget_parser.add_argument(
+        "--strategy", type=str, default="proportional",
+        choices=["proportional", "balanced", "ttft-priority", "tpot-priority"],
+        help="Budget allocation strategy (default: proportional)",
+    )
+    budget_parser.add_argument(
+        "--sla-percentile", type=float, default=95.0,
+        help="Percentile for observed latency analysis (default: 95)",
+    )
+    budget_parser.add_argument(
+        "--output-format", type=str, choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "config":
@@ -2194,6 +2270,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_pipeline(args)
     elif args.command == "generate":
         _cmd_generate(args)
+    elif args.command == "budget":
+        _cmd_budget(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,312 @@
+"""Tests for the SLA budget allocation module (M27)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from xpyd_plan.benchmark_models import (
+    BenchmarkData,
+    BenchmarkMetadata,
+    BenchmarkRequest,
+)
+from xpyd_plan.budget import (
+    AllocationStrategy,
+    BudgetAllocation,
+    BudgetAllocator,
+    StageBudget,
+    allocate_budget,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_requests(
+    n: int = 100, ttft: float = 30.0, tpot: float = 10.0
+) -> list[dict]:
+    """Generate benchmark request dicts with known latencies."""
+    return [
+        {
+            "request_id": f"req-{i}",
+            "prompt_tokens": 128,
+            "output_tokens": 64,
+            "ttft_ms": ttft + (i % 10) * 0.5,
+            "tpot_ms": tpot + (i % 10) * 0.2,
+            "total_latency_ms": ttft + tpot * 64 + (i % 10) * 2.0,
+            "timestamp": 1700000000.0 + i,
+        }
+        for i in range(n)
+    ]
+
+
+def _make_benchmark(
+    n: int = 100, ttft: float = 30.0, tpot: float = 10.0
+) -> BenchmarkData:
+    """Create a BenchmarkData instance."""
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=6,
+            total_instances=8,
+            measured_qps=10.0,
+        ),
+        requests=[BenchmarkRequest(**r) for r in _make_requests(n, ttft, tpot)],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model Tests
+# ---------------------------------------------------------------------------
+
+
+class TestModels:
+    """Test Pydantic models."""
+
+    def test_stage_budget_creation(self):
+        sb = StageBudget(
+            stage="ttft",
+            budget_ms=100.0,
+            share=0.6,
+            observed_ms=80.0,
+            headroom_ms=20.0,
+        )
+        assert sb.stage == "ttft"
+        assert sb.budget_ms == 100.0
+        assert sb.headroom_ms == 20.0
+
+    def test_allocation_strategy_values(self):
+        assert AllocationStrategy.PROPORTIONAL == "proportional"
+        assert AllocationStrategy.BALANCED == "balanced"
+        assert AllocationStrategy.TTFT_PRIORITY == "ttft-priority"
+        assert AllocationStrategy.TPOT_PRIORITY == "tpot-priority"
+
+    def test_budget_allocation_serialization(self):
+        alloc = BudgetAllocation(
+            total_budget_ms=100.0,
+            strategy=AllocationStrategy.PROPORTIONAL,
+            percentile=95.0,
+            ttft=StageBudget(
+                stage="ttft", budget_ms=60.0, share=0.6,
+                observed_ms=50.0, headroom_ms=10.0,
+            ),
+            tpot=StageBudget(
+                stage="tpot", budget_ms=40.0, share=0.4,
+                observed_ms=30.0, headroom_ms=10.0,
+            ),
+            observed_ratio=0.625,
+            feasible=True,
+        )
+        d = alloc.model_dump()
+        assert d["strategy"] == "proportional"
+        assert d["feasible"] is True
+
+
+# ---------------------------------------------------------------------------
+# Allocator Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetAllocator:
+    """Test the BudgetAllocator class."""
+
+    def test_proportional_strategy(self):
+        bench = _make_benchmark(ttft=30.0, tpot=10.0)
+        allocator = BudgetAllocator(bench)
+        result = allocator.allocate(100.0, AllocationStrategy.PROPORTIONAL)
+        # TTFT ~30, TPOT ~10, ratio ~0.75
+        assert result.ttft.share > 0.5
+        assert result.tpot.share < 0.5
+        assert abs(result.ttft.share + result.tpot.share - 1.0) < 1e-6
+
+    def test_balanced_strategy(self):
+        bench = _make_benchmark(ttft=30.0, tpot=10.0)
+        allocator = BudgetAllocator(bench)
+        result = allocator.allocate(100.0, AllocationStrategy.BALANCED)
+        assert result.ttft.share == 0.5
+        assert result.tpot.share == 0.5
+        assert result.ttft.budget_ms == 50.0
+        assert result.tpot.budget_ms == 50.0
+
+    def test_ttft_priority_strategy(self):
+        bench = _make_benchmark()
+        allocator = BudgetAllocator(bench)
+        result = allocator.allocate(100.0, AllocationStrategy.TTFT_PRIORITY)
+        assert result.ttft.share == 0.7
+        assert result.tpot.share == 0.3
+
+    def test_tpot_priority_strategy(self):
+        bench = _make_benchmark()
+        allocator = BudgetAllocator(bench)
+        result = allocator.allocate(100.0, AllocationStrategy.TPOT_PRIORITY)
+        assert result.ttft.share == 0.3
+        assert result.tpot.share == 0.7
+
+    def test_feasibility_true(self):
+        bench = _make_benchmark(ttft=20.0, tpot=10.0)
+        allocator = BudgetAllocator(bench)
+        result = allocator.allocate(200.0, AllocationStrategy.PROPORTIONAL)
+        assert result.feasible is True
+        assert result.ttft.headroom_ms > 0
+        assert result.tpot.headroom_ms > 0
+
+    def test_feasibility_false_tight_budget(self):
+        bench = _make_benchmark(ttft=40.0, tpot=40.0)
+        allocator = BudgetAllocator(bench)
+        # Budget way too small for observed latencies
+        result = allocator.allocate(10.0, AllocationStrategy.BALANCED)
+        assert result.feasible is False
+
+    def test_percentile_affects_result(self):
+        bench = _make_benchmark(n=200, ttft=30.0, tpot=10.0)
+        allocator = BudgetAllocator(bench)
+        r50 = allocator.allocate(100.0, percentile=50.0)
+        r99 = allocator.allocate(100.0, percentile=99.0)
+        # P99 observed should be >= P50 observed
+        assert r99.ttft.observed_ms >= r50.ttft.observed_ms
+
+    def test_total_budget_preserved(self):
+        bench = _make_benchmark()
+        allocator = BudgetAllocator(bench)
+        result = allocator.allocate(500.0, AllocationStrategy.PROPORTIONAL)
+        total = result.ttft.budget_ms + result.tpot.budget_ms
+        assert abs(total - 500.0) < 0.1
+
+    def test_observed_ratio_range(self):
+        bench = _make_benchmark(ttft=50.0, tpot=50.0)
+        allocator = BudgetAllocator(bench)
+        result = allocator.allocate(200.0, AllocationStrategy.PROPORTIONAL)
+        assert 0.0 <= result.observed_ratio <= 1.0
+
+    def test_headroom_calculation(self):
+        bench = _make_benchmark(ttft=20.0, tpot=10.0)
+        allocator = BudgetAllocator(bench)
+        result = allocator.allocate(100.0, AllocationStrategy.BALANCED)
+        assert result.ttft.headroom_ms == pytest.approx(
+            result.ttft.budget_ms - result.ttft.observed_ms, abs=0.1
+        )
+        assert result.tpot.headroom_ms == pytest.approx(
+            result.tpot.budget_ms - result.tpot.observed_ms, abs=0.1
+        )
+
+    def test_small_dataset(self):
+        """Allocator works with minimal data."""
+        bench = BenchmarkData(
+            metadata=BenchmarkMetadata(
+                num_prefill_instances=1,
+                num_decode_instances=1,
+                total_instances=2,
+                measured_qps=1.0,
+            ),
+            requests=[
+                BenchmarkRequest(
+                    request_id="r1",
+                    prompt_tokens=10,
+                    output_tokens=10,
+                    ttft_ms=20.0,
+                    tpot_ms=5.0,
+                    total_latency_ms=70.0,
+                    timestamp=1700000000.0,
+                )
+            ],
+        )
+        allocator = BudgetAllocator(bench)
+        result = allocator.allocate(50.0)
+        assert result.total_budget_ms == 50.0
+
+    def test_equal_latencies(self):
+        bench = _make_benchmark(ttft=25.0, tpot=25.0)
+        allocator = BudgetAllocator(bench)
+        result = allocator.allocate(100.0, AllocationStrategy.PROPORTIONAL)
+        # Should be close to 50/50
+        assert abs(result.ttft.share - 0.5) < 0.05
+
+
+# ---------------------------------------------------------------------------
+# Programmatic API Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAllocateBudgetAPI:
+    """Test the allocate_budget() function."""
+
+    def test_returns_dict(self):
+        bench = _make_benchmark()
+        result = allocate_budget(bench, 100.0)
+        assert isinstance(result, dict)
+        assert "ttft" in result
+        assert "tpot" in result
+        assert "feasible" in result
+
+    def test_strategy_string(self):
+        bench = _make_benchmark()
+        result = allocate_budget(bench, 100.0, strategy="balanced")
+        assert result["strategy"] == "balanced"
+        assert result["ttft"]["share"] == 0.5
+
+    def test_all_strategies(self):
+        bench = _make_benchmark()
+        for s in ["proportional", "balanced", "ttft-priority", "tpot-priority"]:
+            result = allocate_budget(bench, 100.0, strategy=s)
+            assert result["strategy"] == s
+
+    def test_custom_percentile(self):
+        bench = _make_benchmark()
+        result = allocate_budget(bench, 100.0, percentile=99.0)
+        assert result["percentile"] == 99.0
+
+    def test_invalid_strategy_raises(self):
+        bench = _make_benchmark()
+        with pytest.raises(ValueError):
+            allocate_budget(bench, 100.0, strategy="invalid")
+
+    def test_json_serializable(self):
+        bench = _make_benchmark()
+        result = allocate_budget(bench, 200.0, strategy="proportional")
+        serialized = json.dumps(result)
+        assert "ttft" in serialized
+
+
+# ---------------------------------------------------------------------------
+# CLI Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetCLI:
+    """Test the budget CLI subcommand."""
+
+    def test_budget_table_output(self, tmp_path):
+        bench = _make_benchmark()
+        bench_file = tmp_path / "bench.json"
+        bench_file.write_text(bench.model_dump_json())
+
+
+        from xpyd_plan.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main([
+                "budget",
+                "--benchmark", str(bench_file),
+                "--total-budget-ms", "100",
+            ])
+        # Should exit 0 on success
+        assert exc.value.code is None or exc.value.code == 0
+
+    def test_budget_json_output(self, tmp_path):
+        bench = _make_benchmark()
+        bench_file = tmp_path / "bench.json"
+        bench_file.write_text(bench.model_dump_json())
+
+        from xpyd_plan.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main([
+                "budget",
+                "--benchmark", str(bench_file),
+                "--total-budget-ms", "100",
+                "--strategy", "balanced",
+                "--output-format", "json",
+            ])
+        assert exc.value.code is None or exc.value.code == 0


### PR DESCRIPTION
## Summary

Add SLA budget allocation feature that splits a total latency budget between TTFT and TPOT stages based on benchmark data analysis.

## Changes

- `BudgetAllocator` class in `budget.py` — analyzes benchmark data to determine TTFT:TPOT ratio
- `BudgetAllocation`, `StageBudget`, `AllocationStrategy` Pydantic models
- 4 allocation strategies: proportional, balanced, ttft-priority, tpot-priority
- Feasibility check with per-stage headroom calculation
- CLI `budget` subcommand with `--benchmark`, `--total-budget-ms`, `--strategy`, table + JSON output
- Programmatic `allocate_budget()` API
- Updated `__init__.py` exports
- Updated ROADMAP.md with M27

## Tests

23 new tests, 643 total — all passing.

Closes #65