### PR TITLE
feat(discovery): batch benchmark discovery & auto-loading (M38)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -478,9 +478,9 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Programmatic `export_metrics()` API
 - ~20 new tests
 
-### M37 — Correlation Analysis
+### M37 ✅ Correlation Analysis
 
-*In progress — PR #89*
+*Completed — PR #89*
 
 - `CorrelationAnalyzer` class in `correlation.py`
 - `CorrelationPair`, `CorrelationReport`, `CorrelationStrength` Pydantic models
@@ -489,3 +489,17 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `correlation` subcommand with `--benchmark`, `--output-format table|json`
 - Programmatic `analyze_correlation()` API
 - 21 new tests (861 total)
+
+### M38 — Batch Benchmark Discovery & Auto-Loading
+
+*In progress — PR #TBD*
+
+- `BenchmarkDiscovery` class in `discovery.py`
+- `DiscoveredBenchmark`, `DiscoveryReport`, `ConfigGroup`, `ValidationStatus` Pydantic models
+- Recursive directory scanning with configurable depth limit
+- Glob pattern filtering (`--pattern '**/*h100*.json'`)
+- Quick validation without full deserialization
+- Group-by-config summary
+- CLI `discover` subcommand with `--dir`, `--pattern`, `--max-depth`, table + JSON output
+- Programmatic `discover_benchmarks()` API
+- ~22 new tests

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -75,6 +75,14 @@ from xpyd_plan.dashboard import (
     DashboardView,
     run_dashboard,
 )
+from xpyd_plan.discovery import (
+    BenchmarkDiscovery,
+    ConfigGroup,
+    DiscoveredBenchmark,
+    DiscoveryReport,
+    ValidationStatus,
+    discover_benchmarks,
+)
 from xpyd_plan.filter import (
     BenchmarkFilter,
     BenchmarkFilterResult,
@@ -333,4 +341,10 @@ __all__ = [
     "CorrelationReport",
     "CorrelationStrength",
     "analyze_correlation",
+    "BenchmarkDiscovery",
+    "ConfigGroup",
+    "DiscoveredBenchmark",
+    "DiscoveryReport",
+    "ValidationStatus",
+    "discover_benchmarks",
 ]

--- a/src/xpyd_plan/cli/_discover.py
+++ b/src/xpyd_plan/cli/_discover.py
@@ -1,0 +1,117 @@
+"""CLI discover command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.discovery import BenchmarkDiscovery, ValidationStatus
+
+
+def _cmd_discover(args: argparse.Namespace) -> None:
+    """Handle the 'discover' subcommand."""
+    console = Console()
+
+    discoverer = BenchmarkDiscovery()
+    report = discoverer.discover(
+        root_dir=args.dir,
+        pattern=args.pattern,
+        max_depth=args.max_depth,
+    )
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Summary
+    console.print(f"\n[bold]Benchmark Discovery: {report.root_dir}[/bold]")
+    console.print(
+        f"Pattern: {report.pattern} | "
+        f"Scanned: {report.total_files_scanned} | "
+        f"Valid: {report.valid_count} | "
+        f"Invalid: {report.invalid_count}"
+    )
+
+    if not report.benchmarks:
+        console.print("[yellow]No JSON files found.[/yellow]")
+        return
+
+    # Benchmarks table
+    table = Table(title="Discovered Benchmarks")
+    table.add_column("Path", justify="left", max_width=60)
+    table.add_column("Status", justify="center")
+    table.add_column("Config", justify="center")
+    table.add_column("Requests", justify="right")
+    table.add_column("QPS", justify="right")
+    table.add_column("Size", justify="right")
+
+    for b in report.benchmarks:
+        status_style = "green" if b.status == ValidationStatus.VALID else "red"
+        table.add_row(
+            b.path,
+            f"[{status_style}]{b.status.value}[/{status_style}]",
+            b.config_key or "-",
+            str(b.num_requests) if b.num_requests is not None else "-",
+            f"{b.measured_qps:.1f}" if b.measured_qps is not None else "-",
+            f"{b.file_size_bytes:,}",
+        )
+
+    console.print(table)
+
+    # Groups table
+    if report.groups:
+        console.print()
+        gtable = Table(title="Configuration Groups")
+        gtable.add_column("Config", justify="center")
+        gtable.add_column("Prefill", justify="right")
+        gtable.add_column("Decode", justify="right")
+        gtable.add_column("Total", justify="right")
+        gtable.add_column("Files", justify="right")
+
+        for g in report.groups:
+            gtable.add_row(
+                g.config_key,
+                str(g.num_prefill_instances),
+                str(g.num_decode_instances),
+                str(g.total_instances),
+                str(g.count),
+            )
+
+        console.print(gtable)
+
+
+def add_discover_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the discover subcommand parser."""
+    parser = subparsers.add_parser(
+        "discover",
+        help="Discover benchmark files in a directory tree",
+    )
+    parser.add_argument(
+        "--dir",
+        required=True,
+        help="Root directory to scan",
+    )
+    parser.add_argument(
+        "--pattern",
+        default="**/*.json",
+        help="Glob pattern for matching files (default: **/*.json)",
+    )
+    parser.add_argument(
+        "--max-depth",
+        type=int,
+        default=None,
+        help="Maximum directory depth to scan (default: unlimited)",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_discover)

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -16,6 +16,7 @@ from xpyd_plan.cli._confidence import _cmd_confidence
 from xpyd_plan.cli._config import _add_config_flag, _apply_config_defaults, _cmd_config
 from xpyd_plan.cli._correlation import _cmd_correlation, add_correlation_parser
 from xpyd_plan.cli._dashboard import _cmd_dashboard
+from xpyd_plan.cli._discover import _cmd_discover, add_discover_parser
 from xpyd_plan.cli._export import _cmd_export
 from xpyd_plan.cli._filter import _cmd_filter
 from xpyd_plan.cli._fleet import _cmd_fleet
@@ -858,6 +859,9 @@ def main(argv: list[str] | None = None) -> None:
     # --- correlation subcommand ---
     add_correlation_parser(subparsers)
 
+    # --- discover subcommand ---
+    add_discover_parser(subparsers)
+
     args = parser.parse_args(argv)
 
     if args.command == "config":
@@ -921,6 +925,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_metrics(args)
     elif args.command == "correlation":
         _cmd_correlation(args)
+    elif args.command == "discover":
+        _cmd_discover(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/discovery.py
+++ b/src/xpyd_plan/discovery.py
@@ -1,0 +1,240 @@
+"""Batch benchmark discovery and auto-loading from directory trees."""
+
+from __future__ import annotations
+
+import json
+from enum import Enum
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkMetadata
+
+
+class ValidationStatus(str, Enum):
+    """Quick validation result for a candidate file."""
+
+    VALID = "valid"
+    INVALID_JSON = "invalid_json"
+    INVALID_SCHEMA = "invalid_schema"
+
+
+class DiscoveredBenchmark(BaseModel):
+    """Summary of a discovered benchmark file without full loading."""
+
+    path: str = Field(..., description="Absolute path to benchmark file")
+    status: ValidationStatus = Field(..., description="Quick validation result")
+    num_requests: int | None = Field(None, description="Number of requests (if valid)")
+    measured_qps: float | None = Field(None, description="Measured QPS (if valid)")
+    num_prefill_instances: int | None = Field(None, description="Prefill instances")
+    num_decode_instances: int | None = Field(None, description="Decode instances")
+    total_instances: int | None = Field(None, description="Total instances")
+    config_key: str | None = Field(
+        None, description="Cluster config key for grouping (e.g. 'P2:D4')"
+    )
+    file_size_bytes: int = Field(..., description="File size in bytes")
+    error: str | None = Field(None, description="Error message if invalid")
+
+
+class ConfigGroup(BaseModel):
+    """Group of benchmarks sharing the same cluster configuration."""
+
+    config_key: str = Field(..., description="Cluster config key (e.g. 'P2:D4')")
+    num_prefill_instances: int
+    num_decode_instances: int
+    total_instances: int
+    benchmarks: list[DiscoveredBenchmark] = Field(default_factory=list)
+    count: int = Field(0, description="Number of benchmarks in this group")
+
+
+class DiscoveryReport(BaseModel):
+    """Complete discovery report."""
+
+    root_dir: str = Field(..., description="Root directory that was scanned")
+    pattern: str = Field(..., description="Glob pattern used")
+    max_depth: int | None = Field(None, description="Max depth limit (None = unlimited)")
+    total_files_scanned: int = Field(0, description="Total JSON files found")
+    valid_count: int = Field(0, description="Number of valid benchmark files")
+    invalid_count: int = Field(0, description="Number of invalid files")
+    benchmarks: list[DiscoveredBenchmark] = Field(default_factory=list)
+    groups: list[ConfigGroup] = Field(default_factory=list)
+
+
+def _config_key(meta: BenchmarkMetadata) -> str:
+    """Create a grouping key from cluster config."""
+    return f"P{meta.num_prefill_instances}:D{meta.num_decode_instances}"
+
+
+def _quick_validate(path: Path) -> DiscoveredBenchmark:
+    """Quickly validate a file as a benchmark without full Pydantic parsing."""
+    file_size = path.stat().st_size
+
+    try:
+        with open(path) as f:
+            raw = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        return DiscoveredBenchmark(
+            path=str(path.resolve()),
+            status=ValidationStatus.INVALID_JSON,
+            file_size_bytes=file_size,
+            error=str(e),
+        )
+
+    # Quick schema check: must have metadata and requests
+    if not isinstance(raw, dict):
+        return DiscoveredBenchmark(
+            path=str(path.resolve()),
+            status=ValidationStatus.INVALID_SCHEMA,
+            file_size_bytes=file_size,
+            error="Root is not a JSON object",
+        )
+
+    metadata_raw = raw.get("metadata")
+    requests_raw = raw.get("requests")
+
+    if not isinstance(metadata_raw, dict) or not isinstance(requests_raw, list):
+        return DiscoveredBenchmark(
+            path=str(path.resolve()),
+            status=ValidationStatus.INVALID_SCHEMA,
+            file_size_bytes=file_size,
+            error="Missing or invalid 'metadata' or 'requests' field",
+        )
+
+    # Validate metadata fields exist
+    required_meta = [
+        "num_prefill_instances",
+        "num_decode_instances",
+        "total_instances",
+        "measured_qps",
+    ]
+    for field in required_meta:
+        if field not in metadata_raw:
+            return DiscoveredBenchmark(
+                path=str(path.resolve()),
+                status=ValidationStatus.INVALID_SCHEMA,
+                file_size_bytes=file_size,
+                error=f"Missing metadata field: {field}",
+            )
+
+    try:
+        meta = BenchmarkMetadata(**metadata_raw)
+    except Exception as e:
+        return DiscoveredBenchmark(
+            path=str(path.resolve()),
+            status=ValidationStatus.INVALID_SCHEMA,
+            file_size_bytes=file_size,
+            error=f"Invalid metadata: {e}",
+        )
+
+    key = _config_key(meta)
+
+    return DiscoveredBenchmark(
+        path=str(path.resolve()),
+        status=ValidationStatus.VALID,
+        num_requests=len(requests_raw),
+        measured_qps=meta.measured_qps,
+        num_prefill_instances=meta.num_prefill_instances,
+        num_decode_instances=meta.num_decode_instances,
+        total_instances=meta.total_instances,
+        config_key=key,
+        file_size_bytes=file_size,
+    )
+
+
+def _depth_of(path: Path, root: Path) -> int:
+    """Compute the directory depth of path relative to root."""
+    try:
+        rel = path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return 0
+    # Number of parent directories (file itself doesn't count)
+    return len(rel.parts) - 1
+
+
+class BenchmarkDiscovery:
+    """Discover and catalog benchmark files in a directory tree."""
+
+    def discover(
+        self,
+        root_dir: str | Path,
+        pattern: str = "**/*.json",
+        max_depth: int | None = None,
+    ) -> DiscoveryReport:
+        """Scan a directory tree for benchmark files.
+
+        Args:
+            root_dir: Root directory to scan.
+            pattern: Glob pattern for matching files (default: all JSON).
+            max_depth: Maximum directory depth to scan (None = unlimited).
+
+        Returns:
+            DiscoveryReport with all discovered benchmarks and config groups.
+
+        Raises:
+            FileNotFoundError: If root_dir does not exist.
+            NotADirectoryError: If root_dir is not a directory.
+        """
+        root = Path(root_dir)
+        if not root.exists():
+            raise FileNotFoundError(f"Directory not found: {root_dir}")
+        if not root.is_dir():
+            raise NotADirectoryError(f"Not a directory: {root_dir}")
+
+        benchmarks: list[DiscoveredBenchmark] = []
+        groups_map: dict[str, ConfigGroup] = {}
+
+        candidates = sorted(root.glob(pattern))
+        for candidate in candidates:
+            if not candidate.is_file():
+                continue
+
+            if max_depth is not None and _depth_of(candidate, root) > max_depth:
+                continue
+
+            result = _quick_validate(candidate)
+            benchmarks.append(result)
+
+            if result.status == ValidationStatus.VALID and result.config_key:
+                if result.config_key not in groups_map:
+                    groups_map[result.config_key] = ConfigGroup(
+                        config_key=result.config_key,
+                        num_prefill_instances=result.num_prefill_instances or 0,
+                        num_decode_instances=result.num_decode_instances or 0,
+                        total_instances=result.total_instances or 0,
+                    )
+                group = groups_map[result.config_key]
+                group.benchmarks.append(result)
+                group.count = len(group.benchmarks)
+
+        valid_count = sum(1 for b in benchmarks if b.status == ValidationStatus.VALID)
+
+        return DiscoveryReport(
+            root_dir=str(root.resolve()),
+            pattern=pattern,
+            max_depth=max_depth,
+            total_files_scanned=len(benchmarks),
+            valid_count=valid_count,
+            invalid_count=len(benchmarks) - valid_count,
+            benchmarks=benchmarks,
+            groups=sorted(groups_map.values(), key=lambda g: g.config_key),
+        )
+
+
+def discover_benchmarks(
+    root_dir: str | Path,
+    pattern: str = "**/*.json",
+    max_depth: int | None = None,
+) -> dict:
+    """Programmatic API for benchmark discovery.
+
+    Args:
+        root_dir: Root directory to scan.
+        pattern: Glob pattern for matching files.
+        max_depth: Maximum directory depth.
+
+    Returns:
+        Dictionary representation of the DiscoveryReport.
+    """
+    discoverer = BenchmarkDiscovery()
+    report = discoverer.discover(root_dir, pattern=pattern, max_depth=max_depth)
+    return report.model_dump()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,290 @@
+"""Tests for benchmark discovery."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkMetadata
+from xpyd_plan.discovery import (
+    BenchmarkDiscovery,
+    ValidationStatus,
+    _config_key,
+    _depth_of,
+    _quick_validate,
+    discover_benchmarks,
+)
+
+
+def _make_benchmark_json(
+    num_prefill: int = 2,
+    num_decode: int = 2,
+    qps: float = 10.0,
+    num_requests: int = 5,
+) -> dict:
+    """Create a valid benchmark JSON structure."""
+    return {
+        "metadata": {
+            "num_prefill_instances": num_prefill,
+            "num_decode_instances": num_decode,
+            "total_instances": num_prefill + num_decode,
+            "measured_qps": qps,
+        },
+        "requests": [
+            {
+                "request_id": f"req-{i}",
+                "prompt_tokens": 100,
+                "output_tokens": 50,
+                "ttft_ms": 20.0,
+                "tpot_ms": 10.0,
+                "total_latency_ms": 70.0,
+                "timestamp": 1000.0 + i,
+            }
+            for i in range(num_requests)
+        ],
+    }
+
+
+def _write_json(path: Path, data: dict) -> None:
+    """Write JSON data to a file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f)
+
+
+class TestConfigKey:
+    """Tests for _config_key helper."""
+
+    def test_basic(self) -> None:
+        meta = BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=4,
+            total_instances=6,
+            measured_qps=10.0,
+        )
+        assert _config_key(meta) == "P2:D4"
+
+    def test_single_instances(self) -> None:
+        meta = BenchmarkMetadata(
+            num_prefill_instances=1,
+            num_decode_instances=1,
+            total_instances=2,
+            measured_qps=5.0,
+        )
+        assert _config_key(meta) == "P1:D1"
+
+
+class TestDepthOf:
+    """Tests for _depth_of helper."""
+
+    def test_root_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "bench.json"
+        f.touch()
+        assert _depth_of(f, tmp_path) == 0
+
+    def test_nested_file(self, tmp_path: Path) -> None:
+        sub = tmp_path / "a" / "b"
+        sub.mkdir(parents=True)
+        f = sub / "bench.json"
+        f.touch()
+        assert _depth_of(f, tmp_path) == 2
+
+
+class TestQuickValidate:
+    """Tests for _quick_validate."""
+
+    def test_valid_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "valid.json"
+        _write_json(f, _make_benchmark_json())
+        result = _quick_validate(f)
+        assert result.status == ValidationStatus.VALID
+        assert result.num_requests == 5
+        assert result.config_key == "P2:D2"
+
+    def test_invalid_json(self, tmp_path: Path) -> None:
+        f = tmp_path / "bad.json"
+        f.write_text("not json {{{")
+        result = _quick_validate(f)
+        assert result.status == ValidationStatus.INVALID_JSON
+
+    def test_missing_metadata(self, tmp_path: Path) -> None:
+        f = tmp_path / "no_meta.json"
+        _write_json(f, {"requests": []})
+        result = _quick_validate(f)
+        assert result.status == ValidationStatus.INVALID_SCHEMA
+
+    def test_missing_requests(self, tmp_path: Path) -> None:
+        f = tmp_path / "no_req.json"
+        meta = {
+            "num_prefill_instances": 1,
+            "num_decode_instances": 1,
+            "total_instances": 2,
+            "measured_qps": 5.0,
+        }
+        _write_json(f, {"metadata": meta})
+        result = _quick_validate(f)
+        assert result.status == ValidationStatus.INVALID_SCHEMA
+
+    def test_missing_metadata_field(self, tmp_path: Path) -> None:
+        f = tmp_path / "partial.json"
+        _write_json(f, {"metadata": {"num_prefill_instances": 1}, "requests": []})
+        result = _quick_validate(f)
+        assert result.status == ValidationStatus.INVALID_SCHEMA
+        assert "Missing metadata field" in (result.error or "")
+
+    def test_not_an_object(self, tmp_path: Path) -> None:
+        f = tmp_path / "array.json"
+        _write_json(f, [1, 2, 3])
+        result = _quick_validate(f)
+        assert result.status == ValidationStatus.INVALID_SCHEMA
+
+
+class TestBenchmarkDiscovery:
+    """Tests for BenchmarkDiscovery."""
+
+    def test_discover_valid_files(self, tmp_path: Path) -> None:
+        _write_json(tmp_path / "a.json", _make_benchmark_json())
+        _write_json(
+            tmp_path / "b.json",
+            _make_benchmark_json(num_prefill=4, num_decode=4, qps=20.0),
+        )
+
+        discoverer = BenchmarkDiscovery()
+        report = discoverer.discover(tmp_path)
+
+        assert report.total_files_scanned == 2
+        assert report.valid_count == 2
+        assert report.invalid_count == 0
+
+    def test_discover_mixed_valid_invalid(self, tmp_path: Path) -> None:
+        _write_json(tmp_path / "good.json", _make_benchmark_json())
+        (tmp_path / "bad.json").write_text("not json")
+
+        report = BenchmarkDiscovery().discover(tmp_path)
+        assert report.valid_count == 1
+        assert report.invalid_count == 1
+
+    def test_discover_empty_dir(self, tmp_path: Path) -> None:
+        report = BenchmarkDiscovery().discover(tmp_path)
+        assert report.total_files_scanned == 0
+        assert report.valid_count == 0
+
+    def test_discover_nested(self, tmp_path: Path) -> None:
+        _write_json(tmp_path / "level0.json", _make_benchmark_json())
+        _write_json(tmp_path / "sub" / "level1.json", _make_benchmark_json())
+        _write_json(tmp_path / "sub" / "deep" / "level2.json", _make_benchmark_json())
+
+        report = BenchmarkDiscovery().discover(tmp_path)
+        assert report.valid_count == 3
+
+    def test_max_depth_limit(self, tmp_path: Path) -> None:
+        _write_json(tmp_path / "level0.json", _make_benchmark_json())
+        _write_json(tmp_path / "sub" / "level1.json", _make_benchmark_json())
+        _write_json(tmp_path / "sub" / "deep" / "level2.json", _make_benchmark_json())
+
+        report = BenchmarkDiscovery().discover(tmp_path, max_depth=0)
+        assert report.valid_count == 1
+
+        report = BenchmarkDiscovery().discover(tmp_path, max_depth=1)
+        assert report.valid_count == 2
+
+    def test_custom_pattern(self, tmp_path: Path) -> None:
+        _write_json(tmp_path / "h100_bench.json", _make_benchmark_json())
+        _write_json(tmp_path / "a100_bench.json", _make_benchmark_json())
+        _write_json(tmp_path / "other.json", _make_benchmark_json())
+
+        report = BenchmarkDiscovery().discover(tmp_path, pattern="*h100*.json")
+        assert report.valid_count == 1
+
+    def test_config_groups(self, tmp_path: Path) -> None:
+        _write_json(tmp_path / "a.json", _make_benchmark_json(num_prefill=2, num_decode=2))
+        _write_json(tmp_path / "b.json", _make_benchmark_json(num_prefill=2, num_decode=2))
+        _write_json(tmp_path / "c.json", _make_benchmark_json(num_prefill=4, num_decode=4))
+
+        report = BenchmarkDiscovery().discover(tmp_path)
+        assert len(report.groups) == 2
+
+        p2d2 = next(g for g in report.groups if g.config_key == "P2:D2")
+        assert p2d2.count == 2
+        p4d4 = next(g for g in report.groups if g.config_key == "P4:D4")
+        assert p4d4.count == 1
+
+    def test_nonexistent_dir(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            BenchmarkDiscovery().discover("/nonexistent/path")
+
+    def test_not_a_directory(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.txt"
+        f.write_text("hello")
+        with pytest.raises(NotADirectoryError):
+            BenchmarkDiscovery().discover(f)
+
+    def test_report_fields(self, tmp_path: Path) -> None:
+        _write_json(tmp_path / "bench.json", _make_benchmark_json())
+        report = BenchmarkDiscovery().discover(tmp_path, pattern="*.json", max_depth=5)
+        assert report.root_dir == str(tmp_path.resolve())
+        assert report.pattern == "*.json"
+        assert report.max_depth == 5
+
+    def test_file_size_recorded(self, tmp_path: Path) -> None:
+        _write_json(tmp_path / "bench.json", _make_benchmark_json())
+        report = BenchmarkDiscovery().discover(tmp_path)
+        assert report.benchmarks[0].file_size_bytes > 0
+
+
+class TestDiscoverBenchmarksAPI:
+    """Tests for the programmatic API."""
+
+    def test_returns_dict(self, tmp_path: Path) -> None:
+        _write_json(tmp_path / "bench.json", _make_benchmark_json())
+        result = discover_benchmarks(tmp_path)
+        assert isinstance(result, dict)
+        assert "benchmarks" in result
+        assert "groups" in result
+        assert result["valid_count"] == 1
+
+    def test_with_pattern(self, tmp_path: Path) -> None:
+        _write_json(tmp_path / "test.json", _make_benchmark_json())
+        result = discover_benchmarks(tmp_path, pattern="test*.json")
+        assert result["valid_count"] == 1
+
+
+class TestDiscoverCLI:
+    """Tests for CLI integration."""
+
+    def test_table_output(self, tmp_path: Path) -> None:
+        import io
+        from contextlib import redirect_stdout
+
+        from xpyd_plan.cli._main import main
+
+        _write_json(tmp_path / "bench.json", _make_benchmark_json())
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            try:
+                main(["discover", "--dir", str(tmp_path)])
+            except SystemExit:
+                pass
+
+    def test_json_output(self, tmp_path: Path) -> None:
+        import io
+        from contextlib import redirect_stdout
+
+        from xpyd_plan.cli._main import main
+
+        _write_json(tmp_path / "bench.json", _make_benchmark_json())
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            try:
+                main(["discover", "--dir", str(tmp_path), "--output-format", "json"])
+            except SystemExit:
+                pass
+
+        output = buf.getvalue()
+        if output.strip():
+            result = json.loads(output)
+            assert "benchmarks" in result


### PR DESCRIPTION
## Summary

Add batch benchmark discovery for auto-loading benchmark files from directory trees.

### Changes

- `BenchmarkDiscovery` class in `discovery.py`
- `DiscoveredBenchmark`, `DiscoveryReport`, `ConfigGroup`, `ValidationStatus` Pydantic models
- Recursive directory scanning with configurable depth limit
- Glob pattern filtering (`--pattern '**/*h100*.json'`)
- Quick validation without full deserialization
- Group-by-config summary
- CLI `discover` subcommand with `--dir`, `--pattern`, `--max-depth`, table + JSON output
- Programmatic `discover_benchmarks()` API
- 25 new tests (886 total)

Closes #90