### PR TITLE
feat: M32 — Multi-Model Comparison Matrix

### DIFF
--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -101,6 +101,14 @@ from xpyd_plan.merger import (
     MergeStrategy,
     merge_benchmarks,
 )
+from xpyd_plan.model_compare import (
+    ComparisonMatrix,
+    ModelComparator,
+    ModelComparison,
+    ModelProfile,
+    ModelRanking,
+    compare_models,
+)
 from xpyd_plan.models import (
     DatasetStats,
     GPUProfile,
@@ -232,6 +240,12 @@ __all__ = [
     "MergeResult",
     "MergeStrategy",
     "merge_benchmarks",
+    "ComparisonMatrix",
+    "ModelComparator",
+    "ModelComparison",
+    "ModelProfile",
+    "ModelRanking",
+    "compare_models",
     "AnomalyConfig",
     "AnomalyType",
     "BenchmarkGenerator",

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -20,6 +20,7 @@ from xpyd_plan.cli._fleet import _cmd_fleet
 from xpyd_plan.cli._generate import _cmd_generate
 from xpyd_plan.cli._interpolate import _cmd_interpolate
 from xpyd_plan.cli._merge import _cmd_merge
+from xpyd_plan.cli._model_compare import _cmd_model_compare
 from xpyd_plan.cli._pareto import _cmd_pareto
 from xpyd_plan.cli._pipeline import _cmd_pipeline
 from xpyd_plan.cli._recommend import _cmd_recommend
@@ -765,6 +766,28 @@ def main(argv: list[str] | None = None) -> None:
         help="Output format (default: table)",
     )
 
+    # --- model-compare subcommand ---
+    mc_parser = subparsers.add_parser(
+        "model-compare",
+        help="Compare benchmark results across different LLM models",
+    )
+    mc_parser.add_argument(
+        "--benchmarks", type=str, nargs="+", required=True,
+        help="Benchmark JSON files (one per model)",
+    )
+    mc_parser.add_argument(
+        "--models", type=str, required=True,
+        help="Comma-separated model names (must match number of benchmark files)",
+    )
+    mc_parser.add_argument(
+        "--gpu-hourly-rate", type=float, default=None,
+        help="GPU hourly rate for cost-efficiency ranking",
+    )
+    mc_parser.add_argument(
+        "--output-format", type=str, choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "config":
@@ -816,6 +839,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_filter(args)
     elif args.command == "confidence":
         _cmd_confidence(args)
+    elif args.command == "model-compare":
+        _cmd_model_compare(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/cli/_model_compare.py
+++ b/src/xpyd_plan/cli/_model_compare.py
@@ -1,0 +1,87 @@
+"""CLI model-compare command."""
+
+from __future__ import annotations
+
+import argparse
+
+from rich.console import Console
+from rich.table import Table
+
+
+def _cmd_model_compare(args: argparse.Namespace) -> None:
+    """Execute the model-compare subcommand."""
+
+    from xpyd_plan.model_compare import compare_models
+
+    console = Console()
+
+    benchmarks = args.benchmarks
+    models = args.models.split(",")
+
+    if len(benchmarks) != len(models):
+        console.print(
+            f"[red]Error: {len(benchmarks)} benchmark file(s) but {len(models)} model name(s). "
+            "Counts must match.[/red]"
+        )
+        raise SystemExit(1)
+
+    gpu_rate = getattr(args, "gpu_hourly_rate", None)
+    result = compare_models(benchmarks, models, gpu_hourly_rate=gpu_rate)
+
+    if args.output_format == "json":
+        console.print_json(result.model_dump_json(indent=2))
+        return
+
+    # --- Table output ---
+    console.print("\n[bold]🔬 Multi-Model Comparison Matrix[/bold]")
+
+    # Profiles summary
+    profile_table = Table(title="Model Profiles")
+    profile_table.add_column("Model", style="cyan")
+    profile_table.add_column("P:D Ratio", justify="center")
+    profile_table.add_column("QPS", justify="right")
+    profile_table.add_column("TTFT P95", justify="right")
+    profile_table.add_column("TPOT P95", justify="right")
+    profile_table.add_column("Total P95", justify="right")
+    profile_table.add_column("Requests", justify="right")
+    if any(p.cost_per_request is not None for p in result.profiles):
+        profile_table.add_column("$/req", justify="right")
+
+    for p in result.profiles:
+        row = [
+            p.model_name,
+            f"{p.num_prefill_instances}:{p.num_decode_instances}",
+            f"{p.measured_qps:.1f}",
+            f"{p.ttft_p95_ms:.1f}",
+            f"{p.tpot_p95_ms:.1f}",
+            f"{p.total_latency_p95_ms:.1f}",
+            str(p.request_count),
+        ]
+        if any(pr.cost_per_request is not None for pr in result.profiles):
+            row.append(f"{p.cost_per_request:.6f}" if p.cost_per_request is not None else "N/A")
+        profile_table.add_row(*row)
+
+    console.print(profile_table)
+
+    # Rankings
+    rank_table = Table(title="\nModel Rankings")
+    rank_table.add_column("Rank", justify="center", style="bold")
+    rank_table.add_column("Model", style="cyan")
+    rank_table.add_column("Latency Score", justify="right")
+    rank_table.add_column("Cost Score", justify="right")
+    rank_table.add_column("Recommendation")
+
+    for r in result.rankings:
+        rank_table.add_row(
+            str(r.rank),
+            r.model_name,
+            f"{r.latency_score:.3f}",
+            f"{r.cost_efficiency_score:.3f}" if r.cost_efficiency_score is not None else "N/A",
+            r.recommendation,
+        )
+
+    console.print(rank_table)
+
+    console.print(f"\n[bold green]🏆 Best latency: {result.best_latency_model}[/bold green]")
+    if result.best_cost_model:
+        console.print(f"[bold green]💰 Best cost: {result.best_cost_model}[/bold green]")

--- a/src/xpyd_plan/model_compare.py
+++ b/src/xpyd_plan/model_compare.py
@@ -1,0 +1,285 @@
+"""Multi-model comparison matrix.
+
+Compare benchmark results across different LLM models to identify the best
+model+ratio combination based on latency, cost, and SLA compliance.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from xpyd_plan.benchmark_models import BenchmarkData
+
+
+class ModelProfile(BaseModel):
+    """Performance profile for a single model extracted from benchmark data."""
+
+    model_name: str = Field(..., description="Name of the LLM model")
+    num_prefill_instances: int = Field(..., ge=1)
+    num_decode_instances: int = Field(..., ge=1)
+    total_instances: int = Field(..., ge=2)
+    measured_qps: float = Field(..., gt=0)
+    request_count: int = Field(..., ge=1)
+    ttft_p50_ms: float = Field(..., ge=0)
+    ttft_p95_ms: float = Field(..., ge=0)
+    ttft_p99_ms: float = Field(..., ge=0)
+    tpot_p50_ms: float = Field(..., ge=0)
+    tpot_p95_ms: float = Field(..., ge=0)
+    tpot_p99_ms: float = Field(..., ge=0)
+    total_latency_p50_ms: float = Field(..., ge=0)
+    total_latency_p95_ms: float = Field(..., ge=0)
+    total_latency_p99_ms: float = Field(..., ge=0)
+    avg_prompt_tokens: float = Field(..., ge=0)
+    avg_output_tokens: float = Field(..., ge=0)
+    cost_per_hour: Optional[float] = Field(
+        None, ge=0, description="Total hourly cost if cost config provided"
+    )
+    cost_per_request: Optional[float] = Field(
+        None, ge=0, description="Cost per request if cost config provided"
+    )
+
+
+class ModelComparison(BaseModel):
+    """Pairwise comparison between two models for a specific metric."""
+
+    metric: str = Field(..., description="Metric name")
+    model_a: str = Field(..., description="First model name")
+    model_b: str = Field(..., description="Second model name")
+    value_a: float = Field(..., description="Metric value for model A")
+    value_b: float = Field(..., description="Metric value for model B")
+    absolute_delta: float = Field(..., description="value_b - value_a")
+    relative_delta: float = Field(
+        ..., description="Relative change: (value_b - value_a) / value_a, or 0.0 if value_a is 0"
+    )
+    winner: str = Field(..., description="Model with better (lower) value for latency metrics")
+
+
+class ModelRanking(BaseModel):
+    """Ranking of a model across all comparison criteria."""
+
+    model_name: str = Field(..., description="Model name")
+    rank: int = Field(..., ge=1, description="Overall rank (1 = best)")
+    latency_score: float = Field(..., description="Normalized latency score (lower is better)")
+    cost_efficiency_score: Optional[float] = Field(
+        None, description="Cost efficiency score (lower is better)"
+    )
+    recommendation: str = Field(..., description="Human-readable recommendation")
+
+
+class ComparisonMatrix(BaseModel):
+    """Complete comparison result across all models."""
+
+    profiles: list[ModelProfile] = Field(default_factory=list)
+    comparisons: list[ModelComparison] = Field(default_factory=list)
+    rankings: list[ModelRanking] = Field(default_factory=list)
+    best_latency_model: str = Field(..., description="Model with lowest P95 total latency")
+    best_cost_model: Optional[str] = Field(
+        None, description="Model with lowest cost per request (if cost data available)"
+    )
+
+
+class ModelComparator:
+    """Compare benchmark results across different LLM models."""
+
+    def __init__(
+        self,
+        gpu_hourly_rate: Optional[float] = None,
+    ):
+        self._gpu_hourly_rate = gpu_hourly_rate
+
+    def load_profile(self, benchmark_path: str, model_name: str) -> ModelProfile:
+        """Load a benchmark file and extract a model profile."""
+        data = BenchmarkData.model_validate(
+            json.loads(Path(benchmark_path).read_text())
+        )
+        ttfts = np.array([r.ttft_ms for r in data.requests])
+        tpots = np.array([r.tpot_ms for r in data.requests])
+        totals = np.array([r.total_latency_ms for r in data.requests])
+        prompts = np.array([r.prompt_tokens for r in data.requests])
+        outputs = np.array([r.output_tokens for r in data.requests])
+
+        total_instances = data.metadata.total_instances
+        cost_per_hour = None
+        cost_per_request = None
+        if self._gpu_hourly_rate is not None:
+            cost_per_hour = self._gpu_hourly_rate * total_instances
+            if data.metadata.measured_qps > 0:
+                cost_per_request = cost_per_hour / (data.metadata.measured_qps * 3600)
+
+        return ModelProfile(
+            model_name=model_name,
+            num_prefill_instances=data.metadata.num_prefill_instances,
+            num_decode_instances=data.metadata.num_decode_instances,
+            total_instances=total_instances,
+            measured_qps=data.metadata.measured_qps,
+            request_count=len(data.requests),
+            ttft_p50_ms=float(np.percentile(ttfts, 50)),
+            ttft_p95_ms=float(np.percentile(ttfts, 95)),
+            ttft_p99_ms=float(np.percentile(ttfts, 99)),
+            tpot_p50_ms=float(np.percentile(tpots, 50)),
+            tpot_p95_ms=float(np.percentile(tpots, 95)),
+            tpot_p99_ms=float(np.percentile(tpots, 99)),
+            total_latency_p50_ms=float(np.percentile(totals, 50)),
+            total_latency_p95_ms=float(np.percentile(totals, 95)),
+            total_latency_p99_ms=float(np.percentile(totals, 99)),
+            avg_prompt_tokens=float(np.mean(prompts)),
+            avg_output_tokens=float(np.mean(outputs)),
+            cost_per_hour=cost_per_hour,
+            cost_per_request=cost_per_request,
+        )
+
+    def compare(
+        self,
+        benchmark_paths: list[str],
+        model_names: list[str],
+    ) -> ComparisonMatrix:
+        """Compare multiple models and produce a comparison matrix."""
+        if len(benchmark_paths) != len(model_names):
+            raise ValueError(
+                f"Number of benchmarks ({len(benchmark_paths)}) must match "
+                f"number of model names ({len(model_names)})"
+            )
+        if len(benchmark_paths) < 2:
+            raise ValueError("At least 2 benchmarks required for comparison")
+
+        profiles = [
+            self.load_profile(p, n) for p, n in zip(benchmark_paths, model_names)
+        ]
+
+        # Generate pairwise comparisons
+        latency_metrics = [
+            ("ttft_p50_ms", "TTFT P50"),
+            ("ttft_p95_ms", "TTFT P95"),
+            ("ttft_p99_ms", "TTFT P99"),
+            ("tpot_p50_ms", "TPOT P50"),
+            ("tpot_p95_ms", "TPOT P95"),
+            ("tpot_p99_ms", "TPOT P99"),
+            ("total_latency_p50_ms", "Total Latency P50"),
+            ("total_latency_p95_ms", "Total Latency P95"),
+            ("total_latency_p99_ms", "Total Latency P99"),
+        ]
+
+        comparisons: list[ModelComparison] = []
+        for i in range(len(profiles)):
+            for j in range(i + 1, len(profiles)):
+                pa, pb = profiles[i], profiles[j]
+                for attr, label in latency_metrics:
+                    va = getattr(pa, attr)
+                    vb = getattr(pb, attr)
+                    abs_delta = vb - va
+                    rel_delta = abs_delta / va if va != 0 else 0.0
+                    # Lower latency is better
+                    winner = pa.model_name if va <= vb else pb.model_name
+                    comparisons.append(
+                        ModelComparison(
+                            metric=label,
+                            model_a=pa.model_name,
+                            model_b=pb.model_name,
+                            value_a=va,
+                            value_b=vb,
+                            absolute_delta=abs_delta,
+                            relative_delta=rel_delta,
+                            winner=winner,
+                        )
+                    )
+
+        # Rank models
+        rankings = self._rank_models(profiles)
+
+        best_latency_model = min(profiles, key=lambda p: p.total_latency_p95_ms).model_name
+
+        best_cost_model = None
+        cost_profiles = [p for p in profiles if p.cost_per_request is not None]
+        if cost_profiles:
+            best_cost_model = min(cost_profiles, key=lambda p: p.cost_per_request).model_name  # type: ignore[arg-type]
+
+        return ComparisonMatrix(
+            profiles=profiles,
+            comparisons=comparisons,
+            rankings=rankings,
+            best_latency_model=best_latency_model,
+            best_cost_model=best_cost_model,
+        )
+
+    def _rank_models(self, profiles: list[ModelProfile]) -> list[ModelRanking]:
+        """Rank models by normalized latency score and optional cost efficiency."""
+        if not profiles:
+            return []
+
+        # Normalize latency: sum of P95 TTFT + TPOT + total latency
+        latency_scores = []
+        for p in profiles:
+            score = p.ttft_p95_ms + p.tpot_p95_ms + p.total_latency_p95_ms
+            latency_scores.append(score)
+
+        max_lat = max(latency_scores) if max(latency_scores) > 0 else 1.0
+        norm_latency = [s / max_lat for s in latency_scores]
+
+        # Cost efficiency: cost_per_request normalized
+        has_cost = all(p.cost_per_request is not None for p in profiles)
+        norm_cost: list[Optional[float]] = [None] * len(profiles)
+        if has_cost:
+            cost_scores = [p.cost_per_request for p in profiles]  # type: ignore[misc]
+            max_cost = max(cost_scores) if max(cost_scores) > 0 else 1.0  # type: ignore[type-var]
+            norm_cost = [c / max_cost for c in cost_scores]  # type: ignore[operator]
+
+        # Combined score: 60% latency, 40% cost (if available), else 100% latency
+        combined = []
+        for i in range(len(profiles)):
+            if norm_cost[i] is not None:
+                combined.append(0.6 * norm_latency[i] + 0.4 * norm_cost[i])
+            else:
+                combined.append(norm_latency[i])
+
+        # Sort by combined score
+        indexed = sorted(enumerate(combined), key=lambda x: x[1])
+
+        rankings = []
+        for rank_idx, (orig_idx, _score) in enumerate(indexed):
+            p = profiles[orig_idx]
+            if rank_idx == 0:
+                rec = f"Best overall: {p.model_name} leads in combined latency/cost"
+            elif norm_cost[orig_idx] is not None and norm_cost[orig_idx] == min(  # type: ignore[type-var]
+                c for c in norm_cost if c is not None
+            ):
+                rec = f"{p.model_name}: most cost-efficient option"
+            elif norm_latency[orig_idx] == min(norm_latency):
+                rec = f"{p.model_name}: lowest latency option"
+            else:
+                rec = f"{p.model_name}: rank {rank_idx + 1} overall"
+
+            rankings.append(
+                ModelRanking(
+                    model_name=p.model_name,
+                    rank=rank_idx + 1,
+                    latency_score=norm_latency[orig_idx],
+                    cost_efficiency_score=norm_cost[orig_idx],
+                    recommendation=rec,
+                )
+            )
+
+        return rankings
+
+
+def compare_models(
+    benchmark_paths: list[str],
+    model_names: list[str],
+    gpu_hourly_rate: Optional[float] = None,
+) -> ComparisonMatrix:
+    """Programmatic API: compare models across benchmark files.
+
+    Args:
+        benchmark_paths: Paths to benchmark JSON files (one per model).
+        model_names: Model names corresponding to each benchmark file.
+        gpu_hourly_rate: Optional hourly GPU cost for cost-efficiency ranking.
+
+    Returns:
+        ComparisonMatrix with profiles, comparisons, and rankings.
+    """
+    comparator = ModelComparator(gpu_hourly_rate=gpu_hourly_rate)
+    return comparator.compare(benchmark_paths, model_names)

--- a/tests/test_model_compare.py
+++ b/tests/test_model_compare.py
@@ -1,0 +1,318 @@
+"""Tests for multi-model comparison matrix (M32)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_plan.model_compare import (
+    ComparisonMatrix,
+    ModelComparator,
+    ModelComparison,
+    ModelProfile,
+    ModelRanking,
+    compare_models,
+)
+
+
+def _make_benchmark(
+    num_prefill: int = 2,
+    num_decode: int = 6,
+    qps: float = 10.0,
+    ttft_base: float = 50.0,
+    tpot_base: float = 20.0,
+    total_base: float = 200.0,
+    n_requests: int = 100,
+) -> dict:
+    """Create a synthetic benchmark dict."""
+    import random
+
+    random.seed(42)
+    requests = []
+    for i in range(n_requests):
+        ttft = ttft_base + random.gauss(0, ttft_base * 0.1)
+        tpot = tpot_base + random.gauss(0, tpot_base * 0.1)
+        total = total_base + random.gauss(0, total_base * 0.1)
+        requests.append({
+            "request_id": f"req-{i}",
+            "prompt_tokens": random.randint(50, 500),
+            "output_tokens": random.randint(10, 200),
+            "ttft_ms": max(1.0, ttft),
+            "tpot_ms": max(1.0, tpot),
+            "total_latency_ms": max(1.0, total),
+            "timestamp": 1700000000.0 + i,
+        })
+    return {
+        "metadata": {
+            "num_prefill_instances": num_prefill,
+            "num_decode_instances": num_decode,
+            "total_instances": num_prefill + num_decode,
+            "measured_qps": qps,
+        },
+        "requests": requests,
+    }
+
+
+def _write_benchmark(tmp_dir: Path, name: str, **kwargs) -> str:
+    """Write a benchmark file and return its path."""
+    path = tmp_dir / f"{name}.json"
+    path.write_text(json.dumps(_make_benchmark(**kwargs)))
+    return str(path)
+
+
+class TestModelProfile:
+    def test_model_profile_fields(self):
+        p = ModelProfile(
+            model_name="llama-70b",
+            num_prefill_instances=2,
+            num_decode_instances=6,
+            total_instances=8,
+            measured_qps=10.0,
+            request_count=100,
+            ttft_p50_ms=50.0,
+            ttft_p95_ms=65.0,
+            ttft_p99_ms=80.0,
+            tpot_p50_ms=20.0,
+            tpot_p95_ms=28.0,
+            tpot_p99_ms=35.0,
+            total_latency_p50_ms=200.0,
+            total_latency_p95_ms=260.0,
+            total_latency_p99_ms=300.0,
+            avg_prompt_tokens=250.0,
+            avg_output_tokens=100.0,
+        )
+        assert p.model_name == "llama-70b"
+        assert p.cost_per_hour is None
+        assert p.cost_per_request is None
+
+    def test_model_profile_with_cost(self):
+        p = ModelProfile(
+            model_name="test",
+            num_prefill_instances=1,
+            num_decode_instances=3,
+            total_instances=4,
+            measured_qps=5.0,
+            request_count=50,
+            ttft_p50_ms=40.0,
+            ttft_p95_ms=55.0,
+            ttft_p99_ms=70.0,
+            tpot_p50_ms=15.0,
+            tpot_p95_ms=22.0,
+            tpot_p99_ms=30.0,
+            total_latency_p50_ms=180.0,
+            total_latency_p95_ms=240.0,
+            total_latency_p99_ms=280.0,
+            avg_prompt_tokens=200.0,
+            avg_output_tokens=80.0,
+            cost_per_hour=12.0,
+            cost_per_request=0.00066,
+        )
+        assert p.cost_per_hour == 12.0
+        assert p.cost_per_request == 0.00066
+
+
+class TestModelComparison:
+    def test_comparison_fields(self):
+        c = ModelComparison(
+            metric="TTFT P95",
+            model_a="A",
+            model_b="B",
+            value_a=50.0,
+            value_b=60.0,
+            absolute_delta=10.0,
+            relative_delta=0.2,
+            winner="A",
+        )
+        assert c.winner == "A"
+        assert c.relative_delta == pytest.approx(0.2)
+
+
+class TestModelRanking:
+    def test_ranking_fields(self):
+        r = ModelRanking(
+            model_name="llama-70b",
+            rank=1,
+            latency_score=0.5,
+            cost_efficiency_score=0.3,
+            recommendation="Best overall",
+        )
+        assert r.rank == 1
+
+
+class TestModelComparator:
+    def test_load_profile(self, tmp_path):
+        path = _write_benchmark(tmp_path, "model_a")
+        comparator = ModelComparator()
+        profile = comparator.load_profile(path, "model-a")
+        assert profile.model_name == "model-a"
+        assert profile.request_count == 100
+        assert profile.ttft_p50_ms > 0
+        assert profile.cost_per_hour is None
+
+    def test_load_profile_with_cost(self, tmp_path):
+        path = _write_benchmark(tmp_path, "model_a")
+        comparator = ModelComparator(gpu_hourly_rate=3.0)
+        profile = comparator.load_profile(path, "model-a")
+        assert profile.cost_per_hour == pytest.approx(3.0 * 8)  # 8 total instances
+        assert profile.cost_per_request is not None
+        assert profile.cost_per_request > 0
+
+    def test_compare_two_models(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "a", ttft_base=50.0, tpot_base=20.0)
+        path_b = _write_benchmark(tmp_path, "b", ttft_base=70.0, tpot_base=30.0)
+        comparator = ModelComparator()
+        result = comparator.compare([path_a, path_b], ["model-a", "model-b"])
+
+        assert isinstance(result, ComparisonMatrix)
+        assert len(result.profiles) == 2
+        assert len(result.comparisons) == 9  # 9 latency metrics for 1 pair
+        assert len(result.rankings) == 2
+        assert result.best_latency_model == "model-a"  # lower latency
+
+    def test_compare_three_models(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "a", ttft_base=50.0)
+        path_b = _write_benchmark(tmp_path, "b", ttft_base=70.0)
+        path_c = _write_benchmark(tmp_path, "c", ttft_base=90.0)
+        comparator = ModelComparator()
+        result = comparator.compare(
+            [path_a, path_b, path_c], ["A", "B", "C"]
+        )
+
+        assert len(result.profiles) == 3
+        # 3 pairs × 9 metrics = 27
+        assert len(result.comparisons) == 27
+        assert len(result.rankings) == 3
+        assert result.rankings[0].rank == 1
+
+    def test_compare_with_cost(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "a", ttft_base=50.0)
+        path_b = _write_benchmark(tmp_path, "b", ttft_base=70.0)
+        comparator = ModelComparator(gpu_hourly_rate=2.5)
+        result = comparator.compare([path_a, path_b], ["A", "B"])
+
+        assert result.best_cost_model is not None
+        for p in result.profiles:
+            assert p.cost_per_hour is not None
+            assert p.cost_per_request is not None
+        for r in result.rankings:
+            assert r.cost_efficiency_score is not None
+
+    def test_compare_mismatched_counts(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "a")
+        with pytest.raises(ValueError, match="must match"):
+            ModelComparator().compare([path_a], ["A", "B"])
+
+    def test_compare_less_than_two(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "a")
+        with pytest.raises(ValueError, match="At least 2"):
+            ModelComparator().compare([path_a], ["A"])
+
+    def test_winner_determined_correctly(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "a", ttft_base=100.0)
+        path_b = _write_benchmark(tmp_path, "b", ttft_base=30.0)
+        result = ModelComparator().compare([path_a, path_b], ["slow", "fast"])
+
+        ttft_comps = [c for c in result.comparisons if c.metric == "TTFT P95"]
+        assert len(ttft_comps) == 1
+        assert ttft_comps[0].winner == "fast"
+
+    def test_rankings_order(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "a", ttft_base=50.0, tpot_base=20.0, total_base=200.0)
+        path_b = _write_benchmark(tmp_path, "b", ttft_base=100.0, tpot_base=40.0, total_base=400.0)
+        result = ModelComparator().compare([path_a, path_b], ["fast", "slow"])
+
+        assert result.rankings[0].model_name == "fast"
+        assert result.rankings[0].rank == 1
+        assert result.rankings[1].model_name == "slow"
+        assert result.rankings[1].rank == 2
+
+    def test_best_cost_model_none_without_cost(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "a")
+        path_b = _write_benchmark(tmp_path, "b")
+        result = ModelComparator().compare([path_a, path_b], ["A", "B"])
+        assert result.best_cost_model is None
+
+    def test_relative_delta_zero_division(self, tmp_path):
+        """When a metric value is 0 for model_a, relative_delta should be 0."""
+        # This is hard to trigger naturally since latency > 0, but we test the code path
+        path_a = _write_benchmark(tmp_path, "a", ttft_base=50.0)
+        path_b = _write_benchmark(tmp_path, "b", ttft_base=60.0)
+        result = ModelComparator().compare([path_a, path_b], ["A", "B"])
+        # All comparisons should have valid relative_delta
+        for c in result.comparisons:
+            assert not (c.value_a == 0 and c.relative_delta != 0.0)
+
+
+class TestCompareModelsAPI:
+    def test_programmatic_api(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "a", ttft_base=50.0)
+        path_b = _write_benchmark(tmp_path, "b", ttft_base=80.0)
+        result = compare_models([path_a, path_b], ["A", "B"])
+        assert isinstance(result, ComparisonMatrix)
+        assert result.best_latency_model == "A"
+
+    def test_programmatic_api_with_cost(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "a")
+        path_b = _write_benchmark(tmp_path, "b")
+        result = compare_models([path_a, path_b], ["A", "B"], gpu_hourly_rate=2.0)
+        assert result.best_cost_model is not None
+
+    def test_json_serialization(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "a")
+        path_b = _write_benchmark(tmp_path, "b")
+        result = compare_models([path_a, path_b], ["A", "B"])
+        j = json.loads(result.model_dump_json())
+        assert "profiles" in j
+        assert "comparisons" in j
+        assert "rankings" in j
+        assert "best_latency_model" in j
+
+
+class TestCLIModelCompare:
+    def test_cli_table_output(self, tmp_path, capsys):
+        from xpyd_plan.cli._main import main
+
+        path_a = _write_benchmark(tmp_path, "a", ttft_base=50.0)
+        path_b = _write_benchmark(tmp_path, "b", ttft_base=80.0)
+        main([
+            "model-compare",
+            "--benchmarks", path_a, path_b,
+            "--models", "ModelA,ModelB",
+        ])
+
+    def test_cli_json_output(self, tmp_path, capsys):
+        from xpyd_plan.cli._main import main
+
+        path_a = _write_benchmark(tmp_path, "a")
+        path_b = _write_benchmark(tmp_path, "b")
+        main([
+            "model-compare",
+            "--benchmarks", path_a, path_b,
+            "--models", "A,B",
+            "--output-format", "json",
+        ])
+
+    def test_cli_with_cost(self, tmp_path, capsys):
+        from xpyd_plan.cli._main import main
+
+        path_a = _write_benchmark(tmp_path, "a")
+        path_b = _write_benchmark(tmp_path, "b")
+        main([
+            "model-compare",
+            "--benchmarks", path_a, path_b,
+            "--models", "A,B",
+            "--gpu-hourly-rate", "3.0",
+        ])
+
+    def test_cli_mismatched_models(self, tmp_path):
+        from xpyd_plan.cli._main import main
+
+        path_a = _write_benchmark(tmp_path, "a")
+        with pytest.raises(SystemExit):
+            main([
+                "model-compare",
+                "--benchmarks", path_a,
+                "--models", "A,B",
+            ])


### PR DESCRIPTION
## Summary
Multi-Model Comparison Matrix for comparing benchmark results across different LLM models.

## Changes
- `ModelComparator` class in `model_compare.py`
- `ModelProfile`, `ModelComparison`, `ComparisonMatrix`, `ModelRanking` Pydantic models
- Side-by-side latency comparison at P50/P95/P99 for TTFT, TPOT, total latency
- Cost-efficiency ranking when GPU hourly rate provided
- Best-model recommendation with weighted scoring (60% latency, 40% cost)
- CLI `model-compare` subcommand with `--benchmarks`, `--models`, `--gpu-hourly-rate`, table + JSON output
- Programmatic `compare_models()` API
- 22 new tests (734 total, all passing)

Closes #77