### PR TITLE
feat: M31 — Bootstrap Confidence Intervals for Latency Percentiles

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -391,3 +391,16 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Each subcommand in its own module (e.g., `_analyze.py`, `_export.py`, `_fleet.py`)
 - Pure refactor — no behavioral changes
 - All 691 tests pass unchanged
+
+### M31 — Bootstrap Confidence Intervals
+
+- `ConfidenceAnalyzer` class in `confidence.py`
+- `ConfidenceInterval`, `MetricConfidence`, `ConfidenceReport`, `Adequacy` Pydantic models
+- Bootstrap resampling (configurable iterations, default 1000) for percentile CI estimation
+- Configurable confidence level (default 95%) and target percentile
+- Sample size adequacy classification: SUFFICIENT, MARGINAL, INSUFFICIENT
+- Adequacy thresholds based on relative CI width (>10% marginal, >25% insufficient)
+- CLI `confidence` subcommand with `--benchmark`, `--percentile`, `--confidence-level`, `--iterations`, `--seed`, table + JSON output
+- Programmatic `analyze_confidence()` API
+- Reproducible results via `--seed` parameter
+- 21 new tests

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -41,6 +41,14 @@ from xpyd_plan.comparator import (
     MetricDelta,
     compare_benchmarks,
 )
+from xpyd_plan.confidence import (
+    Adequacy,
+    ConfidenceAnalyzer,
+    ConfidenceInterval,
+    ConfidenceReport,
+    MetricConfidence,
+    analyze_confidence,
+)
 from xpyd_plan.config import ConfigProfile, load_config
 from xpyd_plan.dashboard import (
     Dashboard,
@@ -152,6 +160,12 @@ __all__ = [
     "ComparisonResult",
     "MetricDelta",
     "compare_benchmarks",
+    "Adequacy",
+    "ConfidenceAnalyzer",
+    "ConfidenceInterval",
+    "ConfidenceReport",
+    "MetricConfidence",
+    "analyze_confidence",
     "BenchmarkData",
     "BenchmarkMetadata",
     "BenchmarkRequest",

--- a/src/xpyd_plan/cli/_confidence.py
+++ b/src/xpyd_plan/cli/_confidence.py
@@ -1,0 +1,86 @@
+"""CLI confidence command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.confidence import analyze_confidence
+
+
+def _cmd_confidence(args: argparse.Namespace) -> None:
+    """Handle the 'confidence' subcommand."""
+    console = Console()
+
+    benchmarks = [load_benchmark_auto(p) for p in args.benchmark]
+    if not benchmarks:
+        console.print("[red]Error:[/red] No benchmark files provided.")
+        sys.exit(1)
+
+    # Use the first benchmark for analysis
+    data = benchmarks[0]
+
+    report = analyze_confidence(
+        data=data,
+        percentile=args.percentile,
+        confidence_level=args.confidence_level,
+        iterations=args.iterations,
+        seed=args.seed,
+    )
+
+    output_format = getattr(args, "output_format", "table")
+
+    if output_format == "json":
+        console.print(json.dumps(report.model_dump(), indent=2))
+        return
+
+    # Table output
+    console.print(
+        f"\n[bold]Bootstrap Confidence Intervals[/bold] "
+        f"(P{report.percentile:.0f}, {report.confidence_level:.0%} CI, "
+        f"{report.iterations} iterations, n={report.sample_size})\n"
+    )
+
+    table = Table()
+    table.add_column("Metric", style="cyan")
+    table.add_column("Point Estimate", justify="right")
+    table.add_column("CI Lower", justify="right")
+    table.add_column("CI Upper", justify="right")
+    table.add_column("CI Width", justify="right")
+    table.add_column("Relative Width", justify="right")
+    table.add_column("Adequacy", justify="center")
+
+    for mc in report.metrics:
+        ci = mc.intervals[0]
+        adequacy_style = {
+            "sufficient": "[green]SUFFICIENT[/green]",
+            "marginal": "[yellow]MARGINAL[/yellow]",
+            "insufficient": "[red]INSUFFICIENT[/red]",
+        }
+        table.add_row(
+            ci.metric,
+            f"{ci.point_estimate:.2f} ms",
+            f"{ci.ci_lower:.2f} ms",
+            f"{ci.ci_upper:.2f} ms",
+            f"{ci.ci_width:.2f} ms",
+            f"{ci.relative_ci_width:.1%}",
+            adequacy_style.get(mc.adequacy.value, mc.adequacy.value),
+        )
+
+    console.print(table)
+
+    if report.warnings:
+        console.print()
+        for w in report.warnings:
+            console.print(f"[yellow]⚠ {w}[/yellow]")
+
+    if not report.adequate:
+        console.print(
+            "\n[yellow]Some metrics have insufficient sample sizes. "
+            "Consider collecting more benchmark data.[/yellow]"
+        )

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -11,6 +11,7 @@ from xpyd_plan.cli._annotate import _cmd_annotate
 from xpyd_plan.cli._budget import _cmd_budget
 from xpyd_plan.cli._capacity import _cmd_plan_capacity
 from xpyd_plan.cli._compare import _cmd_compare
+from xpyd_plan.cli._confidence import _cmd_confidence
 from xpyd_plan.cli._config import _add_config_flag, _apply_config_defaults, _cmd_config
 from xpyd_plan.cli._dashboard import _cmd_dashboard
 from xpyd_plan.cli._export import _cmd_export
@@ -734,6 +735,36 @@ def main(argv: list[str] | None = None) -> None:
         help="Output format (default: table)",
     )
 
+    # --- confidence subcommand ---
+    confidence_parser = subparsers.add_parser(
+        "confidence",
+        help="Bootstrap confidence intervals for latency percentiles",
+    )
+    confidence_parser.add_argument(
+        "--benchmark", type=str, nargs="+", required=True,
+        help="Benchmark JSON file(s)",
+    )
+    confidence_parser.add_argument(
+        "--percentile", type=float, default=95.0,
+        help="Latency percentile to evaluate (default: 95)",
+    )
+    confidence_parser.add_argument(
+        "--confidence-level", type=float, default=0.95,
+        help="Confidence level for intervals (default: 0.95)",
+    )
+    confidence_parser.add_argument(
+        "--iterations", type=int, default=1000,
+        help="Number of bootstrap iterations (default: 1000)",
+    )
+    confidence_parser.add_argument(
+        "--seed", type=int, default=None,
+        help="Random seed for reproducibility",
+    )
+    confidence_parser.add_argument(
+        "--output-format", type=str, choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "config":
@@ -783,6 +814,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_merge(args)
     elif args.command == "filter":
         _cmd_filter(args)
+    elif args.command == "confidence":
+        _cmd_confidence(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/confidence.py
+++ b/src/xpyd_plan/confidence.py
@@ -1,0 +1,238 @@
+"""Bootstrap confidence interval analysis for latency percentiles."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from xpyd_plan.benchmark_models import BenchmarkData
+
+
+class Adequacy(str, Enum):
+    """Sample size adequacy classification."""
+
+    SUFFICIENT = "sufficient"
+    MARGINAL = "marginal"
+    INSUFFICIENT = "insufficient"
+
+
+class ConfidenceInterval(BaseModel):
+    """A single confidence interval for a metric at a given percentile."""
+
+    metric: str = Field(description="Metric name (ttft_ms, tpot_ms, total_latency_ms)")
+    percentile: float = Field(description="Percentile evaluated (e.g. 95.0)")
+    point_estimate: float = Field(description="Point estimate of the percentile value")
+    ci_lower: float = Field(description="Lower bound of confidence interval")
+    ci_upper: float = Field(description="Upper bound of confidence interval")
+    ci_width: float = Field(description="CI width (upper - lower)")
+    relative_ci_width: float = Field(
+        description="CI width relative to point estimate (ci_width / point_estimate)"
+    )
+    confidence_level: float = Field(description="Confidence level (e.g. 0.95)")
+    iterations: int = Field(description="Number of bootstrap iterations")
+    sample_size: int = Field(description="Number of data points")
+
+
+class MetricConfidence(BaseModel):
+    """Confidence intervals for all percentiles of a single metric."""
+
+    metric: str
+    intervals: list[ConfidenceInterval]
+    adequacy: Adequacy = Field(description="Sample size adequacy for this metric")
+
+
+class ConfidenceReport(BaseModel):
+    """Full confidence analysis report."""
+
+    metrics: list[MetricConfidence]
+    confidence_level: float
+    percentile: float
+    iterations: int
+    sample_size: int
+    adequate: bool = Field(description="True if all metrics have sufficient sample size")
+    warnings: list[str] = Field(default_factory=list)
+
+
+class ConfidenceAnalyzer:
+    """Compute bootstrap confidence intervals for benchmark latency percentiles."""
+
+    METRICS = ["ttft_ms", "tpot_ms", "total_latency_ms"]
+    RELATIVE_WIDTH_MARGINAL = 0.10  # >10% relative CI width = marginal
+    RELATIVE_WIDTH_INSUFFICIENT = 0.25  # >25% relative CI width = insufficient
+
+    def __init__(
+        self,
+        confidence_level: float = 0.95,
+        iterations: int = 1000,
+        seed: Optional[int] = None,
+    ):
+        if not 0 < confidence_level < 1:
+            raise ValueError("confidence_level must be between 0 and 1 (exclusive)")
+        if iterations < 10:
+            raise ValueError("iterations must be at least 10")
+        self.confidence_level = confidence_level
+        self.iterations = iterations
+        self.seed = seed
+
+    def analyze(
+        self,
+        data: BenchmarkData,
+        percentile: float = 95.0,
+    ) -> ConfidenceReport:
+        """Compute bootstrap CIs for all latency metrics at the given percentile."""
+        if not 0 < percentile <= 100:
+            raise ValueError("percentile must be between 0 (exclusive) and 100 (inclusive)")
+
+        requests = data.requests
+        sample_size = len(requests)
+        warnings: list[str] = []
+
+        if sample_size == 0:
+            raise ValueError("No requests in benchmark data")
+
+        if sample_size < 10:
+            warnings.append(
+                f"Very small sample size ({sample_size}). "
+                "Confidence intervals may be unreliable."
+            )
+
+        rng = np.random.default_rng(self.seed)
+        metric_results: list[MetricConfidence] = []
+
+        for metric_name in self.METRICS:
+            values = np.array([getattr(r, metric_name) for r in requests], dtype=np.float64)
+            interval = self._bootstrap_ci(values, percentile, rng)
+            adequacy = self._classify_adequacy(interval.relative_ci_width)
+
+            ci = ConfidenceInterval(
+                metric=metric_name,
+                percentile=percentile,
+                point_estimate=interval.point_estimate,
+                ci_lower=interval.ci_lower,
+                ci_upper=interval.ci_upper,
+                ci_width=interval.ci_width,
+                relative_ci_width=interval.relative_ci_width,
+                confidence_level=self.confidence_level,
+                iterations=self.iterations,
+                sample_size=sample_size,
+            )
+
+            mc = MetricConfidence(
+                metric=metric_name,
+                intervals=[ci],
+                adequacy=adequacy,
+            )
+            metric_results.append(mc)
+
+            if adequacy == Adequacy.INSUFFICIENT:
+                warnings.append(
+                    f"{metric_name}: relative CI width is {interval.relative_ci_width:.1%} "
+                    f"(>{self.RELATIVE_WIDTH_INSUFFICIENT:.0%}). "
+                    "Consider collecting more benchmark data."
+                )
+            elif adequacy == Adequacy.MARGINAL:
+                warnings.append(
+                    f"{metric_name}: relative CI width is {interval.relative_ci_width:.1%} "
+                    f"(>{self.RELATIVE_WIDTH_MARGINAL:.0%}). "
+                    "Results may have limited precision."
+                )
+
+        all_adequate = all(m.adequacy == Adequacy.SUFFICIENT for m in metric_results)
+
+        return ConfidenceReport(
+            metrics=metric_results,
+            confidence_level=self.confidence_level,
+            percentile=percentile,
+            iterations=self.iterations,
+            sample_size=sample_size,
+            adequate=all_adequate,
+            warnings=warnings,
+        )
+
+    def _bootstrap_ci(
+        self,
+        values: np.ndarray,
+        percentile: float,
+        rng: np.random.Generator,
+    ) -> ConfidenceInterval:
+        """Compute bootstrap CI for a single array of values at a percentile."""
+        n = len(values)
+        point_estimate = float(np.percentile(values, percentile))
+
+        if n == 1:
+            # Single data point — CI collapses to the point
+            return ConfidenceInterval(
+                metric="",
+                percentile=percentile,
+                point_estimate=point_estimate,
+                ci_lower=point_estimate,
+                ci_upper=point_estimate,
+                ci_width=0.0,
+                relative_ci_width=0.0,
+                confidence_level=self.confidence_level,
+                iterations=self.iterations,
+                sample_size=n,
+            )
+
+        # Bootstrap resampling
+        bootstrap_percentiles = np.empty(self.iterations)
+        for i in range(self.iterations):
+            sample = rng.choice(values, size=n, replace=True)
+            bootstrap_percentiles[i] = np.percentile(sample, percentile)
+
+        alpha = 1 - self.confidence_level
+        ci_lower = float(np.percentile(bootstrap_percentiles, 100 * alpha / 2))
+        ci_upper = float(np.percentile(bootstrap_percentiles, 100 * (1 - alpha / 2)))
+        ci_width = ci_upper - ci_lower
+        relative_ci_width = ci_width / point_estimate if point_estimate > 0 else 0.0
+
+        return ConfidenceInterval(
+            metric="",
+            percentile=percentile,
+            point_estimate=point_estimate,
+            ci_lower=ci_lower,
+            ci_upper=ci_upper,
+            ci_width=ci_width,
+            relative_ci_width=relative_ci_width,
+            confidence_level=self.confidence_level,
+            iterations=self.iterations,
+            sample_size=n,
+        )
+
+    def _classify_adequacy(self, relative_ci_width: float) -> Adequacy:
+        """Classify sample adequacy based on relative CI width."""
+        if relative_ci_width > self.RELATIVE_WIDTH_INSUFFICIENT:
+            return Adequacy.INSUFFICIENT
+        elif relative_ci_width > self.RELATIVE_WIDTH_MARGINAL:
+            return Adequacy.MARGINAL
+        return Adequacy.SUFFICIENT
+
+
+def analyze_confidence(
+    data: BenchmarkData,
+    percentile: float = 95.0,
+    confidence_level: float = 0.95,
+    iterations: int = 1000,
+    seed: Optional[int] = None,
+) -> ConfidenceReport:
+    """Convenience function: compute bootstrap confidence intervals.
+
+    Args:
+        data: Benchmark data to analyze.
+        percentile: Latency percentile to evaluate (default: 95.0).
+        confidence_level: Confidence level for intervals (default: 0.95).
+        iterations: Number of bootstrap iterations (default: 1000).
+        seed: Random seed for reproducibility.
+
+    Returns:
+        ConfidenceReport with intervals for TTFT, TPOT, and total latency.
+    """
+    analyzer = ConfidenceAnalyzer(
+        confidence_level=confidence_level,
+        iterations=iterations,
+        seed=seed,
+    )
+    return analyzer.analyze(data, percentile=percentile)

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -1,0 +1,219 @@
+"""Tests for bootstrap confidence interval analysis."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.confidence import (
+    Adequacy,
+    ConfidenceAnalyzer,
+    ConfidenceReport,
+    analyze_confidence,
+)
+
+
+def _make_requests(n: int, seed: int = 42) -> list[BenchmarkRequest]:
+    """Generate n synthetic benchmark requests with deterministic values."""
+    import numpy as np
+
+    rng = np.random.default_rng(seed)
+    requests = []
+    for i in range(n):
+        requests.append(
+            BenchmarkRequest(
+                request_id=f"req-{i}",
+                prompt_tokens=100,
+                output_tokens=50,
+                ttft_ms=float(rng.normal(40, 5)),
+                tpot_ms=float(rng.normal(10, 2)),
+                total_latency_ms=float(rng.normal(200, 30)),
+                timestamp=1000.0 + i,
+            )
+        )
+    return requests
+
+
+def _make_benchmark(n: int = 100, seed: int = 42) -> BenchmarkData:
+    """Create a BenchmarkData with n requests."""
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=4,
+            total_instances=6,
+            measured_qps=10.0,
+        ),
+        requests=_make_requests(n, seed=seed),
+    )
+
+
+class TestConfidenceAnalyzer:
+    """Tests for ConfidenceAnalyzer."""
+
+    def test_basic_analysis(self):
+        data = _make_benchmark(100)
+        analyzer = ConfidenceAnalyzer(seed=123)
+        report = analyzer.analyze(data)
+
+        assert isinstance(report, ConfidenceReport)
+        assert len(report.metrics) == 3
+        assert report.sample_size == 100
+        assert report.confidence_level == 0.95
+        assert report.percentile == 95.0
+
+    def test_three_metrics(self):
+        data = _make_benchmark(200)
+        report = analyze_confidence(data, seed=42)
+        metric_names = [m.metric for m in report.metrics]
+        assert metric_names == ["ttft_ms", "tpot_ms", "total_latency_ms"]
+
+    def test_ci_bounds_order(self):
+        """CI lower should be <= point estimate <= CI upper."""
+        data = _make_benchmark(500)
+        report = analyze_confidence(data, seed=42)
+        for mc in report.metrics:
+            ci = mc.intervals[0]
+            assert ci.ci_lower <= ci.point_estimate <= ci.ci_upper
+
+    def test_ci_width_positive(self):
+        data = _make_benchmark(100)
+        report = analyze_confidence(data, seed=42)
+        for mc in report.metrics:
+            ci = mc.intervals[0]
+            assert ci.ci_width >= 0
+
+    def test_larger_sample_tighter_ci(self):
+        """More data should produce tighter confidence intervals."""
+        small = analyze_confidence(_make_benchmark(30, seed=1), seed=42)
+        large = analyze_confidence(_make_benchmark(1000, seed=1), seed=42)
+
+        for s_mc, l_mc in zip(small.metrics, large.metrics):
+            # Larger sample should generally have smaller relative CI width
+            # Use a generous comparison since bootstrap has randomness
+            assert l_mc.intervals[0].relative_ci_width <= s_mc.intervals[0].relative_ci_width + 0.1
+
+    def test_single_request(self):
+        """Single request should produce zero-width CI."""
+        data = _make_benchmark(1)
+        report = analyze_confidence(data, seed=42)
+        for mc in report.metrics:
+            ci = mc.intervals[0]
+            assert ci.ci_width == 0.0
+            assert ci.relative_ci_width == 0.0
+            assert ci.ci_lower == ci.ci_upper == ci.point_estimate
+
+    def test_small_sample_warning(self):
+        data = _make_benchmark(5)
+        report = analyze_confidence(data, seed=42)
+        assert any("small sample" in w.lower() for w in report.warnings)
+
+    def test_empty_data_raises(self):
+        """BenchmarkData with empty requests is rejected by Pydantic validation."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            BenchmarkData(
+                metadata=BenchmarkMetadata(
+                    num_prefill_instances=1,
+                    num_decode_instances=1,
+                    total_instances=2,
+                    measured_qps=1.0,
+                ),
+                requests=[],
+            )
+
+    def test_custom_percentile(self):
+        data = _make_benchmark(200)
+        report = analyze_confidence(data, percentile=99.0, seed=42)
+        assert report.percentile == 99.0
+        for mc in report.metrics:
+            assert mc.intervals[0].percentile == 99.0
+
+    def test_custom_confidence_level(self):
+        data = _make_benchmark(200)
+        report = analyze_confidence(data, confidence_level=0.90, seed=42)
+        assert report.confidence_level == 0.90
+
+    def test_higher_confidence_wider_ci(self):
+        """99% CI should be wider than 90% CI."""
+        data = _make_benchmark(200)
+        r90 = analyze_confidence(data, confidence_level=0.90, seed=42)
+        r99 = analyze_confidence(data, confidence_level=0.99, seed=42)
+        for m90, m99 in zip(r90.metrics, r99.metrics):
+            assert m99.intervals[0].ci_width >= m90.intervals[0].ci_width
+
+    def test_reproducibility_with_seed(self):
+        data = _make_benchmark(100)
+        r1 = analyze_confidence(data, seed=42)
+        r2 = analyze_confidence(data, seed=42)
+        for m1, m2 in zip(r1.metrics, r2.metrics):
+            assert m1.intervals[0].ci_lower == m2.intervals[0].ci_lower
+            assert m1.intervals[0].ci_upper == m2.intervals[0].ci_upper
+
+    def test_different_seeds_different_results(self):
+        data = _make_benchmark(100)
+        r1 = analyze_confidence(data, seed=1)
+        r2 = analyze_confidence(data, seed=2)
+        # At least one metric should differ
+        any_diff = any(
+            m1.intervals[0].ci_lower != m2.intervals[0].ci_lower
+            for m1, m2 in zip(r1.metrics, r2.metrics)
+        )
+        assert any_diff
+
+    def test_adequacy_classification_sufficient(self):
+        data = _make_benchmark(1000)
+        report = analyze_confidence(data, seed=42)
+        assert report.adequate is True
+        for mc in report.metrics:
+            assert mc.adequacy == Adequacy.SUFFICIENT
+
+    def test_invalid_confidence_level(self):
+        with pytest.raises(ValueError, match="confidence_level"):
+            ConfidenceAnalyzer(confidence_level=0.0)
+        with pytest.raises(ValueError, match="confidence_level"):
+            ConfidenceAnalyzer(confidence_level=1.0)
+
+    def test_invalid_iterations(self):
+        with pytest.raises(ValueError, match="iterations"):
+            ConfidenceAnalyzer(iterations=5)
+
+    def test_invalid_percentile(self):
+        data = _make_benchmark(100)
+        analyzer = ConfidenceAnalyzer(seed=42)
+        with pytest.raises(ValueError, match="percentile"):
+            analyzer.analyze(data, percentile=0.0)
+        with pytest.raises(ValueError, match="percentile"):
+            analyzer.analyze(data, percentile=101.0)
+
+    def test_model_serialization(self):
+        data = _make_benchmark(100)
+        report = analyze_confidence(data, seed=42)
+        d = report.model_dump()
+        assert "metrics" in d
+        assert "adequate" in d
+        # Should be JSON-serializable
+        json.dumps(d)
+
+    def test_iterations_parameter(self):
+        data = _make_benchmark(100)
+        report = analyze_confidence(data, iterations=50, seed=42)
+        assert report.iterations == 50
+        for mc in report.metrics:
+            assert mc.intervals[0].iterations == 50
+
+    def test_p50_percentile(self):
+        data = _make_benchmark(200)
+        report = analyze_confidence(data, percentile=50.0, seed=42)
+        assert report.percentile == 50.0
+
+    def test_convenience_function_matches_class(self):
+        data = _make_benchmark(100)
+        r1 = analyze_confidence(data, seed=42)
+        analyzer = ConfidenceAnalyzer(seed=42)
+        r2 = analyzer.analyze(data)
+        for m1, m2 in zip(r1.metrics, r2.metrics):
+            assert m1.intervals[0].point_estimate == m2.intervals[0].point_estimate
+            assert m1.intervals[0].ci_lower == m2.intervals[0].ci_lower


### PR DESCRIPTION
## Summary

Add bootstrap confidence interval analysis for latency percentiles, enabling users to assess the statistical reliability of their P95/P99 measurements.

## Changes

- **`confidence.py`**: `ConfidenceAnalyzer` class with bootstrap resampling
- **Models**: `ConfidenceInterval`, `MetricConfidence`, `ConfidenceReport`, `Adequacy`
- **CLI**: `confidence` subcommand with `--benchmark`, `--percentile`, `--confidence-level`, `--iterations`, `--seed`, table + JSON output
- **API**: `analyze_confidence()` convenience function
- **Tests**: 21 new tests covering edge cases, reproducibility, CI width scaling
- **ROADMAP.md**: Added M31 entry

## Key Features

- Bootstrap resampling (default 1000 iterations) for TTFT, TPOT, total_latency
- Configurable confidence level (default 95%) and target percentile
- Sample size adequacy: SUFFICIENT (<10% relative CI width), MARGINAL (10-25%), INSUFFICIENT (>25%)
- Reproducible results via `--seed` parameter
- Warnings for small samples and wide confidence intervals

Closes #73