### PR TITLE
feat: M28 — Benchmark Merge & Aggregation

### DIFF
--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -80,6 +80,13 @@ from xpyd_plan.md_report import (
     MarkdownReporter,
     generate_markdown_report,
 )
+from xpyd_plan.merger import (
+    BenchmarkMerger,
+    MergeConfig,
+    MergeResult,
+    MergeStrategy,
+    merge_benchmarks,
+)
 from xpyd_plan.models import (
     DatasetStats,
     GPUProfile,
@@ -200,6 +207,11 @@ __all__ = [
     "MarkdownReportConfig",
     "MarkdownReporter",
     "generate_markdown_report",
+    "BenchmarkMerger",
+    "MergeConfig",
+    "MergeResult",
+    "MergeStrategy",
+    "merge_benchmarks",
     "AnomalyConfig",
     "AnomalyType",
     "BenchmarkGenerator",

--- a/src/xpyd_plan/cli.py
+++ b/src/xpyd_plan/cli.py
@@ -1624,6 +1624,60 @@ def _cmd_budget(args: argparse.Namespace) -> None:
     raise SystemExit(0)
 
 
+def _cmd_merge(args: argparse.Namespace) -> None:
+    """Handle 'merge' subcommand."""
+    import json as json_mod
+
+    from rich.console import Console
+    from rich.table import Table
+
+    from xpyd_plan.benchmark_models import BenchmarkData
+    from xpyd_plan.merger import BenchmarkMerger, MergeConfig, MergeStrategy
+
+    console = Console()
+
+    datasets = []
+    for path in args.benchmark:
+        with open(path) as f:
+            data = json_mod.load(f)
+        datasets.append(BenchmarkData.model_validate(data))
+
+    config = MergeConfig(
+        strategy=MergeStrategy(args.strategy),
+        require_same_config=not args.no_config_check,
+    )
+    merger = BenchmarkMerger(config)
+    result = merger.merge(datasets)
+
+    # Write merged benchmark to output file
+    with open(args.output, "w") as f:
+        f.write(result.merged.model_dump_json(indent=2))
+
+    if args.output_format == "json":
+        summary = {
+            "source_count": result.source_count,
+            "total_requests_before": result.total_requests_before,
+            "total_requests_after": result.total_requests_after,
+            "duplicates_removed": result.duplicates_removed,
+            "strategy_used": result.strategy_used.value,
+            "output_file": args.output,
+        }
+        console.print_json(json_mod.dumps(summary))
+    else:
+        table = Table(title="Benchmark Merge Result")
+        table.add_column("Property", style="cyan")
+        table.add_column("Value", style="green")
+        table.add_row("Sources merged", str(result.source_count))
+        table.add_row("Strategy", result.strategy_used.value)
+        table.add_row("Requests before", str(result.total_requests_before))
+        table.add_row("Requests after", str(result.total_requests_after))
+        table.add_row("Duplicates removed", str(result.duplicates_removed))
+        table.add_row("Output file", args.output)
+        console.print(table)
+
+    raise SystemExit(0)
+
+
 def main(argv: list[str] | None = None) -> None:
     """Entry point for `xpyd-plan` command."""
     parser = argparse.ArgumentParser(
@@ -2201,6 +2255,32 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     # budget subcommand
+    merge_parser = subparsers.add_parser(
+        "merge",
+        help="Merge multiple benchmark files into one aggregated dataset",
+    )
+    merge_parser.add_argument(
+        "--benchmark", type=str, action="append", required=True,
+        help="Benchmark JSON file (specify multiple times)",
+    )
+    merge_parser.add_argument(
+        "--output", type=str, required=True,
+        help="Output file path for merged benchmark JSON",
+    )
+    merge_parser.add_argument(
+        "--strategy", type=str, default="union",
+        choices=["union", "intersection"],
+        help="Merge strategy for overlapping request IDs (default: union)",
+    )
+    merge_parser.add_argument(
+        "--no-config-check", action="store_true",
+        help="Allow merging benchmarks with different cluster configurations",
+    )
+    merge_parser.add_argument(
+        "--output-format", type=str, choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
+
     budget_parser = subparsers.add_parser(
         "budget",
         help="Allocate SLA budget across prefill and decode stages",
@@ -2272,6 +2352,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_generate(args)
     elif args.command == "budget":
         _cmd_budget(args)
+    elif args.command == "merge":
+        _cmd_merge(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/merger.py
+++ b/src/xpyd_plan/merger.py
@@ -1,0 +1,174 @@
+"""Benchmark merge and aggregation — combine multiple benchmark files."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+
+
+class MergeStrategy(str, Enum):
+    """Strategy for handling overlapping request IDs."""
+
+    UNION = "union"
+    INTERSECTION = "intersection"
+
+
+class MergeConfig(BaseModel):
+    """Configuration for benchmark merging."""
+
+    strategy: MergeStrategy = Field(
+        MergeStrategy.UNION,
+        description="How to handle overlapping request IDs",
+    )
+    require_same_config: bool = Field(
+        True,
+        description="Require all benchmarks to have identical cluster configuration",
+    )
+
+
+class MergeResult(BaseModel):
+    """Result of benchmark merge operation."""
+
+    merged: BenchmarkData
+    source_count: int = Field(..., ge=2, description="Number of source benchmark files merged")
+    total_requests_before: int = Field(..., description="Total requests across all sources")
+    total_requests_after: int = Field(..., description="Requests in merged dataset")
+    duplicates_removed: int = Field(0, description="Duplicate request IDs resolved")
+    strategy_used: MergeStrategy
+
+
+class BenchmarkMerger:
+    """Merge multiple benchmark datasets into one aggregated dataset."""
+
+    def __init__(self, config: MergeConfig | None = None) -> None:
+        self.config = config or MergeConfig()
+
+    def merge(self, datasets: list[BenchmarkData]) -> MergeResult:
+        """Merge multiple benchmark datasets.
+
+        Args:
+            datasets: List of BenchmarkData to merge (minimum 2).
+
+        Returns:
+            MergeResult with merged data and merge statistics.
+
+        Raises:
+            ValueError: If fewer than 2 datasets, or incompatible configurations.
+        """
+        if len(datasets) < 2:
+            raise ValueError("At least 2 benchmark datasets are required for merging")
+
+        if self.config.require_same_config:
+            self._validate_compatible(datasets)
+
+        total_before = sum(len(d.requests) for d in datasets)
+
+        if self.config.strategy == MergeStrategy.UNION:
+            merged_requests = self._merge_union(datasets)
+        else:
+            merged_requests = self._merge_intersection(datasets)
+
+        if not merged_requests:
+            raise ValueError(
+                "Merge produced an empty dataset — no common requests found "
+                "(intersection strategy with disjoint datasets)"
+            )
+
+        # Aggregate metadata
+        metadata = self._aggregate_metadata(datasets, merged_requests)
+
+        merged_data = BenchmarkData(metadata=metadata, requests=merged_requests)
+
+        return MergeResult(
+            merged=merged_data,
+            source_count=len(datasets),
+            total_requests_before=total_before,
+            total_requests_after=len(merged_requests),
+            duplicates_removed=total_before - len(merged_requests),
+            strategy_used=self.config.strategy,
+        )
+
+    def _validate_compatible(self, datasets: list[BenchmarkData]) -> None:
+        """Ensure all datasets have the same cluster configuration."""
+        ref = datasets[0].metadata
+        for i, ds in enumerate(datasets[1:], start=2):
+            m = ds.metadata
+            if (
+                m.num_prefill_instances != ref.num_prefill_instances
+                or m.num_decode_instances != ref.num_decode_instances
+                or m.total_instances != ref.total_instances
+            ):
+                raise ValueError(
+                    f"Incompatible cluster config: dataset 1 has "
+                    f"{ref.num_prefill_instances}P:{ref.num_decode_instances}D, "
+                    f"dataset {i} has {m.num_prefill_instances}P:{m.num_decode_instances}D"
+                )
+
+    def _merge_union(self, datasets: list[BenchmarkData]) -> list[BenchmarkRequest]:
+        """Union merge: keep all unique requests; first occurrence wins for duplicates."""
+        seen: dict[str, BenchmarkRequest] = {}
+        for ds in datasets:
+            for req in ds.requests:
+                if req.request_id not in seen:
+                    seen[req.request_id] = req
+        return sorted(seen.values(), key=lambda r: r.timestamp)
+
+    def _merge_intersection(self, datasets: list[BenchmarkData]) -> list[BenchmarkRequest]:
+        """Intersection merge: keep only requests present in ALL datasets."""
+        # Find common request IDs
+        id_sets = [set(r.request_id for r in ds.requests) for ds in datasets]
+        common_ids = id_sets[0]
+        for s in id_sets[1:]:
+            common_ids &= s
+
+        # Take from first dataset for consistent values
+        first_map = {r.request_id: r for r in datasets[0].requests}
+        return sorted(
+            [first_map[rid] for rid in common_ids if rid in first_map],
+            key=lambda r: r.timestamp,
+        )
+
+    def _aggregate_metadata(
+        self,
+        datasets: list[BenchmarkData],
+        merged_requests: list[BenchmarkRequest],
+    ) -> BenchmarkMetadata:
+        """Compute aggregated metadata from merged datasets."""
+        ref = datasets[0].metadata
+
+        # Combined QPS: sum of individual QPS values (more data from same config)
+        combined_qps = sum(d.metadata.measured_qps for d in datasets)
+
+        return BenchmarkMetadata(
+            num_prefill_instances=ref.num_prefill_instances,
+            num_decode_instances=ref.num_decode_instances,
+            total_instances=ref.total_instances,
+            measured_qps=combined_qps,
+        )
+
+
+def merge_benchmarks(
+    datasets: list[BenchmarkData],
+    strategy: str = "union",
+    require_same_config: bool = True,
+) -> dict:
+    """Programmatic API for merging benchmarks.
+
+    Args:
+        datasets: List of BenchmarkData to merge.
+        strategy: "union" or "intersection".
+        require_same_config: Whether to require identical cluster configs.
+
+    Returns:
+        Dict with merge results.
+    """
+    config = MergeConfig(
+        strategy=MergeStrategy(strategy),
+        require_same_config=require_same_config,
+    )
+    merger = BenchmarkMerger(config)
+    result = merger.merge(datasets)
+    return result.model_dump()

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -1,0 +1,273 @@
+"""Tests for benchmark merge and aggregation."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.merger import (
+    BenchmarkMerger,
+    MergeConfig,
+    MergeStrategy,
+    merge_benchmarks,
+)
+
+
+def _make_request(rid: str, ts: float = 1000.0) -> BenchmarkRequest:
+    return BenchmarkRequest(
+        request_id=rid,
+        prompt_tokens=100,
+        output_tokens=50,
+        ttft_ms=20.0,
+        tpot_ms=5.0,
+        total_latency_ms=270.0,
+        timestamp=ts,
+    )
+
+
+def _make_benchmark(
+    request_ids: list[str],
+    prefill: int = 2,
+    decode: int = 2,
+    qps: float = 10.0,
+    base_ts: float = 1000.0,
+) -> BenchmarkData:
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=prefill,
+            num_decode_instances=decode,
+            total_instances=prefill + decode,
+            measured_qps=qps,
+        ),
+        requests=[_make_request(rid, base_ts + i) for i, rid in enumerate(request_ids)],
+    )
+
+
+class TestBenchmarkMerger:
+    """Tests for BenchmarkMerger class."""
+
+    def test_merge_union_no_overlap(self):
+        ds1 = _make_benchmark(["a1", "a2", "a3"], qps=10.0)
+        ds2 = _make_benchmark(["b1", "b2", "b3"], qps=12.0, base_ts=2000.0)
+        merger = BenchmarkMerger()
+        result = merger.merge([ds1, ds2])
+
+        assert result.source_count == 2
+        assert result.total_requests_before == 6
+        assert result.total_requests_after == 6
+        assert result.duplicates_removed == 0
+        assert result.strategy_used == MergeStrategy.UNION
+        assert len(result.merged.requests) == 6
+
+    def test_merge_union_with_duplicates(self):
+        ds1 = _make_benchmark(["a1", "a2", "shared1"], qps=10.0)
+        ds2 = _make_benchmark(["shared1", "b1", "b2"], qps=12.0, base_ts=2000.0)
+        merger = BenchmarkMerger()
+        result = merger.merge([ds1, ds2])
+
+        assert result.total_requests_before == 6
+        assert result.total_requests_after == 5
+        assert result.duplicates_removed == 1
+        # First occurrence wins — shared1 should have ds1 timestamp
+        shared = [r for r in result.merged.requests if r.request_id == "shared1"]
+        assert len(shared) == 1
+        assert shared[0].timestamp == 1002.0  # 3rd request in ds1
+
+    def test_merge_intersection(self):
+        ds1 = _make_benchmark(["a1", "shared1", "shared2"], qps=10.0)
+        ds2 = _make_benchmark(["shared1", "shared2", "b1"], qps=12.0, base_ts=2000.0)
+        config = MergeConfig(strategy=MergeStrategy.INTERSECTION)
+        merger = BenchmarkMerger(config)
+        result = merger.merge([ds1, ds2])
+
+        assert result.total_requests_after == 2
+        ids = {r.request_id for r in result.merged.requests}
+        assert ids == {"shared1", "shared2"}
+
+    def test_merge_intersection_empty_raises(self):
+        ds1 = _make_benchmark(["a1", "a2"], qps=10.0)
+        ds2 = _make_benchmark(["b1", "b2"], qps=12.0, base_ts=2000.0)
+        config = MergeConfig(strategy=MergeStrategy.INTERSECTION)
+        merger = BenchmarkMerger(config)
+        with pytest.raises(ValueError, match="empty dataset"):
+            merger.merge([ds1, ds2])
+
+    def test_merge_less_than_two_raises(self):
+        ds1 = _make_benchmark(["a1", "a2"], qps=10.0)
+        merger = BenchmarkMerger()
+        with pytest.raises(ValueError, match="At least 2"):
+            merger.merge([ds1])
+
+    def test_merge_incompatible_config_raises(self):
+        ds1 = _make_benchmark(["a1", "a2"], prefill=2, decode=2, qps=10.0)
+        ds2 = _make_benchmark(["b1", "b2"], prefill=3, decode=1, qps=10.0, base_ts=2000.0)
+        merger = BenchmarkMerger()
+        with pytest.raises(ValueError, match="Incompatible cluster config"):
+            merger.merge([ds1, ds2])
+
+    def test_merge_incompatible_config_allowed(self):
+        ds1 = _make_benchmark(["a1", "a2"], prefill=2, decode=2, qps=10.0)
+        ds2 = _make_benchmark(["b1", "b2"], prefill=3, decode=1, qps=10.0, base_ts=2000.0)
+        config = MergeConfig(require_same_config=False)
+        merger = BenchmarkMerger(config)
+        result = merger.merge([ds1, ds2])
+        assert result.total_requests_after == 4
+
+    def test_merge_aggregated_metadata(self):
+        ds1 = _make_benchmark(["a1", "a2"], qps=10.0)
+        ds2 = _make_benchmark(["b1", "b2"], qps=15.0, base_ts=2000.0)
+        merger = BenchmarkMerger()
+        result = merger.merge([ds1, ds2])
+
+        assert result.merged.metadata.measured_qps == 25.0
+        assert result.merged.metadata.num_prefill_instances == 2
+        assert result.merged.metadata.num_decode_instances == 2
+
+    def test_merge_three_datasets(self):
+        ds1 = _make_benchmark(["a1", "a2"], qps=10.0)
+        ds2 = _make_benchmark(["b1", "b2"], qps=12.0, base_ts=2000.0)
+        ds3 = _make_benchmark(["c1", "c2"], qps=8.0, base_ts=3000.0)
+        merger = BenchmarkMerger()
+        result = merger.merge([ds1, ds2, ds3])
+
+        assert result.source_count == 3
+        assert result.total_requests_after == 6
+        assert result.merged.metadata.measured_qps == 30.0
+
+    def test_merge_sorted_by_timestamp(self):
+        ds1 = _make_benchmark(["a1", "a2"], qps=10.0, base_ts=2000.0)
+        ds2 = _make_benchmark(["b1", "b2"], qps=10.0, base_ts=1000.0)
+        merger = BenchmarkMerger()
+        result = merger.merge([ds1, ds2])
+
+        timestamps = [r.timestamp for r in result.merged.requests]
+        assert timestamps == sorted(timestamps)
+
+    def test_merge_intersection_three_datasets(self):
+        ds1 = _make_benchmark(["s1", "s2", "a1"], qps=10.0)
+        ds2 = _make_benchmark(["s1", "s2", "b1"], qps=10.0, base_ts=2000.0)
+        ds3 = _make_benchmark(["s1", "s2", "c1"], qps=10.0, base_ts=3000.0)
+        config = MergeConfig(strategy=MergeStrategy.INTERSECTION)
+        merger = BenchmarkMerger(config)
+        result = merger.merge([ds1, ds2, ds3])
+
+        assert result.total_requests_after == 2
+        ids = {r.request_id for r in result.merged.requests}
+        assert ids == {"s1", "s2"}
+
+    def test_default_config(self):
+        config = MergeConfig()
+        assert config.strategy == MergeStrategy.UNION
+        assert config.require_same_config is True
+
+
+class TestMergeResult:
+    """Tests for MergeResult model."""
+
+    def test_model_serialization(self):
+        ds1 = _make_benchmark(["a1", "a2"], qps=10.0)
+        ds2 = _make_benchmark(["b1", "b2"], qps=10.0, base_ts=2000.0)
+        merger = BenchmarkMerger()
+        result = merger.merge([ds1, ds2])
+
+        data = result.model_dump()
+        assert data["source_count"] == 2
+        assert data["strategy_used"] == "union"
+
+
+class TestMergeBenchmarksAPI:
+    """Tests for the programmatic merge_benchmarks() API."""
+
+    def test_api_union(self):
+        ds1 = _make_benchmark(["a1", "a2"], qps=10.0)
+        ds2 = _make_benchmark(["b1", "b2"], qps=10.0, base_ts=2000.0)
+        result = merge_benchmarks([ds1, ds2])
+
+        assert result["source_count"] == 2
+        assert result["total_requests_after"] == 4
+        assert result["strategy_used"] == "union"
+
+    def test_api_intersection(self):
+        ds1 = _make_benchmark(["s1", "a1"], qps=10.0)
+        ds2 = _make_benchmark(["s1", "b1"], qps=10.0, base_ts=2000.0)
+        result = merge_benchmarks([ds1, ds2], strategy="intersection")
+
+        assert result["total_requests_after"] == 1
+        assert result["strategy_used"] == "intersection"
+
+    def test_api_no_config_check(self):
+        ds1 = _make_benchmark(["a1"], prefill=2, decode=2, qps=10.0)
+        ds2 = _make_benchmark(["b1"], prefill=3, decode=1, qps=10.0, base_ts=2000.0)
+        result = merge_benchmarks([ds1, ds2], require_same_config=False)
+        assert result["total_requests_after"] == 2
+
+    def test_api_invalid_strategy_raises(self):
+        ds1 = _make_benchmark(["a1"], qps=10.0)
+        ds2 = _make_benchmark(["b1"], qps=10.0, base_ts=2000.0)
+        with pytest.raises(ValueError):
+            merge_benchmarks([ds1, ds2], strategy="invalid")
+
+
+class TestMergeCLI:
+    """Tests for CLI merge subcommand integration."""
+
+    def test_merge_subcommand_help(self):
+        """Verify the merge subcommand is registered in CLI."""
+        from xpyd_plan.cli import main
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(["merge", "--help"])
+        assert exc_info.value.code == 0
+
+    def test_merge_subcommand_runs(self):
+        """End-to-end CLI merge test."""
+        from xpyd_plan.cli import main
+
+        ds1 = _make_benchmark(["a1", "a2", "a3"], qps=10.0)
+        ds2 = _make_benchmark(["b1", "b2", "b3"], qps=12.0, base_ts=2000.0)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f1:
+            f1.write(ds1.model_dump_json())
+            f1_path = f1.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f2:
+            f2.write(ds2.model_dump_json())
+            f2_path = f2.name
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as out:
+            out_path = out.name
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(["merge", "--benchmark", f1_path, "--benchmark", f2_path, "--output", out_path])
+        assert exc_info.value.code == 0
+
+        with open(out_path) as f:
+            merged = json.load(f)
+        assert len(merged["requests"]) == 6
+
+    def test_merge_json_output(self):
+        """CLI merge with JSON output format."""
+        from xpyd_plan.cli import main
+
+        ds1 = _make_benchmark(["a1", "a2"], qps=10.0)
+        ds2 = _make_benchmark(["b1", "b2"], qps=12.0, base_ts=2000.0)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f1:
+            f1.write(ds1.model_dump_json())
+            f1_path = f1.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f2:
+            f2.write(ds2.model_dump_json())
+            f2_path = f2.name
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as out:
+            out_path = out.name
+
+        with pytest.raises(SystemExit) as exc_info:
+            main([
+                "merge",
+                "--benchmark", f1_path,
+                "--benchmark", f2_path,
+                "--output", out_path,
+                "--output-format", "json",
+            ])
+        assert exc_info.value.code == 0


### PR DESCRIPTION
## Summary

Add benchmark merge and aggregation capability — combine multiple benchmark files from identical P:D configurations into a single aggregated dataset for more statistically robust analysis.

## Changes

- **`merger.py`**: `BenchmarkMerger` class with `merge()` method
- **`MergeConfig`**, **`MergeResult`**, **`MergeStrategy`** Pydantic models
- Union strategy: keep all unique requests, first occurrence wins for duplicates
- Intersection strategy: keep only requests present in all files
- Validates compatible cluster configurations (can be disabled)
- Aggregated metadata: combined QPS from all sources
- **CLI** `merge` subcommand with `--benchmark`, `--output`, `--strategy`, `--output-format`
- **Programmatic API**: `merge_benchmarks()` function
- **20 new tests** (663 total, all passing)
- Lint clean: ruff + isort pass

Closes #67