### PR TITLE
feat: M29 — Benchmark Filtering & Slicing

### DIFF
--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -48,6 +48,12 @@ from xpyd_plan.dashboard import (
     DashboardView,
     run_dashboard,
 )
+from xpyd_plan.filter import (
+    BenchmarkFilter,
+    BenchmarkFilterResult,
+    FilterConfig,
+    filter_benchmark,
+)
 from xpyd_plan.fleet import (
     FleetAllocation,
     FleetCalculator,
@@ -225,4 +231,8 @@ __all__ = [
     "BudgetAllocator",
     "StageBudget",
     "allocate_budget",
+    "BenchmarkFilter",
+    "BenchmarkFilterResult",
+    "FilterConfig",
+    "filter_benchmark",
 ]

--- a/src/xpyd_plan/cli.py
+++ b/src/xpyd_plan/cli.py
@@ -1678,6 +1678,71 @@ def _cmd_merge(args: argparse.Namespace) -> None:
     raise SystemExit(0)
 
 
+def _cmd_filter(args: argparse.Namespace) -> None:
+    """Handle 'filter' subcommand."""
+    import json as json_mod
+
+    from rich.console import Console
+    from rich.table import Table
+
+    from xpyd_plan.benchmark_models import BenchmarkData
+    from xpyd_plan.filter import BenchmarkFilter, FilterConfig
+
+    console = Console()
+
+    with open(args.benchmark) as f:
+        data = BenchmarkData.model_validate(json_mod.load(f))
+
+    config = FilterConfig(
+        min_prompt_tokens=args.min_prompt_tokens,
+        max_prompt_tokens=args.max_prompt_tokens,
+        min_output_tokens=args.min_output_tokens,
+        max_output_tokens=args.max_output_tokens,
+        min_ttft_ms=args.min_ttft_ms,
+        max_ttft_ms=args.max_ttft_ms,
+        min_tpot_ms=args.min_tpot_ms,
+        max_tpot_ms=args.max_tpot_ms,
+        min_total_latency_ms=args.min_total_latency_ms,
+        max_total_latency_ms=args.max_total_latency_ms,
+        time_start=args.time_start,
+        time_end=args.time_end,
+        sample_count=args.sample_count,
+        sample_fraction=args.sample_fraction,
+        seed=args.seed,
+    )
+
+    bf = BenchmarkFilter(config)
+    result = bf.apply(data)
+
+    # Write filtered benchmark to output file
+    with open(args.output, "w") as f:
+        f.write(result.data.model_dump_json(indent=2))
+
+    if args.output_format == "json":
+        summary = {
+            "original_count": result.original_count,
+            "filtered_count": result.filtered_count,
+            "removed_count": result.removed_count,
+            "retention_rate": round(result.retention_rate, 4),
+            "filters_applied": result.filters_applied,
+            "output_file": args.output,
+        }
+        console.print_json(json_mod.dumps(summary))
+    else:
+        table = Table(title="Benchmark Filter Result")
+        table.add_column("Property", style="cyan")
+        table.add_column("Value", style="green")
+        table.add_row("Original requests", str(result.original_count))
+        table.add_row("Filtered requests", str(result.filtered_count))
+        table.add_row("Removed", str(result.removed_count))
+        table.add_row("Retention rate", f"{result.retention_rate:.1%}")
+        table.add_row("Filters applied", ", ".join(result.filters_applied) or "none")
+        table.add_row("Output file", args.output)
+        console.print(table)
+
+    raise SystemExit(0)
+
+
 def main(argv: list[str] | None = None) -> None:
     """Entry point for `xpyd-plan` command."""
     parser = argparse.ArgumentParser(
@@ -2307,6 +2372,84 @@ def main(argv: list[str] | None = None) -> None:
         help="Output format (default: table)",
     )
 
+    # filter subcommand
+    filter_parser = subparsers.add_parser(
+        "filter",
+        help="Filter benchmark data by token count, latency, time window, or sampling",
+    )
+    filter_parser.add_argument(
+        "--benchmark", type=str, required=True,
+        help="Benchmark JSON file",
+    )
+    filter_parser.add_argument(
+        "--output", type=str, required=True,
+        help="Output file path for filtered benchmark JSON",
+    )
+    filter_parser.add_argument(
+        "--min-prompt-tokens", type=int, default=None,
+        help="Minimum prompt token count",
+    )
+    filter_parser.add_argument(
+        "--max-prompt-tokens", type=int, default=None,
+        help="Maximum prompt token count",
+    )
+    filter_parser.add_argument(
+        "--min-output-tokens", type=int, default=None,
+        help="Minimum output token count",
+    )
+    filter_parser.add_argument(
+        "--max-output-tokens", type=int, default=None,
+        help="Maximum output token count",
+    )
+    filter_parser.add_argument(
+        "--min-ttft-ms", type=float, default=None,
+        help="Minimum TTFT (ms)",
+    )
+    filter_parser.add_argument(
+        "--max-ttft-ms", type=float, default=None,
+        help="Maximum TTFT (ms)",
+    )
+    filter_parser.add_argument(
+        "--min-tpot-ms", type=float, default=None,
+        help="Minimum TPOT (ms)",
+    )
+    filter_parser.add_argument(
+        "--max-tpot-ms", type=float, default=None,
+        help="Maximum TPOT (ms)",
+    )
+    filter_parser.add_argument(
+        "--min-total-latency-ms", type=float, default=None,
+        help="Minimum total latency (ms)",
+    )
+    filter_parser.add_argument(
+        "--max-total-latency-ms", type=float, default=None,
+        help="Maximum total latency (ms)",
+    )
+    filter_parser.add_argument(
+        "--time-start", type=float, default=None,
+        help="Start timestamp (epoch seconds)",
+    )
+    filter_parser.add_argument(
+        "--time-end", type=float, default=None,
+        help="End timestamp (epoch seconds)",
+    )
+    filter_parser.add_argument(
+        "--sample-count", type=int, default=None,
+        help="Random sample N requests",
+    )
+    filter_parser.add_argument(
+        "--sample-fraction", type=float, default=None,
+        help="Random sample fraction (0, 1]",
+    )
+    filter_parser.add_argument(
+        "--seed", type=int, default=None,
+        help="Random seed for reproducible sampling",
+    )
+    filter_parser.add_argument(
+        "--output-format", type=str, choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "config":
@@ -2354,6 +2497,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_budget(args)
     elif args.command == "merge":
         _cmd_merge(args)
+    elif args.command == "filter":
+        _cmd_filter(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/filter.py
+++ b/src/xpyd_plan/filter.py
@@ -1,0 +1,199 @@
+"""Benchmark filtering and slicing — select subsets of benchmark data by criteria."""
+
+from __future__ import annotations
+
+import random
+from typing import Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+from .benchmark_models import BenchmarkData, BenchmarkRequest
+
+
+class FilterConfig(BaseModel):
+    """Configuration for filtering benchmark requests."""
+
+    min_prompt_tokens: Optional[int] = Field(None, ge=1, description="Minimum prompt tokens")
+    max_prompt_tokens: Optional[int] = Field(None, ge=1, description="Maximum prompt tokens")
+    min_output_tokens: Optional[int] = Field(None, ge=1, description="Minimum output tokens")
+    max_output_tokens: Optional[int] = Field(None, ge=1, description="Maximum output tokens")
+    min_ttft_ms: Optional[float] = Field(None, ge=0, description="Minimum TTFT (ms)")
+    max_ttft_ms: Optional[float] = Field(None, ge=0, description="Maximum TTFT (ms)")
+    min_tpot_ms: Optional[float] = Field(None, ge=0, description="Minimum TPOT (ms)")
+    max_tpot_ms: Optional[float] = Field(None, ge=0, description="Maximum TPOT (ms)")
+    min_total_latency_ms: Optional[float] = Field(
+        None, ge=0, description="Minimum total latency (ms)"
+    )
+    max_total_latency_ms: Optional[float] = Field(
+        None, ge=0, description="Maximum total latency (ms)"
+    )
+    time_start: Optional[float] = Field(None, description="Start timestamp (epoch seconds)")
+    time_end: Optional[float] = Field(None, description="End timestamp (epoch seconds)")
+    sample_count: Optional[int] = Field(None, ge=1, description="Random sample N requests")
+    sample_fraction: Optional[float] = Field(
+        None, gt=0.0, le=1.0, description="Random sample fraction (0, 1]"
+    )
+    seed: Optional[int] = Field(None, description="Random seed for reproducible sampling")
+
+    @model_validator(mode="after")
+    def validate_ranges(self) -> "FilterConfig":
+        """Ensure min <= max for all range pairs."""
+        pairs = [
+            ("min_prompt_tokens", "max_prompt_tokens"),
+            ("min_output_tokens", "max_output_tokens"),
+            ("min_ttft_ms", "max_ttft_ms"),
+            ("min_tpot_ms", "max_tpot_ms"),
+            ("min_total_latency_ms", "max_total_latency_ms"),
+            ("time_start", "time_end"),
+        ]
+        for min_field, max_field in pairs:
+            min_val = getattr(self, min_field)
+            max_val = getattr(self, max_field)
+            if min_val is not None and max_val is not None and min_val > max_val:
+                msg = f"{min_field} ({min_val}) must be <= {max_field} ({max_val})"
+                raise ValueError(msg)
+        if self.sample_count is not None and self.sample_fraction is not None:
+            msg = "Cannot specify both sample_count and sample_fraction"
+            raise ValueError(msg)
+        return self
+
+
+class BenchmarkFilterResult(BaseModel):
+    """Result of applying a filter to benchmark data."""
+
+    original_count: int = Field(..., description="Number of requests before filtering")
+    filtered_count: int = Field(..., description="Number of requests after filtering")
+    removed_count: int = Field(..., description="Number of requests removed")
+    retention_rate: float = Field(..., description="Fraction of requests retained")
+    filters_applied: list[str] = Field(
+        default_factory=list, description="List of filter descriptions applied"
+    )
+    data: BenchmarkData = Field(..., description="Filtered benchmark data")
+
+
+class BenchmarkFilter:
+    """Filter benchmark data by configurable criteria."""
+
+    def __init__(self, config: FilterConfig) -> None:
+        self.config = config
+
+    def apply(self, data: BenchmarkData) -> BenchmarkFilterResult:
+        """Apply all configured filters to benchmark data."""
+        original_count = len(data.requests)
+        requests = list(data.requests)
+        filters_applied: list[str] = []
+
+        # Token count filters
+        requests, desc = self._filter_range(
+            requests, "prompt_tokens", self.config.min_prompt_tokens,
+            self.config.max_prompt_tokens,
+        )
+        if desc:
+            filters_applied.append(desc)
+
+        requests, desc = self._filter_range(
+            requests, "output_tokens", self.config.min_output_tokens,
+            self.config.max_output_tokens,
+        )
+        if desc:
+            filters_applied.append(desc)
+
+        # Latency filters
+        requests, desc = self._filter_range(
+            requests, "ttft_ms", self.config.min_ttft_ms, self.config.max_ttft_ms,
+        )
+        if desc:
+            filters_applied.append(desc)
+
+        requests, desc = self._filter_range(
+            requests, "tpot_ms", self.config.min_tpot_ms, self.config.max_tpot_ms,
+        )
+        if desc:
+            filters_applied.append(desc)
+
+        requests, desc = self._filter_range(
+            requests, "total_latency_ms", self.config.min_total_latency_ms,
+            self.config.max_total_latency_ms,
+        )
+        if desc:
+            filters_applied.append(desc)
+
+        # Time window filter
+        requests, desc = self._filter_range(
+            requests, "timestamp", self.config.time_start, self.config.time_end,
+        )
+        if desc:
+            filters_applied.append(desc)
+
+        # Sampling (applied last, after all deterministic filters)
+        if self.config.sample_count is not None or self.config.sample_fraction is not None:
+            rng = random.Random(self.config.seed)
+            if self.config.sample_count is not None:
+                n = min(self.config.sample_count, len(requests))
+                requests = rng.sample(requests, n)
+                filters_applied.append(f"sample_count={self.config.sample_count}")
+            else:
+                assert self.config.sample_fraction is not None
+                n = max(1, int(len(requests) * self.config.sample_fraction))
+                requests = rng.sample(requests, n)
+                filters_applied.append(f"sample_fraction={self.config.sample_fraction}")
+
+        if not requests:
+            msg = "Filter removed all requests — no data remaining"
+            raise ValueError(msg)
+
+        # Adjust QPS proportionally
+        retention = len(requests) / original_count if original_count > 0 else 0.0
+        adjusted_qps = data.metadata.measured_qps * retention
+
+        filtered_data = BenchmarkData(
+            metadata=data.metadata.model_copy(update={"measured_qps": adjusted_qps}),
+            requests=requests,
+        )
+
+        return BenchmarkFilterResult(
+            original_count=original_count,
+            filtered_count=len(requests),
+            removed_count=original_count - len(requests),
+            retention_rate=retention,
+            filters_applied=filters_applied,
+            data=filtered_data,
+        )
+
+    @staticmethod
+    def _filter_range(
+        requests: list[BenchmarkRequest],
+        attr: str,
+        min_val: float | int | None,
+        max_val: float | int | None,
+    ) -> tuple[list[BenchmarkRequest], str]:
+        """Filter requests where attr is within [min_val, max_val]."""
+        if min_val is None and max_val is None:
+            return requests, ""
+
+        parts: list[str] = []
+        filtered = requests
+        if min_val is not None:
+            filtered = [r for r in filtered if getattr(r, attr) >= min_val]
+            parts.append(f"{attr}>={min_val}")
+        if max_val is not None:
+            filtered = [r for r in filtered if getattr(r, attr) <= max_val]
+            parts.append(f"{attr}<={max_val}")
+
+        return filtered, " & ".join(parts)
+
+
+def filter_benchmark(
+    data: BenchmarkData,
+    config: FilterConfig,
+) -> BenchmarkFilterResult:
+    """Programmatic API: filter benchmark data by criteria.
+
+    Args:
+        data: Benchmark data to filter.
+        config: Filter configuration.
+
+    Returns:
+        BenchmarkFilterResult with filtered data and statistics.
+    """
+    return BenchmarkFilter(config).apply(data)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,235 @@
+"""Tests for benchmark filtering and slicing."""
+
+from __future__ import annotations
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.filter import BenchmarkFilter, BenchmarkFilterResult, FilterConfig, filter_benchmark
+
+
+def _make_requests(n: int = 20, base_ts: float = 1000.0) -> list[BenchmarkRequest]:
+    """Generate n benchmark requests with varying properties."""
+    requests = []
+    for i in range(n):
+        requests.append(
+            BenchmarkRequest(
+                request_id=f"req-{i:03d}",
+                prompt_tokens=50 + i * 10,  # 50..240
+                output_tokens=10 + i * 5,  # 10..105
+                ttft_ms=10.0 + i * 2.0,  # 10..48
+                tpot_ms=1.0 + i * 0.5,  # 1..10.5
+                total_latency_ms=50.0 + i * 10.0,  # 50..240
+                timestamp=base_ts + i * 1.0,  # 1000..1019
+            )
+        )
+    return requests
+
+
+def _make_data(n: int = 20) -> BenchmarkData:
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=4,
+            total_instances=6,
+            measured_qps=100.0,
+        ),
+        requests=_make_requests(n),
+    )
+
+
+class TestFilterConfig:
+    """Test FilterConfig validation."""
+
+    def test_empty_config(self) -> None:
+        config = FilterConfig()
+        assert config.min_prompt_tokens is None
+        assert config.sample_count is None
+
+    def test_valid_range(self) -> None:
+        config = FilterConfig(min_prompt_tokens=10, max_prompt_tokens=100)
+        assert config.min_prompt_tokens == 10
+
+    def test_invalid_range_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be <="):
+            FilterConfig(min_prompt_tokens=200, max_prompt_tokens=100)
+
+    def test_invalid_latency_range(self) -> None:
+        with pytest.raises(ValueError, match="must be <="):
+            FilterConfig(min_ttft_ms=50.0, max_ttft_ms=10.0)
+
+    def test_invalid_time_range(self) -> None:
+        with pytest.raises(ValueError, match="must be <="):
+            FilterConfig(time_start=2000.0, time_end=1000.0)
+
+    def test_sample_count_and_fraction_exclusive(self) -> None:
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            FilterConfig(sample_count=5, sample_fraction=0.5)
+
+    def test_sample_count_only(self) -> None:
+        config = FilterConfig(sample_count=10)
+        assert config.sample_count == 10
+        assert config.sample_fraction is None
+
+    def test_sample_fraction_only(self) -> None:
+        config = FilterConfig(sample_fraction=0.5)
+        assert config.sample_fraction == 0.5
+        assert config.sample_count is None
+
+
+class TestBenchmarkFilter:
+    """Test BenchmarkFilter.apply()."""
+
+    def test_no_filters_returns_all(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig()
+        result = BenchmarkFilter(config).apply(data)
+        assert result.filtered_count == 20
+        assert result.removed_count == 0
+        assert result.retention_rate == 1.0
+        assert result.filters_applied == []
+
+    def test_min_prompt_tokens(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(min_prompt_tokens=150)
+        result = BenchmarkFilter(config).apply(data)
+        # prompt_tokens: 50,60,...240 — >=150 means i>=10 → 10 requests
+        assert result.filtered_count == 10
+        for r in result.data.requests:
+            assert r.prompt_tokens >= 150
+
+    def test_max_prompt_tokens(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(max_prompt_tokens=100)
+        result = BenchmarkFilter(config).apply(data)
+        # prompt_tokens: 50,60,70,80,90,100 → 6 requests
+        assert result.filtered_count == 6
+        for r in result.data.requests:
+            assert r.prompt_tokens <= 100
+
+    def test_prompt_token_range(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(min_prompt_tokens=100, max_prompt_tokens=150)
+        result = BenchmarkFilter(config).apply(data)
+        # 100,110,120,130,140,150 → 6 requests
+        assert result.filtered_count == 6
+
+    def test_output_token_filter(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(min_output_tokens=50, max_output_tokens=80)
+        result = BenchmarkFilter(config).apply(data)
+        for r in result.data.requests:
+            assert 50 <= r.output_tokens <= 80
+
+    def test_ttft_filter(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(max_ttft_ms=20.0)
+        result = BenchmarkFilter(config).apply(data)
+        # ttft: 10,12,14,16,18,20 → 6 requests
+        assert result.filtered_count == 6
+
+    def test_tpot_filter(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(min_tpot_ms=5.0)
+        result = BenchmarkFilter(config).apply(data)
+        for r in result.data.requests:
+            assert r.tpot_ms >= 5.0
+
+    def test_total_latency_filter(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(min_total_latency_ms=100.0, max_total_latency_ms=200.0)
+        result = BenchmarkFilter(config).apply(data)
+        for r in result.data.requests:
+            assert 100.0 <= r.total_latency_ms <= 200.0
+
+    def test_time_window(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(time_start=1005.0, time_end=1010.0)
+        result = BenchmarkFilter(config).apply(data)
+        # timestamps 1005,1006,1007,1008,1009,1010 → 6 requests
+        assert result.filtered_count == 6
+
+    def test_sample_count(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(sample_count=5, seed=42)
+        result = BenchmarkFilter(config).apply(data)
+        assert result.filtered_count == 5
+
+    def test_sample_count_larger_than_data(self) -> None:
+        data = _make_data(5)
+        config = FilterConfig(sample_count=100, seed=42)
+        result = BenchmarkFilter(config).apply(data)
+        assert result.filtered_count == 5
+
+    def test_sample_fraction(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(sample_fraction=0.25, seed=42)
+        result = BenchmarkFilter(config).apply(data)
+        assert result.filtered_count == 5
+
+    def test_sample_reproducible_with_seed(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(sample_count=5, seed=42)
+        r1 = BenchmarkFilter(config).apply(data)
+        r2 = BenchmarkFilter(config).apply(data)
+        ids1 = [r.request_id for r in r1.data.requests]
+        ids2 = [r.request_id for r in r2.data.requests]
+        assert ids1 == ids2
+
+    def test_combined_filters(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(min_prompt_tokens=100, max_ttft_ms=30.0)
+        result = BenchmarkFilter(config).apply(data)
+        for r in result.data.requests:
+            assert r.prompt_tokens >= 100
+            assert r.ttft_ms <= 30.0
+
+    def test_qps_adjusted(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(min_prompt_tokens=150)
+        result = BenchmarkFilter(config).apply(data)
+        # 10/20 retained → QPS should be 50.0
+        assert result.data.metadata.measured_qps == pytest.approx(50.0)
+
+    def test_metadata_preserved(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(min_prompt_tokens=150)
+        result = BenchmarkFilter(config).apply(data)
+        assert result.data.metadata.num_prefill_instances == 2
+        assert result.data.metadata.num_decode_instances == 4
+        assert result.data.metadata.total_instances == 6
+
+    def test_empty_result_raises(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(min_prompt_tokens=9999)
+        with pytest.raises(ValueError, match="no data remaining"):
+            BenchmarkFilter(config).apply(data)
+
+    def test_filters_applied_list(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(min_prompt_tokens=100, sample_count=3, seed=1)
+        result = BenchmarkFilter(config).apply(data)
+        assert len(result.filters_applied) == 2
+        assert "prompt_tokens>=100" in result.filters_applied[0]
+        assert "sample_count=3" in result.filters_applied[1]
+
+    def test_result_model(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(max_prompt_tokens=100)
+        result = BenchmarkFilter(config).apply(data)
+        assert isinstance(result, BenchmarkFilterResult)
+        assert result.original_count == 20
+        assert result.removed_count == result.original_count - result.filtered_count
+
+
+class TestFilterBenchmarkAPI:
+    """Test the programmatic filter_benchmark() API."""
+
+    def test_api(self) -> None:
+        data = _make_data(20)
+        config = FilterConfig(min_prompt_tokens=100, max_prompt_tokens=200)
+        result = filter_benchmark(data, config)
+        assert isinstance(result, BenchmarkFilterResult)
+        assert result.filtered_count > 0
+        for r in result.data.requests:
+            assert 100 <= r.prompt_tokens <= 200


### PR DESCRIPTION
## Summary

Add benchmark filtering and slicing capability — select subsets of benchmark data by token count, latency ranges, time windows, or random sampling before analysis.

## Changes

- **`filter.py`**: `BenchmarkFilter` class with `apply()` method
- **`FilterConfig`**, **`BenchmarkFilterResult`** Pydantic models
- Token count filters: min/max prompt_tokens, min/max output_tokens
- Latency filters: min/max ttft_ms, tpot_ms, total_latency_ms
- Time window: start_time / end_time (epoch seconds)
- Random sampling: sample_count or sample_fraction with reproducible seed
- QPS automatically adjusted proportionally to retention rate
- Metadata preserved (instance counts unchanged)
- Raises ValueError if all requests filtered out
- **CLI** `filter` subcommand with all filter flags, `--output`, table + JSON output
- **Programmatic API**: `filter_benchmark()` function
- **28 new tests** (691 total, all passing)
- Lint clean: ruff + isort pass

Closes #69