### PR TITLE
feat(scaling): throughput scaling analysis (M35)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -450,3 +450,16 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `workload` subcommand with table + JSON output
 - Programmatic `classify_workload()` API
 - 25 new tests (800 total)
+
+### M35 ✅ Throughput Scaling Analysis
+
+*Completed — PR #TBD*
+
+- `ScalingAnalyzer` class in `scaling.py`
+- `ScalingPoint`, `ScalingCurve`, `ScalingReport` Pydantic models
+- Per-instance throughput and scaling efficiency calculation (relative to baseline)
+- Knee-point detection: first configuration where efficiency drops below threshold (default 80%)
+- Optimal scaling point recommendation (highest QPS while above threshold)
+- CLI `scaling` subcommand with `--benchmark` (multiple files), `--knee-threshold`, table + JSON output
+- Programmatic `analyze_scaling()` API
+- 21 new tests (821 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -152,6 +152,13 @@ from xpyd_plan.recommender import (
     RecommendationReport,
     get_recommendations,
 )
+from xpyd_plan.scaling import (
+    ScalingAnalyzer,
+    ScalingCurve,
+    ScalingPoint,
+    ScalingReport,
+    analyze_scaling,
+)
 from xpyd_plan.trend import TrendEntry, TrendReport, TrendTracker, track_trend
 from xpyd_plan.validator import (
     DataQualityScore,
@@ -299,4 +306,9 @@ __all__ = [
     "WorkloadProfile",
     "WorkloadReport",
     "classify_workload",
+    "ScalingAnalyzer",
+    "ScalingCurve",
+    "ScalingPoint",
+    "ScalingReport",
+    "analyze_scaling",
 ]

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -25,6 +25,7 @@ from xpyd_plan.cli._model_compare import _cmd_model_compare
 from xpyd_plan.cli._pareto import _cmd_pareto
 from xpyd_plan.cli._pipeline import _cmd_pipeline
 from xpyd_plan.cli._recommend import _cmd_recommend
+from xpyd_plan.cli._scaling import _cmd_scaling, add_scaling_parser
 from xpyd_plan.cli._trend import _cmd_trend
 from xpyd_plan.cli._validate import _cmd_validate
 from xpyd_plan.cli._whatif import _cmd_what_if
@@ -846,6 +847,9 @@ def main(argv: list[str] | None = None) -> None:
         help="Output format (default: table)",
     )
 
+    # --- scaling subcommand ---
+    add_scaling_parser(subparsers)
+
     args = parser.parse_args(argv)
 
     if args.command == "config":
@@ -903,6 +907,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_ab_test(args)
     elif args.command == "workload":
         _cmd_workload(args)
+    elif args.command == "scaling":
+        _cmd_scaling(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/cli/_scaling.py
+++ b/src/xpyd_plan/cli/_scaling.py
@@ -1,0 +1,94 @@
+"""CLI scaling command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.scaling import ScalingAnalyzer
+
+
+def _cmd_scaling(args: argparse.Namespace) -> None:
+    """Handle the 'scaling' subcommand."""
+    console = Console()
+
+    if len(args.benchmark) < 2:
+        console.print("[red]Error: need at least 2 benchmark files for scaling analysis[/red]")
+        sys.exit(1)
+
+    benchmarks = []
+    for path in args.benchmark:
+        benchmarks.append(load_benchmark_auto(path))
+
+    analyzer = ScalingAnalyzer(knee_threshold=args.knee_threshold)
+    report = analyzer.analyze(benchmarks)
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Table output
+    table = Table(title="Throughput Scaling Analysis")
+    table.add_column("Instances", justify="right")
+    table.add_column("P:D", justify="center")
+    table.add_column("QPS", justify="right")
+    table.add_column("Per-Instance QPS", justify="right")
+    table.add_column("Efficiency", justify="right")
+    table.add_column("Note", justify="left")
+
+    for point in report.curve.points:
+        note = ""
+        knee = report.curve.knee_point
+        if knee and point.total_instances == knee.total_instances:
+            note = "⚠ knee"
+        if point.total_instances == report.curve.optimal_point.total_instances:
+            note = "★ optimal" if not note else "⚠ knee"
+
+        eff_style = "green" if point.scaling_efficiency >= args.knee_threshold else "red"
+
+        table.add_row(
+            str(point.total_instances),
+            f"{point.num_prefill}:{point.num_decode}",
+            f"{point.measured_qps:.1f}",
+            f"{point.per_instance_qps:.2f}",
+            f"[{eff_style}]{point.scaling_efficiency:.0%}[/{eff_style}]",
+            note,
+        )
+
+    console.print(table)
+    console.print()
+    console.print(f"[bold]{report.recommendation}[/bold]")
+
+
+def add_scaling_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the scaling subcommand parser."""
+    parser = subparsers.add_parser(
+        "scaling",
+        help="Analyze throughput scaling across different instance counts",
+    )
+    parser.add_argument(
+        "--benchmark",
+        nargs="+",
+        required=True,
+        help="Benchmark JSON files (at least 2, different instance counts)",
+    )
+    parser.add_argument(
+        "--knee-threshold",
+        type=float,
+        default=0.8,
+        help="Scaling efficiency threshold for knee detection (default: 0.8)",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_scaling)

--- a/src/xpyd_plan/scaling.py
+++ b/src/xpyd_plan/scaling.py
@@ -1,0 +1,181 @@
+"""Throughput scaling analysis across benchmark runs with different instance counts."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData
+
+
+class ScalingPoint(BaseModel):
+    """A single data point on the scaling curve."""
+
+    total_instances: int = Field(..., ge=2, description="Total instance count")
+    num_prefill: int = Field(..., ge=1)
+    num_decode: int = Field(..., ge=1)
+    measured_qps: float = Field(..., gt=0, description="Measured throughput (QPS)")
+    per_instance_qps: float = Field(..., gt=0, description="QPS per instance")
+    scaling_efficiency: float = Field(
+        ...,
+        ge=0,
+        le=1,
+        description="Actual throughput / ideal linear throughput (relative to baseline)",
+    )
+
+
+class ScalingCurve(BaseModel):
+    """Scaling curve with all data points and analysis."""
+
+    points: list[ScalingPoint] = Field(..., min_length=1)
+    baseline_per_instance_qps: float = Field(
+        ..., gt=0, description="Per-instance QPS of the smallest configuration (baseline)"
+    )
+    knee_point: ScalingPoint | None = Field(
+        None,
+        description="First point where scaling efficiency drops below threshold",
+    )
+    knee_threshold: float = Field(
+        0.8, description="Efficiency threshold used for knee detection"
+    )
+    optimal_point: ScalingPoint = Field(
+        ..., description="Point with highest total QPS while above knee threshold"
+    )
+
+
+class ScalingReport(BaseModel):
+    """Complete scaling analysis report."""
+
+    curve: ScalingCurve
+    recommendation: str = Field(..., description="Human-readable recommendation")
+
+
+class ScalingAnalyzer:
+    """Analyze throughput scaling across benchmark runs with different instance counts."""
+
+    def __init__(self, knee_threshold: float = 0.8) -> None:
+        """Initialize with knee-point detection threshold.
+
+        Args:
+            knee_threshold: Scaling efficiency below this triggers knee detection.
+                Must be between 0 and 1 (exclusive). Default 0.8 (80%).
+        """
+        if not 0 < knee_threshold < 1:
+            msg = f"knee_threshold must be between 0 and 1 exclusive, got {knee_threshold}"
+            raise ValueError(msg)
+        self.knee_threshold = knee_threshold
+
+    def analyze(self, benchmarks: list[BenchmarkData]) -> ScalingReport:
+        """Analyze scaling across multiple benchmark runs.
+
+        Args:
+            benchmarks: List of benchmark datasets with different instance counts.
+                Must contain at least 2 benchmarks with distinct total_instances.
+
+        Returns:
+            ScalingReport with curve, knee point, and recommendation.
+
+        Raises:
+            ValueError: If fewer than 2 benchmarks or all have same instance count.
+        """
+        if len(benchmarks) < 2:
+            msg = "Need at least 2 benchmark datasets for scaling analysis"
+            raise ValueError(msg)
+
+        # Sort by total instances
+        sorted_benchmarks = sorted(benchmarks, key=lambda b: b.metadata.total_instances)
+
+        # Check distinct instance counts
+        instance_counts = {b.metadata.total_instances for b in sorted_benchmarks}
+        if len(instance_counts) < 2:
+            msg = "Need benchmarks with at least 2 distinct total_instances values"
+            raise ValueError(msg)
+
+        # Baseline: smallest configuration
+        baseline = sorted_benchmarks[0]
+        baseline_per_instance = baseline.metadata.measured_qps / baseline.metadata.total_instances
+
+        # Build scaling points
+        points: list[ScalingPoint] = []
+        for bench in sorted_benchmarks:
+            meta = bench.metadata
+            per_inst = meta.measured_qps / meta.total_instances
+            ideal_qps = baseline_per_instance * meta.total_instances
+            efficiency = meta.measured_qps / ideal_qps if ideal_qps > 0 else 0.0
+            # Clamp efficiency to [0, 1]
+            efficiency = min(1.0, max(0.0, efficiency))
+
+            points.append(
+                ScalingPoint(
+                    total_instances=meta.total_instances,
+                    num_prefill=meta.num_prefill_instances,
+                    num_decode=meta.num_decode_instances,
+                    measured_qps=meta.measured_qps,
+                    per_instance_qps=round(per_inst, 4),
+                    scaling_efficiency=round(efficiency, 4),
+                )
+            )
+
+        # Find knee point (first point below threshold)
+        knee_point: ScalingPoint | None = None
+        for point in points:
+            if point.scaling_efficiency < self.knee_threshold:
+                knee_point = point
+                break
+
+        # Optimal point: highest QPS among points at or above threshold
+        above_threshold = [p for p in points if p.scaling_efficiency >= self.knee_threshold]
+        if above_threshold:
+            optimal = max(above_threshold, key=lambda p: p.measured_qps)
+        else:
+            # All below threshold, pick the one with best efficiency
+            optimal = max(points, key=lambda p: p.scaling_efficiency)
+
+        curve = ScalingCurve(
+            points=points,
+            baseline_per_instance_qps=round(baseline_per_instance, 4),
+            knee_point=knee_point,
+            knee_threshold=self.knee_threshold,
+            optimal_point=optimal,
+        )
+
+        # Build recommendation
+        recommendation = self._build_recommendation(curve)
+
+        return ScalingReport(curve=curve, recommendation=recommendation)
+
+    def _build_recommendation(self, curve: ScalingCurve) -> str:
+        """Generate a human-readable recommendation from the scaling curve."""
+        opt = curve.optimal_point
+        if curve.knee_point is None:
+            return (
+                f"Scaling is efficient across all tested configurations. "
+                f"Optimal: {opt.total_instances} instances "
+                f"({opt.num_prefill}P:{opt.num_decode}D) at {opt.measured_qps:.1f} QPS "
+                f"with {opt.scaling_efficiency:.0%} efficiency."
+            )
+        knee = curve.knee_point
+        return (
+            f"Diminishing returns detected at {knee.total_instances} instances "
+            f"({knee.scaling_efficiency:.0%} efficiency). "
+            f"Recommended: {opt.total_instances} instances "
+            f"({opt.num_prefill}P:{opt.num_decode}D) at {opt.measured_qps:.1f} QPS "
+            f"with {opt.scaling_efficiency:.0%} efficiency."
+        )
+
+
+def analyze_scaling(
+    benchmarks: list[BenchmarkData],
+    knee_threshold: float = 0.8,
+) -> dict:
+    """Programmatic API for scaling analysis.
+
+    Args:
+        benchmarks: List of benchmark datasets with different instance counts.
+        knee_threshold: Efficiency threshold for knee-point detection.
+
+    Returns:
+        Dictionary representation of ScalingReport.
+    """
+    analyzer = ScalingAnalyzer(knee_threshold=knee_threshold)
+    report = analyzer.analyze(benchmarks)
+    return report.model_dump()

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -1,0 +1,296 @@
+"""Tests for throughput scaling analysis."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.scaling import ScalingAnalyzer, analyze_scaling
+
+
+def _make_benchmark(
+    num_prefill: int,
+    num_decode: int,
+    qps: float,
+    num_requests: int = 50,
+) -> BenchmarkData:
+    """Create a benchmark dataset with given configuration."""
+    total = num_prefill + num_decode
+    requests = [
+        BenchmarkRequest(
+            request_id=f"req-{i}",
+            prompt_tokens=100,
+            output_tokens=50,
+            ttft_ms=20.0,
+            tpot_ms=10.0,
+            total_latency_ms=70.0,
+            timestamp=1000.0 + i,
+        )
+        for i in range(num_requests)
+    ]
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=num_prefill,
+            num_decode_instances=num_decode,
+            total_instances=total,
+            measured_qps=qps,
+        ),
+        requests=requests,
+    )
+
+
+class TestScalingAnalyzer:
+    """Tests for ScalingAnalyzer."""
+
+    def test_basic_linear_scaling(self) -> None:
+        """Perfect linear scaling should have 100% efficiency everywhere."""
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),   # 2 instances, 10 QPS
+            _make_benchmark(2, 2, 20.0),   # 4 instances, 20 QPS
+            _make_benchmark(3, 3, 30.0),   # 6 instances, 30 QPS
+        ]
+        analyzer = ScalingAnalyzer()
+        report = analyzer.analyze(benchmarks)
+
+        assert len(report.curve.points) == 3
+        for point in report.curve.points:
+            assert point.scaling_efficiency == 1.0
+        assert report.curve.knee_point is None
+
+    def test_diminishing_returns(self) -> None:
+        """Scaling that degrades should detect knee point."""
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),   # 2 inst, 5.0/inst
+            _make_benchmark(2, 2, 18.0),   # 4 inst, 4.5/inst, eff=0.9
+            _make_benchmark(3, 3, 21.0),   # 6 inst, 3.5/inst, eff=0.7
+        ]
+        analyzer = ScalingAnalyzer(knee_threshold=0.8)
+        report = analyzer.analyze(benchmarks)
+
+        assert report.curve.knee_point is not None
+        assert report.curve.knee_point.total_instances == 6
+        assert report.curve.optimal_point.total_instances == 4
+
+    def test_all_below_threshold(self) -> None:
+        """When all points are below threshold, pick best efficiency."""
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),   # baseline
+            _make_benchmark(2, 2, 14.0),   # eff=0.7
+            _make_benchmark(3, 3, 15.0),   # eff=0.5
+        ]
+        analyzer = ScalingAnalyzer(knee_threshold=0.9)
+        report = analyzer.analyze(benchmarks)
+
+        # Baseline itself has eff=1.0 which is above threshold
+        # So optimal is baseline
+        assert report.curve.optimal_point.total_instances == 2
+
+    def test_minimum_two_benchmarks(self) -> None:
+        """Need at least 2 benchmarks."""
+        with pytest.raises(ValueError, match="at least 2"):
+            ScalingAnalyzer().analyze([_make_benchmark(1, 1, 10.0)])
+
+    def test_same_instance_count_error(self) -> None:
+        """Same instance count in all benchmarks is an error."""
+        with pytest.raises(ValueError, match="distinct"):
+            ScalingAnalyzer().analyze([
+                _make_benchmark(1, 1, 10.0),
+                _make_benchmark(1, 1, 12.0),
+            ])
+
+    def test_invalid_knee_threshold(self) -> None:
+        """Knee threshold must be between 0 and 1 exclusive."""
+        with pytest.raises(ValueError):
+            ScalingAnalyzer(knee_threshold=0.0)
+        with pytest.raises(ValueError):
+            ScalingAnalyzer(knee_threshold=1.0)
+        with pytest.raises(ValueError):
+            ScalingAnalyzer(knee_threshold=-0.1)
+
+    def test_sorted_by_instances(self) -> None:
+        """Points should be sorted by instance count regardless of input order."""
+        benchmarks = [
+            _make_benchmark(3, 3, 30.0),
+            _make_benchmark(1, 1, 10.0),
+            _make_benchmark(2, 2, 20.0),
+        ]
+        report = ScalingAnalyzer().analyze(benchmarks)
+        instances = [p.total_instances for p in report.curve.points]
+        assert instances == [2, 4, 6]
+
+    def test_per_instance_qps(self) -> None:
+        """Per-instance QPS should be correctly calculated."""
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),
+            _make_benchmark(2, 3, 25.0),
+        ]
+        report = ScalingAnalyzer().analyze(benchmarks)
+        assert report.curve.points[0].per_instance_qps == 5.0
+        assert report.curve.points[1].per_instance_qps == 5.0
+
+    def test_baseline_per_instance_qps(self) -> None:
+        """Baseline per-instance QPS should come from smallest config."""
+        benchmarks = [
+            _make_benchmark(2, 2, 20.0),
+            _make_benchmark(1, 1, 12.0),
+        ]
+        report = ScalingAnalyzer().analyze(benchmarks)
+        assert report.curve.baseline_per_instance_qps == 6.0
+
+    def test_recommendation_no_knee(self) -> None:
+        """Recommendation when no knee point exists."""
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),
+            _make_benchmark(2, 2, 20.0),
+        ]
+        report = ScalingAnalyzer().analyze(benchmarks)
+        assert "efficient" in report.recommendation.lower()
+
+    def test_recommendation_with_knee(self) -> None:
+        """Recommendation when knee point exists."""
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),
+            _make_benchmark(2, 2, 18.0),
+            _make_benchmark(3, 3, 21.0),
+        ]
+        report = ScalingAnalyzer(knee_threshold=0.8).analyze(benchmarks)
+        assert "diminishing" in report.recommendation.lower()
+
+    def test_analyze_scaling_api(self) -> None:
+        """Programmatic API returns dict."""
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),
+            _make_benchmark(2, 2, 20.0),
+        ]
+        result = analyze_scaling(benchmarks)
+        assert isinstance(result, dict)
+        assert "curve" in result
+        assert "recommendation" in result
+
+    def test_asymmetric_pd_ratios(self) -> None:
+        """Handle benchmarks with different P:D ratios."""
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),
+            _make_benchmark(1, 3, 18.0),
+        ]
+        report = ScalingAnalyzer().analyze(benchmarks)
+        assert report.curve.points[0].num_prefill == 1
+        assert report.curve.points[1].num_decode == 3
+
+    def test_many_points(self) -> None:
+        """Handle many scaling points."""
+        benchmarks = []
+        for i in range(1, 11):
+            # Simulate sub-linear scaling
+            qps = 10.0 * i * (1 - 0.02 * i)
+            benchmarks.append(_make_benchmark(i, i, qps))
+        report = ScalingAnalyzer(knee_threshold=0.8).analyze(benchmarks)
+        assert len(report.curve.points) == 10
+
+    def test_scaling_efficiency_clamped(self) -> None:
+        """Efficiency should be clamped to [0, 1]."""
+        # Second config has BETTER per-instance QPS than baseline (super-linear)
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),
+            _make_benchmark(2, 2, 25.0),  # super-linear
+        ]
+        report = ScalingAnalyzer().analyze(benchmarks)
+        for p in report.curve.points:
+            assert 0.0 <= p.scaling_efficiency <= 1.0
+
+    def test_model_dump(self) -> None:
+        """ScalingReport should be serializable."""
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),
+            _make_benchmark(2, 2, 18.0),
+            _make_benchmark(3, 3, 21.0),
+        ]
+        report = ScalingAnalyzer(knee_threshold=0.8).analyze(benchmarks)
+        data = report.model_dump()
+        assert isinstance(data, dict)
+        assert data["curve"]["knee_threshold"] == 0.8
+
+    def test_two_benchmarks_minimum(self) -> None:
+        """Exactly 2 benchmarks should work."""
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),
+            _make_benchmark(2, 2, 18.0),
+        ]
+        report = ScalingAnalyzer().analyze(benchmarks)
+        assert len(report.curve.points) == 2
+
+    def test_custom_knee_threshold(self) -> None:
+        """Custom knee threshold changes knee detection."""
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),
+            _make_benchmark(2, 2, 18.0),   # eff=0.9
+            _make_benchmark(3, 3, 21.0),   # eff=0.7
+        ]
+        # With 0.95 threshold, knee should be at 4 instances (eff=0.9 < 0.95)
+        report = ScalingAnalyzer(knee_threshold=0.95).analyze(benchmarks)
+        assert report.curve.knee_point is not None
+        assert report.curve.knee_point.total_instances == 4
+
+    def test_json_roundtrip(self) -> None:
+        """Report can be serialized and deserialized."""
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),
+            _make_benchmark(2, 2, 20.0),
+        ]
+        report = ScalingAnalyzer().analyze(benchmarks)
+        data = json.loads(json.dumps(report.model_dump()))
+        assert data["curve"]["points"][0]["total_instances"] == 2
+
+
+class TestScalingCLI:
+    """Tests for scaling CLI subcommand."""
+
+    def test_cli_scaling_table(self) -> None:
+        """CLI scaling command produces output."""
+        from xpyd_plan.cli._main import main
+
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),
+            _make_benchmark(2, 2, 20.0),
+        ]
+
+        files = []
+        for i, bench in enumerate(benchmarks):
+            f = tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False, prefix=f"bench{i}_"
+            )
+            json.dump(bench.model_dump(), f)
+            f.close()
+            files.append(f.name)
+
+        # Should not raise
+        try:
+            main(["scaling", "--benchmark", *files])
+        except SystemExit:
+            pass  # OK if it exits cleanly
+
+    def test_cli_scaling_json(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """CLI scaling JSON output is valid JSON."""
+        from xpyd_plan.cli._main import main
+
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),
+            _make_benchmark(2, 2, 20.0),
+        ]
+
+        files = []
+        for i, bench in enumerate(benchmarks):
+            f = tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False, prefix=f"bench{i}_"
+            )
+            json.dump(bench.model_dump(), f)
+            f.close()
+            files.append(f.name)
+
+        main(["scaling", "--benchmark", *files, "--output-format", "json"])
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "curve" in data


### PR DESCRIPTION
## Summary

Add throughput scaling analysis to identify diminishing returns when scaling PD-disaggregated clusters.

## Changes

- `ScalingAnalyzer` class in `scaling.py` with knee-point detection
- `ScalingPoint`, `ScalingCurve`, `ScalingReport` Pydantic models
- Per-instance throughput and scaling efficiency calculation
- Optimal scaling point recommendation (highest QPS above efficiency threshold)
- CLI `scaling` subcommand with `--benchmark`, `--knee-threshold`, table + JSON output
- Programmatic `analyze_scaling()` API
- 21 new tests (821 total, all passing)

Closes #84