### PR TITLE
feat(metrics): Prometheus/OpenMetrics export (M36)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -453,7 +453,7 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 
 ### M35 ✅ Throughput Scaling Analysis
 
-*Completed — PR #TBD*
+*Completed — PR #85*
 
 - `ScalingAnalyzer` class in `scaling.py`
 - `ScalingPoint`, `ScalingCurve`, `ScalingReport` Pydantic models
@@ -463,3 +463,17 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `scaling` subcommand with `--benchmark` (multiple files), `--knee-threshold`, table + JSON output
 - Programmatic `analyze_scaling()` API
 - 21 new tests (821 total)
+
+### M36 ✅ Prometheus/OpenMetrics Export
+
+*Completed — PR #TBD*
+
+- `MetricsExporter` class in `metrics_export.py`
+- `MetricLine`, `MetricsReport` Pydantic models
+- Export analysis results as Prometheus/OpenMetrics text format
+- Metrics: latency percentiles (P50/P95/P99) for TTFT/TPOT/total, QPS, instance counts, request count
+- Labels encode P:D ratio, instance configuration
+- HELP and TYPE annotations per OpenMetrics spec
+- CLI `metrics` subcommand with `--benchmark`, `--output`, `--output-format text|json|table`
+- Programmatic `export_metrics()` API
+- ~20 new tests

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -113,6 +113,12 @@ from xpyd_plan.merger import (
     MergeStrategy,
     merge_benchmarks,
 )
+from xpyd_plan.metrics_export import (
+    MetricLine,
+    MetricsExporter,
+    MetricsReport,
+    export_metrics,
+)
 from xpyd_plan.model_compare import (
     ComparisonMatrix,
     ModelComparator,
@@ -311,4 +317,8 @@ __all__ = [
     "ScalingPoint",
     "ScalingReport",
     "analyze_scaling",
+    "MetricLine",
+    "MetricsExporter",
+    "MetricsReport",
+    "export_metrics",
 ]

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -21,6 +21,7 @@ from xpyd_plan.cli._fleet import _cmd_fleet
 from xpyd_plan.cli._generate import _cmd_generate
 from xpyd_plan.cli._interpolate import _cmd_interpolate
 from xpyd_plan.cli._merge import _cmd_merge
+from xpyd_plan.cli._metrics import _cmd_metrics, add_metrics_parser
 from xpyd_plan.cli._model_compare import _cmd_model_compare
 from xpyd_plan.cli._pareto import _cmd_pareto
 from xpyd_plan.cli._pipeline import _cmd_pipeline
@@ -847,6 +848,9 @@ def main(argv: list[str] | None = None) -> None:
         help="Output format (default: table)",
     )
 
+    # --- metrics subcommand ---
+    add_metrics_parser(subparsers)
+
     # --- scaling subcommand ---
     add_scaling_parser(subparsers)
 
@@ -909,6 +913,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_workload(args)
     elif args.command == "scaling":
         _cmd_scaling(args)
+    elif args.command == "metrics":
+        _cmd_metrics(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/cli/_metrics.py
+++ b/src/xpyd_plan/cli/_metrics.py
@@ -1,0 +1,80 @@
+"""CLI metrics command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.metrics_export import MetricsExporter
+
+
+def _cmd_metrics(args: argparse.Namespace) -> None:
+    """Handle the 'metrics' subcommand."""
+    console = Console()
+
+    benchmarks = []
+    for path in args.benchmark:
+        benchmarks.append(load_benchmark_auto(path))
+
+    exporter = MetricsExporter()
+    report = exporter.export(benchmarks)
+
+    output_format = getattr(args, "output_format", "text")
+
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    elif output_format == "table":
+        table = Table(title="Exported Metrics")
+        table.add_column("Name", style="cyan")
+        table.add_column("Labels", style="dim")
+        table.add_column("Value", justify="right")
+        table.add_column("Type", style="green")
+
+        for m in report.metrics:
+            label_str = ", ".join(f"{k}={v}" for k, v in sorted(m.labels.items()))
+            table.add_row(m.name, label_str, f"{m.value:.4f}", m.metric_type)
+
+        console.print(table)
+    else:
+        # Default: OpenMetrics text format
+        sys.stdout.write(report.text)
+
+    # Write to file if requested
+    output_path = getattr(args, "output", None)
+    if output_path:
+        Path(output_path).write_text(report.text)
+        console.print(f"[green]Metrics written to {output_path}[/green]", stderr=True)
+
+
+def add_metrics_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the metrics subcommand parser."""
+    parser = subparsers.add_parser(
+        "metrics",
+        help="Export benchmark analysis as Prometheus/OpenMetrics format",
+    )
+    parser.add_argument(
+        "--benchmark",
+        nargs="+",
+        required=True,
+        help="Benchmark JSON files to export",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Write OpenMetrics text to file",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["text", "json", "table"],
+        default="text",
+        help="Output format (default: text = OpenMetrics)",
+    )
+    parser.set_defaults(func=_cmd_metrics)

--- a/src/xpyd_plan/metrics_export.py
+++ b/src/xpyd_plan/metrics_export.py
@@ -1,0 +1,156 @@
+"""Prometheus/OpenMetrics text format exporter for benchmark analysis results."""
+
+from __future__ import annotations
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData
+
+
+class MetricLine(BaseModel):
+    """A single metric line in OpenMetrics format."""
+
+    name: str = Field(..., description="Metric name")
+    labels: dict[str, str] = Field(default_factory=dict, description="Label key-value pairs")
+    value: float = Field(..., description="Metric value")
+    metric_type: str = Field("gauge", description="Metric type (gauge, counter, info)")
+    help_text: str = Field("", description="HELP description for this metric")
+
+
+class MetricsReport(BaseModel):
+    """Complete metrics export result."""
+
+    metrics: list[MetricLine] = Field(default_factory=list)
+    text: str = Field("", description="Rendered OpenMetrics text")
+
+
+class MetricsExporter:
+    """Export benchmark analysis results in Prometheus/OpenMetrics text format."""
+
+    METRIC_PREFIX = "xpyd_plan"
+
+    def export(self, benchmarks: list[BenchmarkData]) -> MetricsReport:
+        """Export one or more benchmark datasets as OpenMetrics metrics.
+
+        Args:
+            benchmarks: Benchmark datasets to export.
+
+        Returns:
+            MetricsReport with structured metrics and rendered text.
+
+        Raises:
+            ValueError: If benchmarks list is empty.
+        """
+        if not benchmarks:
+            msg = "Need at least 1 benchmark dataset"
+            raise ValueError(msg)
+
+        metrics: list[MetricLine] = []
+
+        for bench in benchmarks:
+            meta = bench.metadata
+            labels = {
+                "num_prefill": str(meta.num_prefill_instances),
+                "num_decode": str(meta.num_decode_instances),
+                "total_instances": str(meta.total_instances),
+                "pd_ratio": f"{meta.num_prefill_instances}:{meta.num_decode_instances}",
+            }
+
+            # Instance counts
+            metrics.append(MetricLine(
+                name=f"{self.METRIC_PREFIX}_prefill_instances",
+                labels=labels,
+                value=float(meta.num_prefill_instances),
+                help_text="Number of prefill instances",
+            ))
+            metrics.append(MetricLine(
+                name=f"{self.METRIC_PREFIX}_decode_instances",
+                labels=labels,
+                value=float(meta.num_decode_instances),
+                help_text="Number of decode instances",
+            ))
+            metrics.append(MetricLine(
+                name=f"{self.METRIC_PREFIX}_total_instances",
+                labels=labels,
+                value=float(meta.total_instances),
+                help_text="Total instance count",
+            ))
+
+            # QPS
+            metrics.append(MetricLine(
+                name=f"{self.METRIC_PREFIX}_measured_qps",
+                labels=labels,
+                value=meta.measured_qps,
+                help_text="Measured queries per second",
+            ))
+
+            # Request count
+            metrics.append(MetricLine(
+                name=f"{self.METRIC_PREFIX}_request_count",
+                labels=labels,
+                value=float(len(bench.requests)),
+                metric_type="counter",
+                help_text="Total number of benchmark requests",
+            ))
+
+            # Latency percentiles
+            ttft_vals = [r.ttft_ms for r in bench.requests]
+            tpot_vals = [r.tpot_ms for r in bench.requests]
+            total_vals = [r.total_latency_ms for r in bench.requests]
+
+            for metric_name, values in [
+                ("ttft_ms", ttft_vals),
+                ("tpot_ms", tpot_vals),
+                ("total_latency_ms", total_vals),
+            ]:
+                for pct in [50, 95, 99]:
+                    pct_val = float(np.percentile(values, pct))
+                    pct_labels = {**labels, "percentile": str(pct)}
+                    metrics.append(MetricLine(
+                        name=f"{self.METRIC_PREFIX}_{metric_name}",
+                        labels=pct_labels,
+                        value=round(pct_val, 4),
+                        help_text=f"{metric_name} at p{pct}",
+                    ))
+
+        text = self._render_openmetrics(metrics)
+        return MetricsReport(metrics=metrics, text=text)
+
+    def _render_openmetrics(self, metrics: list[MetricLine]) -> str:
+        """Render metrics as OpenMetrics text format."""
+        lines: list[str] = []
+        seen_help: set[str] = set()
+
+        for m in metrics:
+            if m.name not in seen_help:
+                lines.append(f"# HELP {m.name} {m.help_text}")
+                lines.append(f"# TYPE {m.name} {m.metric_type}")
+                seen_help.add(m.name)
+
+            if m.labels:
+                label_str = ",".join(
+                    f'{k}="{v}"' for k, v in sorted(m.labels.items())
+                )
+                lines.append(f"{m.name}{{{label_str}}} {m.value}")
+            else:
+                lines.append(f"{m.name} {m.value}")
+
+        lines.append("# EOF")
+        return "\n".join(lines) + "\n"
+
+
+def export_metrics(
+    benchmarks: list[BenchmarkData],
+) -> dict:
+    """Programmatic API for metrics export.
+
+    Args:
+        benchmarks: List of benchmark datasets.
+
+    Returns:
+        Dictionary representation of MetricsReport.
+    """
+    exporter = MetricsExporter()
+    report = exporter.export(benchmarks)
+    return report.model_dump()

--- a/tests/test_metrics_export.py
+++ b/tests/test_metrics_export.py
@@ -1,0 +1,222 @@
+"""Tests for Prometheus/OpenMetrics export."""
+
+from __future__ import annotations
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.metrics_export import MetricLine, MetricsExporter, MetricsReport, export_metrics
+
+
+def _make_benchmark(
+    num_prefill: int,
+    num_decode: int,
+    qps: float,
+    num_requests: int = 50,
+) -> BenchmarkData:
+    """Create a benchmark dataset with given configuration."""
+    requests = [
+        BenchmarkRequest(
+            request_id=f"req-{i}",
+            prompt_tokens=100,
+            output_tokens=50,
+            ttft_ms=20.0 + i * 0.5,
+            tpot_ms=10.0 + i * 0.2,
+            total_latency_ms=70.0 + i * 1.0,
+            timestamp=1000.0 + i,
+        )
+        for i in range(num_requests)
+    ]
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=num_prefill,
+            num_decode_instances=num_decode,
+            total_instances=num_prefill + num_decode,
+            measured_qps=qps,
+        ),
+        requests=requests,
+    )
+
+
+class TestMetricsExporter:
+    """Tests for MetricsExporter."""
+
+    def test_basic_export(self) -> None:
+        """Single benchmark produces expected metrics."""
+        bench = _make_benchmark(2, 3, 50.0)
+        exporter = MetricsExporter()
+        report = exporter.export([bench])
+
+        assert len(report.metrics) > 0
+        assert report.text.endswith("# EOF\n")
+
+    def test_metric_names(self) -> None:
+        """All metric names use correct prefix."""
+        bench = _make_benchmark(1, 1, 10.0)
+        report = MetricsExporter().export([bench])
+
+        for m in report.metrics:
+            assert m.name.startswith("xpyd_plan_")
+
+    def test_labels_include_pd_ratio(self) -> None:
+        """Labels should include P:D ratio."""
+        bench = _make_benchmark(2, 3, 50.0)
+        report = MetricsExporter().export([bench])
+
+        for m in report.metrics:
+            assert "pd_ratio" in m.labels
+            assert m.labels["pd_ratio"] == "2:3"
+
+    def test_instance_metrics(self) -> None:
+        """Instance count metrics are present."""
+        bench = _make_benchmark(2, 3, 50.0)
+        report = MetricsExporter().export([bench])
+
+        names = [m.name for m in report.metrics]
+        assert "xpyd_plan_prefill_instances" in names
+        assert "xpyd_plan_decode_instances" in names
+        assert "xpyd_plan_total_instances" in names
+
+    def test_qps_metric(self) -> None:
+        """QPS metric matches input."""
+        bench = _make_benchmark(1, 1, 42.5)
+        report = MetricsExporter().export([bench])
+
+        qps_metrics = [m for m in report.metrics if m.name == "xpyd_plan_measured_qps"]
+        assert len(qps_metrics) == 1
+        assert qps_metrics[0].value == 42.5
+
+    def test_request_count_metric(self) -> None:
+        """Request count metric matches."""
+        bench = _make_benchmark(1, 1, 10.0, num_requests=30)
+        report = MetricsExporter().export([bench])
+
+        count_metrics = [m for m in report.metrics if m.name == "xpyd_plan_request_count"]
+        assert len(count_metrics) == 1
+        assert count_metrics[0].value == 30.0
+        assert count_metrics[0].metric_type == "counter"
+
+    def test_latency_percentiles(self) -> None:
+        """Latency percentile metrics for TTFT, TPOT, total_latency at P50/P95/P99."""
+        bench = _make_benchmark(1, 1, 10.0)
+        report = MetricsExporter().export([bench])
+
+        ttft_metrics = [m for m in report.metrics if m.name == "xpyd_plan_ttft_ms"]
+        tpot_metrics = [m for m in report.metrics if m.name == "xpyd_plan_tpot_ms"]
+        total_metrics = [m for m in report.metrics if m.name == "xpyd_plan_total_latency_ms"]
+
+        assert len(ttft_metrics) == 3  # p50, p95, p99
+        assert len(tpot_metrics) == 3
+        assert len(total_metrics) == 3
+
+        percentiles = {m.labels["percentile"] for m in ttft_metrics}
+        assert percentiles == {"50", "95", "99"}
+
+    def test_latency_values_reasonable(self) -> None:
+        """Latency values should be within expected range."""
+        bench = _make_benchmark(1, 1, 10.0, num_requests=100)
+        report = MetricsExporter().export([bench])
+
+        ttft_p50 = [
+            m for m in report.metrics
+            if m.name == "xpyd_plan_ttft_ms" and m.labels.get("percentile") == "50"
+        ]
+        assert len(ttft_p50) == 1
+        assert ttft_p50[0].value > 0
+
+    def test_multi_benchmark_export(self) -> None:
+        """Multiple benchmarks produce metrics for each."""
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),
+            _make_benchmark(2, 2, 20.0),
+        ]
+        report = MetricsExporter().export(benchmarks)
+
+        qps_metrics = [m for m in report.metrics if m.name == "xpyd_plan_measured_qps"]
+        assert len(qps_metrics) == 2
+        values = {m.value for m in qps_metrics}
+        assert values == {10.0, 20.0}
+
+    def test_empty_benchmarks_error(self) -> None:
+        """Empty benchmark list raises ValueError."""
+        with pytest.raises(ValueError, match="at least 1"):
+            MetricsExporter().export([])
+
+    def test_openmetrics_format_has_help_and_type(self) -> None:
+        """Rendered text includes HELP and TYPE lines."""
+        bench = _make_benchmark(1, 1, 10.0)
+        report = MetricsExporter().export([bench])
+
+        assert "# HELP xpyd_plan_measured_qps" in report.text
+        assert "# TYPE xpyd_plan_measured_qps gauge" in report.text
+
+    def test_openmetrics_format_eof(self) -> None:
+        """OpenMetrics text ends with # EOF."""
+        bench = _make_benchmark(1, 1, 10.0)
+        report = MetricsExporter().export([bench])
+        assert report.text.strip().endswith("# EOF")
+
+    def test_openmetrics_label_format(self) -> None:
+        """Labels are correctly formatted with quotes."""
+        bench = _make_benchmark(1, 2, 10.0)
+        report = MetricsExporter().export([bench])
+
+        # Should have labels like num_decode="2"
+        assert 'num_decode="2"' in report.text
+        assert 'pd_ratio="1:2"' in report.text
+
+    def test_help_not_duplicated(self) -> None:
+        """HELP line for each metric name appears only once."""
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),
+            _make_benchmark(2, 2, 20.0),
+        ]
+        report = MetricsExporter().export(benchmarks)
+
+        help_count = report.text.count("# HELP xpyd_plan_measured_qps")
+        assert help_count == 1
+
+    def test_metric_line_model(self) -> None:
+        """MetricLine model validates correctly."""
+        m = MetricLine(name="test", labels={"a": "b"}, value=1.0)
+        assert m.metric_type == "gauge"
+        assert m.help_text == ""
+
+    def test_metrics_report_model(self) -> None:
+        """MetricsReport model works with defaults."""
+        r = MetricsReport()
+        assert r.metrics == []
+        assert r.text == ""
+
+
+class TestExportMetricsAPI:
+    """Tests for the programmatic export_metrics() function."""
+
+    def test_returns_dict(self) -> None:
+        """Programmatic API returns a dict."""
+        bench = _make_benchmark(1, 1, 10.0)
+        result = export_metrics([bench])
+        assert isinstance(result, dict)
+        assert "metrics" in result
+        assert "text" in result
+
+    def test_dict_structure(self) -> None:
+        """Returned dict has expected structure."""
+        bench = _make_benchmark(1, 1, 10.0)
+        result = export_metrics([bench])
+        assert len(result["metrics"]) > 0
+        first = result["metrics"][0]
+        assert "name" in first
+        assert "value" in first
+        assert "labels" in first
+
+    def test_api_multi_benchmark(self) -> None:
+        """API works with multiple benchmarks."""
+        benchmarks = [
+            _make_benchmark(1, 1, 10.0),
+            _make_benchmark(2, 2, 20.0),
+            _make_benchmark(3, 3, 30.0),
+        ]
+        result = export_metrics(benchmarks)
+        qps = [m for m in result["metrics"] if m["name"] == "xpyd_plan_measured_qps"]
+        assert len(qps) == 3


### PR DESCRIPTION
## Summary

Add Prometheus/OpenMetrics text format exporter for benchmark analysis results, enabling integration with monitoring stacks (Grafana, Prometheus, Datadog).

## Changes

- `MetricsExporter` class in `metrics_export.py`
- `MetricLine`, `MetricsReport` Pydantic models
- Export analysis results as OpenMetrics text format with HELP/TYPE annotations
- Metrics: latency percentiles (P50/P95/P99) for TTFT/TPOT/total, QPS, instance counts, request count
- Labels encode P:D ratio and cluster configuration
- CLI `metrics` subcommand with `--benchmark`, `--output`, `--output-format text|json|table`
- Programmatic `export_metrics()` API
- 19 new tests (840 total, all passing)

Closes #86