### PR TITLE
feat: M33 — A/B Test Analysis

### DIFF
--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -2,6 +2,18 @@
 
 __version__ = "0.2.0"
 
+from xpyd_plan.ab_test import (
+    ABConfidenceInterval,
+    ABTestAnalyzer,
+    ABTestConfig,
+    ABTestReport,
+    ABTestResult,
+    EffectMagnitude,
+    EffectSize,
+    PowerWarning,
+    StatisticalTest,
+    analyze_ab_test,
+)
 from xpyd_plan.alerting import (
     AlertEngine,
     AlertReport,
@@ -246,6 +258,16 @@ __all__ = [
     "ModelProfile",
     "ModelRanking",
     "compare_models",
+    "ABTestAnalyzer",
+    "ABTestConfig",
+    "ABTestReport",
+    "ABTestResult",
+    "ABConfidenceInterval",
+    "EffectMagnitude",
+    "EffectSize",
+    "PowerWarning",
+    "StatisticalTest",
+    "analyze_ab_test",
     "AnomalyConfig",
     "AnomalyType",
     "BenchmarkGenerator",

--- a/src/xpyd_plan/ab_test.py
+++ b/src/xpyd_plan/ab_test.py
@@ -1,0 +1,460 @@
+"""A/B Test Analysis for benchmark comparisons.
+
+Compare two benchmark datasets (control vs treatment) with statistical
+rigor: hypothesis testing, effect sizes, and power analysis.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from xpyd_plan.benchmark_models import BenchmarkData
+
+
+class EffectMagnitude(str, Enum):
+    """Cohen's d magnitude classification."""
+
+    NEGLIGIBLE = "negligible"
+    SMALL = "small"
+    MEDIUM = "medium"
+    LARGE = "large"
+
+
+class StatisticalTest(BaseModel):
+    """Result of a single statistical test."""
+
+    test_name: str = Field(..., description="Name of the test (welch_t, mann_whitney_u)")
+    statistic: float = Field(..., description="Test statistic value")
+    p_value: float = Field(..., description="Two-sided p-value")
+    significant: bool = Field(..., description="True if p_value < alpha")
+
+
+class EffectSize(BaseModel):
+    """Effect size measurement."""
+
+    cohens_d: float = Field(..., description="Cohen's d value")
+    magnitude: EffectMagnitude = Field(..., description="Effect magnitude classification")
+
+
+class ABConfidenceInterval(BaseModel):
+    """Confidence interval for mean difference."""
+
+    lower: float = Field(..., description="Lower bound")
+    upper: float = Field(..., description="Upper bound")
+    confidence_level: float = Field(0.95, description="Confidence level (e.g. 0.95)")
+
+
+class PowerWarning(BaseModel):
+    """Warning about statistical power."""
+
+    adequate: bool = Field(..., description="True if power is adequate")
+    reason: str = Field(..., description="Explanation")
+    control_n: int = Field(..., description="Control sample size")
+    treatment_n: int = Field(..., description="Treatment sample size")
+
+
+class ABTestResult(BaseModel):
+    """Result of an A/B test for a single metric."""
+
+    metric: str = Field(..., description="Metric name (e.g. ttft_ms)")
+    control_mean: float = Field(..., description="Control group mean")
+    treatment_mean: float = Field(..., description="Treatment group mean")
+    mean_difference: float = Field(..., description="treatment_mean - control_mean")
+    relative_difference: float = Field(
+        ..., description="Relative difference: diff / control_mean, or 0.0 if control_mean is 0"
+    )
+    welch_t: StatisticalTest = Field(..., description="Welch's t-test result")
+    mann_whitney_u: StatisticalTest = Field(..., description="Mann-Whitney U test result")
+    effect_size: EffectSize = Field(..., description="Cohen's d effect size")
+    ci: ABConfidenceInterval = Field(..., description="CI for mean difference")
+    power_warning: PowerWarning = Field(..., description="Statistical power warning")
+    winner: Optional[str] = Field(
+        None, description="'control' or 'treatment' if significant, else None"
+    )
+
+
+class ABTestConfig(BaseModel):
+    """Configuration for A/B test analysis."""
+
+    alpha: float = Field(0.05, ge=0.001, le=0.5, description="Significance level")
+    metrics: list[str] = Field(
+        default_factory=lambda: ["ttft_ms", "tpot_ms", "total_latency_ms"],
+        description="Metrics to compare",
+    )
+    confidence_level: float = Field(0.95, ge=0.5, le=0.999, description="CI confidence level")
+    min_sample_size: int = Field(30, ge=2, description="Minimum sample size warning threshold")
+
+
+class ABTestReport(BaseModel):
+    """Full A/B test report across all metrics."""
+
+    control_file: str = Field(..., description="Control benchmark file path")
+    treatment_file: str = Field(..., description="Treatment benchmark file path")
+    alpha: float = Field(..., description="Significance level used")
+    results: list[ABTestResult] = Field(..., description="Per-metric results")
+    summary: str = Field(..., description="Human-readable summary")
+
+
+VALID_METRICS = {"ttft_ms", "tpot_ms", "total_latency_ms"}
+
+
+def _classify_cohens_d(d: float) -> EffectMagnitude:
+    """Classify Cohen's d magnitude."""
+    abs_d = abs(d)
+    if abs_d < 0.2:
+        return EffectMagnitude.NEGLIGIBLE
+    if abs_d < 0.5:
+        return EffectMagnitude.SMALL
+    if abs_d < 0.8:
+        return EffectMagnitude.MEDIUM
+    return EffectMagnitude.LARGE
+
+
+def _welch_t_test(
+    a: np.ndarray, b: np.ndarray, alpha: float
+) -> StatisticalTest:
+    """Welch's t-test (unequal variance)."""
+    n_a, n_b = len(a), len(b)
+    mean_a, mean_b = np.mean(a), np.mean(b)
+    var_a, var_b = np.var(a, ddof=1), np.var(b, ddof=1)
+
+    se = math.sqrt(var_a / n_a + var_b / n_b) if (var_a / n_a + var_b / n_b) > 0 else 1e-12
+    t_stat = float((mean_b - mean_a) / se)
+
+    # Welch-Satterthwaite degrees of freedom
+    num = (var_a / n_a + var_b / n_b) ** 2
+    denom_a = (var_a / n_a) ** 2 / (n_a - 1) if n_a > 1 else 1e-12
+    denom_b = (var_b / n_b) ** 2 / (n_b - 1) if n_b > 1 else 1e-12
+    df = num / (denom_a + denom_b) if (denom_a + denom_b) > 0 else 1.0
+
+    p_value = 2.0 * (1.0 - _t_cdf(abs(t_stat), df))
+    p_value = min(max(p_value, 0.0), 1.0)
+
+    return StatisticalTest(
+        test_name="welch_t",
+        statistic=t_stat,
+        p_value=p_value,
+        significant=p_value < alpha,
+    )
+
+
+def _mann_whitney_u(
+    a: np.ndarray, b: np.ndarray, alpha: float
+) -> StatisticalTest:
+    """Mann-Whitney U test (non-parametric)."""
+    n_a, n_b = len(a), len(b)
+    # Combine and rank
+    combined = np.concatenate([a, b])
+    ranks = np.empty_like(combined, dtype=float)
+    order = np.argsort(combined)
+    # Handle ties with average ranks
+    i = 0
+    while i < len(order):
+        j = i
+        while j < len(order) and combined[order[j]] == combined[order[i]]:
+            j += 1
+        avg_rank = (i + j + 1) / 2.0  # 1-indexed average
+        for k in range(i, j):
+            ranks[order[k]] = avg_rank
+        i = j
+
+    r_a = np.sum(ranks[:n_a])
+    u_a = r_a - n_a * (n_a + 1) / 2.0
+    u_b = n_a * n_b - u_a
+    u_stat = min(u_a, u_b)
+
+    # Normal approximation for large samples
+    mean_u = n_a * n_b / 2.0
+    std_u = math.sqrt(n_a * n_b * (n_a + n_b + 1) / 12.0)
+    if std_u == 0:
+        z = 0.0
+    else:
+        z = (u_stat - mean_u) / std_u
+
+    # Two-sided p-value from normal approximation
+    p_value = 2.0 * _norm_cdf(-abs(z))
+    p_value = min(max(p_value, 0.0), 1.0)
+
+    return StatisticalTest(
+        test_name="mann_whitney_u",
+        statistic=float(u_stat),
+        p_value=p_value,
+        significant=p_value < alpha,
+    )
+
+
+def _norm_cdf(x: float) -> float:
+    """Standard normal CDF using error function."""
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+def _t_cdf(x: float, df: float) -> float:
+    """Approximate t-distribution CDF.
+
+    Uses normal approximation for df >= 30, otherwise uses a more
+    accurate approximation.
+    """
+    if df >= 30:
+        return _norm_cdf(x)
+    # Approximation using the formula from Abramowitz and Stegun
+    # For moderate df, adjust x to normal equivalent
+    g1 = 1.0 / (4.0 * df)
+    z = x * (1.0 - g1) / math.sqrt(1.0 + x * x / (2.0 * df))
+    return _norm_cdf(z)
+
+
+def _cohens_d(a: np.ndarray, b: np.ndarray) -> float:
+    """Compute Cohen's d (pooled standard deviation)."""
+    n_a, n_b = len(a), len(b)
+    var_a, var_b = np.var(a, ddof=1), np.var(b, ddof=1)
+    pooled_std = math.sqrt(((n_a - 1) * var_a + (n_b - 1) * var_b) / (n_a + n_b - 2))
+    if pooled_std == 0:
+        return 0.0
+    return float((np.mean(b) - np.mean(a)) / pooled_std)
+
+
+def _mean_diff_ci(
+    a: np.ndarray, b: np.ndarray, confidence_level: float
+) -> ABConfidenceInterval:
+    """Confidence interval for difference of means."""
+    n_a, n_b = len(a), len(b)
+    mean_diff = float(np.mean(b) - np.mean(a))
+    var_a, var_b = np.var(a, ddof=1), np.var(b, ddof=1)
+    se = math.sqrt(var_a / n_a + var_b / n_b) if (var_a / n_a + var_b / n_b) > 0 else 0.0
+
+    # Use normal quantile for CI
+    z = _norm_quantile((1.0 + confidence_level) / 2.0)
+    margin = z * se
+
+    return ABConfidenceInterval(
+        lower=mean_diff - margin,
+        upper=mean_diff + margin,
+        confidence_level=confidence_level,
+    )
+
+
+def _norm_quantile(p: float) -> float:
+    """Approximate inverse normal CDF (probit function).
+
+    Uses rational approximation from Peter Acklam.
+    """
+    if p <= 0:
+        return -10.0
+    if p >= 1:
+        return 10.0
+    if p == 0.5:
+        return 0.0
+
+    # Coefficients
+    a = [
+        -3.969683028665376e01,
+        2.209460984245205e02,
+        -2.759285104469687e02,
+        1.383577518672690e02,
+        -3.066479806614716e01,
+        2.506628277459239e00,
+    ]
+    b = [
+        -5.447609879822406e01,
+        1.615858368580409e02,
+        -1.556989798598866e02,
+        6.680131188771972e01,
+        -1.328068155288572e01,
+    ]
+    c = [
+        -7.784894002430293e-03,
+        -3.223964580411365e-01,
+        -2.400758277161838e00,
+        -2.549732539343734e00,
+        4.374664141464968e00,
+        2.938163982698783e00,
+    ]
+    d = [
+        7.784695709041462e-03,
+        3.224671290700398e-01,
+        2.445134137142996e00,
+        3.754408661907416e00,
+    ]
+
+    p_low = 0.02425
+    p_high = 1.0 - p_low
+
+    if p < p_low:
+        q = math.sqrt(-2.0 * math.log(p))
+        x = (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) / (
+            (((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0
+        )
+    elif p <= p_high:
+        q = p - 0.5
+        r = q * q
+        x = (((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) * q / (
+            ((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1.0
+        )
+    else:
+        q = math.sqrt(-2.0 * math.log(1.0 - p))
+        x = -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) / (
+            (((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0
+        )
+
+    return x
+
+
+def _check_power(
+    n_control: int, n_treatment: int, min_sample: int
+) -> PowerWarning:
+    """Check if sample sizes are adequate for statistical power."""
+    adequate = n_control >= min_sample and n_treatment >= min_sample
+    if adequate:
+        reason = f"Sample sizes adequate (control={n_control}, treatment={n_treatment})"
+    else:
+        parts = []
+        if n_control < min_sample:
+            parts.append(f"control ({n_control} < {min_sample})")
+        if n_treatment < min_sample:
+            parts.append(f"treatment ({n_treatment} < {min_sample})")
+        reason = (
+            f"Insufficient sample size: {', '.join(parts)}. "
+            "Results may lack statistical power."
+        )
+
+    return PowerWarning(
+        adequate=adequate,
+        reason=reason,
+        control_n=n_control,
+        treatment_n=n_treatment,
+    )
+
+
+class ABTestAnalyzer:
+    """Analyze A/B test results between two benchmark datasets."""
+
+    def __init__(self, config: ABTestConfig | None = None) -> None:
+        self.config = config or ABTestConfig()
+
+    def _extract_metric(self, data: BenchmarkData, metric: str) -> np.ndarray:
+        """Extract metric values from benchmark data."""
+        if metric not in VALID_METRICS:
+            msg = f"Invalid metric '{metric}'. Valid: {sorted(VALID_METRICS)}"
+            raise ValueError(msg)
+        values = [getattr(r, metric) for r in data.requests]
+        return np.array(values, dtype=float)
+
+    def _analyze_metric(
+        self, control: np.ndarray, treatment: np.ndarray, metric: str
+    ) -> ABTestResult:
+        """Run full analysis for a single metric."""
+        alpha = self.config.alpha
+        control_mean = float(np.mean(control))
+        treatment_mean = float(np.mean(treatment))
+        mean_diff = treatment_mean - control_mean
+        rel_diff = mean_diff / control_mean if control_mean != 0 else 0.0
+
+        welch = _welch_t_test(control, treatment, alpha)
+        mwu = _mann_whitney_u(control, treatment, alpha)
+        d = _cohens_d(control, treatment)
+        effect = EffectSize(cohens_d=d, magnitude=_classify_cohens_d(d))
+        ci = _mean_diff_ci(control, treatment, self.config.confidence_level)
+        power = _check_power(len(control), len(treatment), self.config.min_sample_size)
+
+        # Determine winner: lower latency is better
+        winner = None
+        if welch.significant:
+            winner = "treatment" if mean_diff < 0 else "control"
+
+        return ABTestResult(
+            metric=metric,
+            control_mean=control_mean,
+            treatment_mean=treatment_mean,
+            mean_difference=mean_diff,
+            relative_difference=rel_diff,
+            welch_t=welch,
+            mann_whitney_u=mwu,
+            effect_size=effect,
+            ci=ci,
+            power_warning=power,
+            winner=winner,
+        )
+
+    def analyze(
+        self, control_path: str, treatment_path: str
+    ) -> ABTestReport:
+        """Run A/B test analysis on two benchmark files.
+
+        Args:
+            control_path: Path to control (baseline) benchmark JSON.
+            treatment_path: Path to treatment benchmark JSON.
+
+        Returns:
+            ABTestReport with per-metric results and summary.
+        """
+        control_data = BenchmarkData.model_validate(
+            json.loads(Path(control_path).read_text())
+        )
+        treatment_data = BenchmarkData.model_validate(
+            json.loads(Path(treatment_path).read_text())
+        )
+
+        results = []
+        for metric in self.config.metrics:
+            control_vals = self._extract_metric(control_data, metric)
+            treatment_vals = self._extract_metric(treatment_data, metric)
+            results.append(self._analyze_metric(control_vals, treatment_vals, metric))
+
+        # Build summary
+        sig_results = [r for r in results if r.welch_t.significant]
+        if not sig_results:
+            summary = (
+                "No statistically significant differences found "
+                "between control and treatment."
+            )
+        else:
+            parts = []
+            for r in sig_results:
+                direction = "lower" if r.mean_difference < 0 else "higher"
+                parts.append(
+                    f"{r.metric}: treatment is "
+                    f"{abs(r.relative_difference):.1%} {direction} "
+                    f"(p={r.welch_t.p_value:.4f}, "
+                    f"d={r.effect_size.cohens_d:.2f} "
+                    f"[{r.effect_size.magnitude.value}])"
+                )
+            summary = "Significant differences: " + "; ".join(parts)
+
+        return ABTestReport(
+            control_file=control_path,
+            treatment_file=treatment_path,
+            alpha=self.config.alpha,
+            results=results,
+            summary=summary,
+        )
+
+
+def analyze_ab_test(
+    control_path: str,
+    treatment_path: str,
+    alpha: float = 0.05,
+    metrics: list[str] | None = None,
+) -> ABTestReport:
+    """Programmatic API: run A/B test analysis.
+
+    Args:
+        control_path: Path to control benchmark JSON.
+        treatment_path: Path to treatment benchmark JSON.
+        alpha: Significance level (default 0.05).
+        metrics: Metrics to compare (default: ttft_ms, tpot_ms, total_latency_ms).
+
+    Returns:
+        ABTestReport with per-metric results and summary.
+    """
+    config = ABTestConfig(alpha=alpha)
+    if metrics:
+        config.metrics = metrics
+    analyzer = ABTestAnalyzer(config=config)
+    return analyzer.analyze(control_path, treatment_path)

--- a/src/xpyd_plan/cli/_ab_test.py
+++ b/src/xpyd_plan/cli/_ab_test.py
@@ -1,0 +1,85 @@
+"""CLI ab-test command."""
+
+from __future__ import annotations
+
+import argparse
+
+from rich.console import Console
+from rich.table import Table
+
+
+def _cmd_ab_test(args: argparse.Namespace) -> None:
+    """Execute the ab-test subcommand."""
+    from xpyd_plan.ab_test import ABTestAnalyzer, ABTestConfig
+
+    config = ABTestConfig(alpha=args.alpha)
+    if args.metric:
+        config.metrics = args.metric
+
+    analyzer = ABTestAnalyzer(config=config)
+    report = analyzer.analyze(args.control, args.treatment)
+
+    if args.output_format == "json":
+        print(report.model_dump_json(indent=2))
+        return
+
+    console = Console()
+
+    console.print("\n[bold]A/B Test Report[/bold]")
+    console.print(f"Control:   {report.control_file}")
+    console.print(f"Treatment: {report.treatment_file}")
+    console.print(f"Alpha:     {report.alpha}")
+    console.print()
+
+    table = Table(title="Metric Comparison")
+    table.add_column("Metric", style="cyan")
+    table.add_column("Control Mean", justify="right")
+    table.add_column("Treatment Mean", justify="right")
+    table.add_column("Diff", justify="right")
+    table.add_column("Rel Diff", justify="right")
+    table.add_column("p-value (t)", justify="right")
+    table.add_column("Significant", justify="center")
+    table.add_column("Effect Size", justify="right")
+    table.add_column("Winner", justify="center")
+
+    for r in report.results:
+        sig_style = "green" if r.welch_t.significant else "dim"
+        table.add_row(
+            r.metric,
+            f"{r.control_mean:.2f}",
+            f"{r.treatment_mean:.2f}",
+            f"{r.mean_difference:+.2f}",
+            f"{r.relative_difference:+.1%}",
+            f"{r.welch_t.p_value:.4f}",
+            f"[{sig_style}]{'Yes' if r.welch_t.significant else 'No'}[/{sig_style}]",
+            f"{r.effect_size.cohens_d:.2f} ({r.effect_size.magnitude.value})",
+            r.winner or "-",
+        )
+
+    console.print(table)
+    console.print()
+
+    # CI table
+    ci_table = Table(title="Confidence Intervals (Mean Difference)")
+    ci_table.add_column("Metric", style="cyan")
+    ci_table.add_column("Lower", justify="right")
+    ci_table.add_column("Upper", justify="right")
+    ci_table.add_column("Level", justify="right")
+
+    for r in report.results:
+        ci_table.add_row(
+            r.metric,
+            f"{r.ci.lower:.2f}",
+            f"{r.ci.upper:.2f}",
+            f"{r.ci.confidence_level:.0%}",
+        )
+
+    console.print(ci_table)
+    console.print()
+
+    # Power warnings
+    for r in report.results:
+        if not r.power_warning.adequate:
+            console.print(f"[yellow]⚠ {r.metric}: {r.power_warning.reason}[/yellow]")
+
+    console.print(f"\n[bold]Summary:[/bold] {report.summary}\n")

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import sys
 
+from xpyd_plan.cli._ab_test import _cmd_ab_test
 from xpyd_plan.cli._alert import _cmd_alert
 from xpyd_plan.cli._analyze import _cmd_analyze
 from xpyd_plan.cli._annotate import _cmd_annotate
@@ -788,6 +789,32 @@ def main(argv: list[str] | None = None) -> None:
         help="Output format (default: table)",
     )
 
+    # --- ab-test subcommand ---
+    ab_parser = subparsers.add_parser(
+        "ab-test",
+        help="A/B test analysis: compare control vs treatment benchmarks",
+    )
+    ab_parser.add_argument(
+        "--control", type=str, required=True,
+        help="Control (baseline) benchmark JSON file",
+    )
+    ab_parser.add_argument(
+        "--treatment", type=str, required=True,
+        help="Treatment benchmark JSON file",
+    )
+    ab_parser.add_argument(
+        "--alpha", type=float, default=0.05,
+        help="Significance level (default: 0.05)",
+    )
+    ab_parser.add_argument(
+        "--metric", type=str, nargs="+", default=None,
+        help="Metrics to compare (default: ttft_ms tpot_ms total_latency_ms)",
+    )
+    ab_parser.add_argument(
+        "--output-format", type=str, choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "config":
@@ -841,6 +868,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_confidence(args)
     elif args.command == "model-compare":
         _cmd_model_compare(args)
+    elif args.command == "ab-test":
+        _cmd_ab_test(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/tests/test_ab_test.py
+++ b/tests/test_ab_test.py
@@ -1,0 +1,357 @@
+"""Tests for A/B test analysis (M33)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from xpyd_plan.ab_test import (
+    ABTestAnalyzer,
+    ABTestConfig,
+    ABTestReport,
+    EffectMagnitude,
+    EffectSize,
+    PowerWarning,
+    _classify_cohens_d,
+    _cohens_d,
+    _mann_whitney_u,
+    _norm_cdf,
+    _norm_quantile,
+    _t_cdf,
+    _welch_t_test,
+    analyze_ab_test,
+)
+
+
+def _make_benchmark(
+    num_prefill: int = 2,
+    num_decode: int = 6,
+    qps: float = 10.0,
+    ttft_base: float = 50.0,
+    tpot_base: float = 20.0,
+    total_base: float = 200.0,
+    n_requests: int = 100,
+    seed: int = 42,
+) -> dict:
+    """Create a synthetic benchmark dict."""
+    rng = np.random.default_rng(seed)
+    requests = []
+    for i in range(n_requests):
+        ttft = max(1.0, ttft_base + rng.normal(0, ttft_base * 0.1))
+        tpot = max(1.0, tpot_base + rng.normal(0, tpot_base * 0.1))
+        total = max(1.0, total_base + rng.normal(0, total_base * 0.1))
+        requests.append({
+            "request_id": f"req-{i}",
+            "prompt_tokens": int(rng.integers(50, 500)),
+            "output_tokens": int(rng.integers(10, 200)),
+            "ttft_ms": float(ttft),
+            "tpot_ms": float(tpot),
+            "total_latency_ms": float(total),
+            "timestamp": 1700000000.0 + i,
+        })
+    return {
+        "metadata": {
+            "num_prefill_instances": num_prefill,
+            "num_decode_instances": num_decode,
+            "total_instances": num_prefill + num_decode,
+            "measured_qps": qps,
+        },
+        "requests": requests,
+    }
+
+
+def _write_benchmark(tmp_dir: Path, name: str, **kwargs) -> str:
+    path = tmp_dir / f"{name}.json"
+    path.write_text(json.dumps(_make_benchmark(**kwargs)))
+    return str(path)
+
+
+class TestStatisticalHelpers:
+    def test_norm_cdf_center(self):
+        assert _norm_cdf(0.0) == pytest.approx(0.5, abs=1e-10)
+
+    def test_norm_cdf_positive(self):
+        assert _norm_cdf(1.96) == pytest.approx(0.975, abs=0.001)
+
+    def test_norm_cdf_negative(self):
+        assert _norm_cdf(-1.96) == pytest.approx(0.025, abs=0.001)
+
+    def test_t_cdf_large_df(self):
+        # For large df, should approximate normal
+        assert _t_cdf(1.96, 100) == pytest.approx(0.975, abs=0.01)
+
+    def test_t_cdf_small_df(self):
+        # For small df, heavier tails
+        val = _t_cdf(1.96, 5)
+        assert 0.9 < val < 0.98
+
+    def test_norm_quantile_center(self):
+        assert _norm_quantile(0.5) == pytest.approx(0.0, abs=1e-10)
+
+    def test_norm_quantile_975(self):
+        assert _norm_quantile(0.975) == pytest.approx(1.96, abs=0.01)
+
+    def test_norm_quantile_extremes(self):
+        assert _norm_quantile(0.0) == -10.0
+        assert _norm_quantile(1.0) == 10.0
+
+
+class TestClassifyCohensD:
+    def test_negligible(self):
+        assert _classify_cohens_d(0.1) == EffectMagnitude.NEGLIGIBLE
+
+    def test_small(self):
+        assert _classify_cohens_d(0.3) == EffectMagnitude.SMALL
+
+    def test_medium(self):
+        assert _classify_cohens_d(0.6) == EffectMagnitude.MEDIUM
+
+    def test_large(self):
+        assert _classify_cohens_d(1.0) == EffectMagnitude.LARGE
+
+    def test_negative(self):
+        assert _classify_cohens_d(-0.9) == EffectMagnitude.LARGE
+
+
+class TestWelchTTest:
+    def test_same_distributions(self):
+        rng = np.random.default_rng(42)
+        a = rng.normal(50, 5, 100)
+        b = rng.normal(50, 5, 100)
+        result = _welch_t_test(a, b, 0.05)
+        assert result.test_name == "welch_t"
+        assert not result.significant  # same distribution, should not be significant
+
+    def test_different_distributions(self):
+        rng = np.random.default_rng(42)
+        a = rng.normal(50, 5, 200)
+        b = rng.normal(60, 5, 200)
+        result = _welch_t_test(a, b, 0.05)
+        assert result.significant
+        assert result.statistic > 0  # b > a
+
+    def test_p_value_bounds(self):
+        a = np.array([1.0, 2.0, 3.0])
+        b = np.array([1.0, 2.0, 3.0])
+        result = _welch_t_test(a, b, 0.05)
+        assert 0.0 <= result.p_value <= 1.0
+
+
+class TestMannWhitneyU:
+    def test_same_distributions(self):
+        rng = np.random.default_rng(42)
+        a = rng.normal(50, 5, 100)
+        b = rng.normal(50, 5, 100)
+        result = _mann_whitney_u(a, b, 0.05)
+        assert result.test_name == "mann_whitney_u"
+        assert not result.significant
+
+    def test_different_distributions(self):
+        rng = np.random.default_rng(42)
+        a = rng.normal(50, 5, 200)
+        b = rng.normal(70, 5, 200)
+        result = _mann_whitney_u(a, b, 0.05)
+        assert result.significant
+
+
+class TestCohensD:
+    def test_same_values(self):
+        a = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        b = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        assert _cohens_d(a, b) == pytest.approx(0.0)
+
+    def test_large_effect(self):
+        a = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        b = np.array([5.0, 6.0, 7.0, 8.0, 9.0])
+        d = _cohens_d(a, b)
+        assert abs(d) > 0.8  # large effect
+
+    def test_zero_variance(self):
+        a = np.array([5.0, 5.0, 5.0])
+        b = np.array([5.0, 5.0, 5.0])
+        assert _cohens_d(a, b) == 0.0
+
+
+class TestPowerWarning:
+    def test_adequate(self):
+        pw = PowerWarning(adequate=True, reason="OK", control_n=100, treatment_n=100)
+        assert pw.adequate
+
+    def test_inadequate(self):
+        pw = PowerWarning(adequate=False, reason="Too small", control_n=10, treatment_n=10)
+        assert not pw.adequate
+
+
+class TestEffectSize:
+    def test_fields(self):
+        es = EffectSize(cohens_d=0.5, magnitude=EffectMagnitude.MEDIUM)
+        assert es.cohens_d == 0.5
+        assert es.magnitude == EffectMagnitude.MEDIUM
+
+
+class TestABTestAnalyzer:
+    def test_same_data(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "control", seed=42)
+        path_b = _write_benchmark(tmp_path, "treatment", seed=42)
+        analyzer = ABTestAnalyzer()
+        report = analyzer.analyze(path_a, path_b)
+
+        assert isinstance(report, ABTestReport)
+        assert len(report.results) == 3
+        for r in report.results:
+            assert not r.welch_t.significant
+            assert r.winner is None
+
+    def test_different_data(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "control", ttft_base=50.0, seed=42)
+        path_b = _write_benchmark(tmp_path, "treatment", ttft_base=80.0, seed=99)
+        analyzer = ABTestAnalyzer()
+        report = analyzer.analyze(path_a, path_b)
+
+        ttft_result = next(r for r in report.results if r.metric == "ttft_ms")
+        assert ttft_result.welch_t.significant
+        assert ttft_result.winner == "control"  # lower latency wins
+        assert ttft_result.mean_difference > 0  # treatment higher
+
+    def test_custom_alpha(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "control", seed=42)
+        path_b = _write_benchmark(tmp_path, "treatment", seed=43)
+        config = ABTestConfig(alpha=0.001)
+        analyzer = ABTestAnalyzer(config=config)
+        report = analyzer.analyze(path_a, path_b)
+        assert report.alpha == 0.001
+
+    def test_custom_metrics(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "control", seed=42)
+        path_b = _write_benchmark(tmp_path, "treatment", seed=42)
+        config = ABTestConfig(metrics=["ttft_ms"])
+        analyzer = ABTestAnalyzer(config=config)
+        report = analyzer.analyze(path_a, path_b)
+        assert len(report.results) == 1
+        assert report.results[0].metric == "ttft_ms"
+
+    def test_invalid_metric(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "control", seed=42)
+        path_b = _write_benchmark(tmp_path, "treatment", seed=42)
+        config = ABTestConfig(metrics=["invalid_metric"])
+        analyzer = ABTestAnalyzer(config=config)
+        with pytest.raises(ValueError, match="Invalid metric"):
+            analyzer.analyze(path_a, path_b)
+
+    def test_small_sample_warning(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "control", n_requests=10, seed=42)
+        path_b = _write_benchmark(tmp_path, "treatment", n_requests=10, seed=43)
+        analyzer = ABTestAnalyzer()
+        report = analyzer.analyze(path_a, path_b)
+        for r in report.results:
+            assert not r.power_warning.adequate
+
+    def test_summary_no_significant(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "control", seed=42)
+        path_b = _write_benchmark(tmp_path, "treatment", seed=42)
+        report = ABTestAnalyzer().analyze(path_a, path_b)
+        assert "No statistically significant" in report.summary
+
+    def test_summary_with_significant(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "control", ttft_base=50.0, seed=42)
+        path_b = _write_benchmark(tmp_path, "treatment", ttft_base=100.0, seed=99)
+        report = ABTestAnalyzer().analyze(path_a, path_b)
+        assert "Significant differences" in report.summary
+
+    def test_ci_contains_zero_for_same_data(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "control", seed=42)
+        path_b = _write_benchmark(tmp_path, "treatment", seed=42)
+        report = ABTestAnalyzer().analyze(path_a, path_b)
+        for r in report.results:
+            assert r.ci.lower <= 0 <= r.ci.upper
+
+    def test_effect_size_negligible_for_same_data(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "control", seed=42)
+        path_b = _write_benchmark(tmp_path, "treatment", seed=42)
+        report = ABTestAnalyzer().analyze(path_a, path_b)
+        for r in report.results:
+            assert r.effect_size.magnitude == EffectMagnitude.NEGLIGIBLE
+
+
+class TestAnalyzeABTestAPI:
+    def test_default(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "control", seed=42)
+        path_b = _write_benchmark(tmp_path, "treatment", seed=42)
+        report = analyze_ab_test(path_a, path_b)
+        assert isinstance(report, ABTestReport)
+        assert len(report.results) == 3
+
+    def test_custom_params(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "control", seed=42)
+        path_b = _write_benchmark(tmp_path, "treatment", seed=42)
+        report = analyze_ab_test(path_a, path_b, alpha=0.01, metrics=["tpot_ms"])
+        assert len(report.results) == 1
+        assert report.alpha == 0.01
+
+    def test_json_serialization(self, tmp_path):
+        path_a = _write_benchmark(tmp_path, "control", seed=42)
+        path_b = _write_benchmark(tmp_path, "treatment", seed=42)
+        report = analyze_ab_test(path_a, path_b)
+        j = json.loads(report.model_dump_json())
+        assert "results" in j
+        assert "summary" in j
+        assert len(j["results"]) == 3
+
+
+class TestCLIABTest:
+    def test_cli_table_output(self, tmp_path):
+        from xpyd_plan.cli._main import main
+
+        path_a = _write_benchmark(tmp_path, "control", ttft_base=50.0, seed=42)
+        path_b = _write_benchmark(tmp_path, "treatment", ttft_base=80.0, seed=99)
+        main([
+            "ab-test",
+            "--control", path_a,
+            "--treatment", path_b,
+        ])
+
+    def test_cli_json_output(self, tmp_path, capsys):
+        from xpyd_plan.cli._main import main
+
+        path_a = _write_benchmark(tmp_path, "control", seed=42)
+        path_b = _write_benchmark(tmp_path, "treatment", seed=42)
+        main([
+            "ab-test",
+            "--control", path_a,
+            "--treatment", path_b,
+            "--output-format", "json",
+        ])
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert "results" in data
+
+    def test_cli_custom_alpha(self, tmp_path):
+        from xpyd_plan.cli._main import main
+
+        path_a = _write_benchmark(tmp_path, "control", seed=42)
+        path_b = _write_benchmark(tmp_path, "treatment", seed=42)
+        main([
+            "ab-test",
+            "--control", path_a,
+            "--treatment", path_b,
+            "--alpha", "0.01",
+        ])
+
+    def test_cli_custom_metric(self, tmp_path, capsys):
+        from xpyd_plan.cli._main import main
+
+        path_a = _write_benchmark(tmp_path, "control", seed=42)
+        path_b = _write_benchmark(tmp_path, "treatment", seed=42)
+        main([
+            "ab-test",
+            "--control", path_a,
+            "--treatment", path_b,
+            "--metric", "ttft_ms",
+            "--output-format", "json",
+        ])
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert len(data["results"]) == 1


### PR DESCRIPTION
## Summary

Implements M33: A/B Test Analysis for statistically rigorous comparison of benchmark configurations.

### Changes

- `ABTestAnalyzer` class in `ab_test.py` with `analyze()` method
- `ABTestConfig`, `ABTestResult`, `StatisticalTest`, `EffectSize`, `ABConfidenceInterval`, `PowerWarning` Pydantic models
- Welch's t-test for latency metric differences (TTFT, TPOT, total latency)
- Mann-Whitney U test as non-parametric alternative
- Cohen's d effect size with negligible/small/medium/large classification
- 95% CI for mean difference
- Power analysis: warns when sample size < 30
- CLI `ab-test` subcommand with `--control`, `--treatment`, `--alpha`, `--metric`, `--output-format`
- Programmatic `analyze_ab_test()` API
- 41 new tests (775 total)

Closes #80