### PR TITLE
feat(heatmap): latency heatmap data generation (M39)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -490,9 +490,9 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Programmatic `analyze_correlation()` API
 - 21 new tests (861 total)
 
-### M38 — Batch Benchmark Discovery & Auto-Loading
+### M38 ✅ Batch Benchmark Discovery & Auto-Loading
 
-*In progress — PR #TBD*
+*Completed — PR #91*
 
 - `BenchmarkDiscovery` class in `discovery.py`
 - `DiscoveredBenchmark`, `DiscoveryReport`, `ConfigGroup`, `ValidationStatus` Pydantic models
@@ -502,4 +502,15 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Group-by-config summary
 - CLI `discover` subcommand with `--dir`, `--pattern`, `--max-depth`, table + JSON output
 - Programmatic `discover_benchmarks()` API
+- 25 new tests (886 total)
+
+### M39 — Latency Heatmap Data Generation
+
+- `HeatmapGenerator` class in `heatmap.py`
+- `HeatmapConfig`, `HeatmapCell`, `HeatmapGrid`, `HeatmapReport` Pydantic models
+- 2D grid mapping (prompt_tokens bins × output_tokens bins) to aggregated latency metrics
+- Configurable bin count, aggregation metric (mean, P50, P95, P99), and target latency field (TTFT, TPOT, total)
+- Hotspot detection: identify cells exceeding SLA thresholds
+- CLI `heatmap` subcommand with `--benchmark`, `--bins`, `--metric`, `--field`, table + JSON output
+- Programmatic `generate_heatmap()` API
 - ~22 new tests

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -108,6 +108,16 @@ from xpyd_plan.generator import (
     load_generator_config,
 )
 from xpyd_plan.gpu_profiles import get_gpu_profile, list_gpu_profiles
+from xpyd_plan.heatmap import (
+    AggregationMetric,
+    HeatmapCell,
+    HeatmapConfig,
+    HeatmapGenerator,
+    HeatmapGrid,
+    HeatmapReport,
+    LatencyField,
+    generate_heatmap,
+)
 from xpyd_plan.interpolator import (
     InterpolationConfidence,
     InterpolationMethod,
@@ -347,4 +357,12 @@ __all__ = [
     "DiscoveryReport",
     "ValidationStatus",
     "discover_benchmarks",
+    "AggregationMetric",
+    "HeatmapCell",
+    "HeatmapConfig",
+    "HeatmapGenerator",
+    "HeatmapGrid",
+    "HeatmapReport",
+    "LatencyField",
+    "generate_heatmap",
 ]

--- a/src/xpyd_plan/cli/_heatmap.py
+++ b/src/xpyd_plan/cli/_heatmap.py
@@ -1,0 +1,124 @@
+"""CLI heatmap command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.heatmap import (
+    AggregationMetric,
+    HeatmapConfig,
+    HeatmapGenerator,
+    LatencyField,
+)
+
+
+def add_heatmap_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Register the heatmap subcommand."""
+    parser = subparsers.add_parser(
+        "heatmap",
+        help="Generate latency heatmap data from benchmark results",
+    )
+    parser.add_argument(
+        "--benchmark", required=True, help="Path to benchmark JSON file"
+    )
+    parser.add_argument(
+        "--prompt-bins", type=int, default=10, help="Number of prompt token bins (default: 10)"
+    )
+    parser.add_argument(
+        "--output-bins", type=int, default=10, help="Number of output token bins (default: 10)"
+    )
+    parser.add_argument(
+        "--metric",
+        choices=["mean", "p50", "p95", "p99"],
+        default="p95",
+        help="Aggregation metric (default: p95)",
+    )
+    parser.add_argument(
+        "--field",
+        choices=["ttft_ms", "tpot_ms", "total_latency_ms"],
+        default="total_latency_ms",
+        help="Latency field to analyze (default: total_latency_ms)",
+    )
+    parser.add_argument(
+        "--sla-threshold",
+        type=float,
+        default=None,
+        help="SLA threshold in ms for hotspot detection",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+
+
+def _cmd_heatmap(args: argparse.Namespace) -> None:
+    """Handle the 'heatmap' subcommand."""
+    import json as json_mod
+    from pathlib import Path
+
+    from xpyd_plan.benchmark_models import BenchmarkData
+
+    console = Console()
+
+    path = Path(args.benchmark)
+    if not path.exists():
+        console.print(f"[red]Error: file not found: {path}[/red]")
+        sys.exit(1)
+
+    raw = json_mod.loads(path.read_text())
+    data = BenchmarkData.model_validate(raw)
+
+    config = HeatmapConfig(
+        prompt_bins=args.prompt_bins,
+        output_bins=args.output_bins,
+        metric=AggregationMetric(args.metric),
+        field=LatencyField(args.field),
+        sla_threshold_ms=args.sla_threshold,
+    )
+
+    generator = HeatmapGenerator()
+    report = generator.generate(data, config)
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Table output
+    console.print(f"\n[bold]Latency Heatmap — {config.field.value} ({config.metric.value})[/bold]")
+    console.print(f"Total requests: {report.total_requests}")
+    if report.min_value is not None:
+        console.print(f"Range: {report.min_value:.1f}ms – {report.max_value:.1f}ms")
+    if report.hotspot_count > 0:
+        console.print(f"[red]Hotspots: {report.hotspot_count}[/red]")
+    console.print()
+
+    table = Table(title="Heatmap Cells (non-empty)")
+    table.add_column("Prompt Tokens", justify="right")
+    table.add_column("Output Tokens", justify="right")
+    table.add_column("Count", justify="right")
+    table.add_column(f"{config.metric.value} (ms)", justify="right")
+    table.add_column("Hotspot", justify="center")
+
+    for cell in report.grid.cells:
+        if cell.count == 0:
+            continue
+        hotspot_str = "[red]●[/red]" if cell.is_hotspot else ""
+        table.add_row(
+            f"{cell.prompt_bin_start}–{cell.prompt_bin_end}",
+            f"{cell.output_bin_start}–{cell.output_bin_end}",
+            str(cell.count),
+            f"{cell.value:.1f}",
+            hotspot_str,
+        )
+
+    console.print(table)
+    console.print(f"\n{report.recommendation}")

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -21,6 +21,7 @@ from xpyd_plan.cli._export import _cmd_export
 from xpyd_plan.cli._filter import _cmd_filter
 from xpyd_plan.cli._fleet import _cmd_fleet
 from xpyd_plan.cli._generate import _cmd_generate
+from xpyd_plan.cli._heatmap import _cmd_heatmap, add_heatmap_parser
 from xpyd_plan.cli._interpolate import _cmd_interpolate
 from xpyd_plan.cli._merge import _cmd_merge
 from xpyd_plan.cli._metrics import _cmd_metrics, add_metrics_parser
@@ -861,6 +862,7 @@ def main(argv: list[str] | None = None) -> None:
 
     # --- discover subcommand ---
     add_discover_parser(subparsers)
+    add_heatmap_parser(subparsers)
 
     args = parser.parse_args(argv)
 
@@ -927,6 +929,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_correlation(args)
     elif args.command == "discover":
         _cmd_discover(args)
+    elif args.command == "heatmap":
+        _cmd_heatmap(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/heatmap.py
+++ b/src/xpyd_plan/heatmap.py
@@ -1,0 +1,277 @@
+"""Latency heatmap data generation from benchmark results."""
+
+from __future__ import annotations
+
+import math
+from enum import Enum
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData
+
+
+class AggregationMetric(str, Enum):
+    """Aggregation method for latency values within a cell."""
+
+    MEAN = "mean"
+    P50 = "p50"
+    P95 = "p95"
+    P99 = "p99"
+
+
+class LatencyField(str, Enum):
+    """Which latency field to analyze."""
+
+    TTFT = "ttft_ms"
+    TPOT = "tpot_ms"
+    TOTAL = "total_latency_ms"
+
+
+class HeatmapCell(BaseModel):
+    """Single cell in the heatmap grid."""
+
+    prompt_bin_start: int = Field(..., description="Start of prompt token bin (inclusive)")
+    prompt_bin_end: int = Field(..., description="End of prompt token bin (exclusive)")
+    output_bin_start: int = Field(..., description="Start of output token bin (inclusive)")
+    output_bin_end: int = Field(..., description="End of output token bin (exclusive)")
+    value: float = Field(..., description="Aggregated latency value")
+    count: int = Field(..., ge=0, description="Number of requests in this cell")
+    is_hotspot: bool = Field(False, description="Whether this cell exceeds the SLA threshold")
+
+
+class HeatmapConfig(BaseModel):
+    """Configuration for heatmap generation."""
+
+    prompt_bins: int = Field(10, ge=1, description="Number of bins for prompt tokens")
+    output_bins: int = Field(10, ge=1, description="Number of bins for output tokens")
+    metric: AggregationMetric = Field(AggregationMetric.P95, description="Aggregation metric")
+    field: LatencyField = Field(LatencyField.TOTAL, description="Latency field to analyze")
+    sla_threshold_ms: float | None = Field(
+        None, ge=0, description="SLA threshold for hotspot detection"
+    )
+
+
+class HeatmapGrid(BaseModel):
+    """2D grid of heatmap cells."""
+
+    cells: list[HeatmapCell] = Field(..., description="All cells in row-major order")
+    rows: int = Field(..., ge=1, description="Number of rows (prompt bins)")
+    cols: int = Field(..., ge=1, description="Number of columns (output bins)")
+
+
+class HeatmapReport(BaseModel):
+    """Complete heatmap analysis report."""
+
+    config: HeatmapConfig = Field(..., description="Configuration used")
+    grid: HeatmapGrid = Field(..., description="The heatmap grid")
+    total_requests: int = Field(..., ge=0, description="Total requests analyzed")
+    hotspot_count: int = Field(0, ge=0, description="Number of hotspot cells")
+    min_value: float | None = Field(None, description="Minimum cell value")
+    max_value: float | None = Field(None, description="Maximum cell value")
+    recommendation: str = Field(..., description="Human-readable summary")
+
+
+def _percentile(values: list[float], p: float) -> float:
+    """Compute the p-th percentile of a sorted list."""
+    if not values:
+        return 0.0
+    sorted_vals = sorted(values)
+    k = (p / 100.0) * (len(sorted_vals) - 1)
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return sorted_vals[int(k)]
+    return sorted_vals[f] * (c - k) + sorted_vals[c] * (k - f)
+
+
+def _aggregate(values: list[float], metric: AggregationMetric) -> float:
+    """Aggregate a list of values using the specified metric."""
+    if not values:
+        return 0.0
+    if metric == AggregationMetric.MEAN:
+        return sum(values) / len(values)
+    if metric == AggregationMetric.P50:
+        return _percentile(values, 50)
+    if metric == AggregationMetric.P95:
+        return _percentile(values, 95)
+    # P99
+    return _percentile(values, 99)
+
+
+class HeatmapGenerator:
+    """Generate 2D latency heatmap data from benchmark results."""
+
+    def generate(
+        self,
+        data: BenchmarkData,
+        config: HeatmapConfig | None = None,
+    ) -> HeatmapReport:
+        """Generate a heatmap report from benchmark data.
+
+        Args:
+            data: Loaded benchmark data.
+            config: Optional configuration; uses defaults if not provided.
+
+        Returns:
+            HeatmapReport with the 2D grid and hotspot analysis.
+        """
+        if config is None:
+            config = HeatmapConfig()
+
+        requests = data.requests
+        if not requests:
+            return HeatmapReport(
+                config=config,
+                grid=HeatmapGrid(cells=[], rows=config.prompt_bins, cols=config.output_bins),
+                total_requests=0,
+                hotspot_count=0,
+                min_value=None,
+                max_value=None,
+                recommendation="No requests in benchmark data.",
+            )
+
+        # Determine ranges
+        prompt_tokens = [r.prompt_tokens for r in requests]
+        output_tokens = [r.output_tokens for r in requests]
+
+        prompt_min, prompt_max = min(prompt_tokens), max(prompt_tokens)
+        output_min, output_max = min(output_tokens), max(output_tokens)
+
+        # Build bin edges
+        prompt_edges = self._build_edges(prompt_min, prompt_max, config.prompt_bins)
+        output_edges = self._build_edges(output_min, output_max, config.output_bins)
+
+        # Bucket requests
+        field_name = config.field.value
+        buckets: dict[tuple[int, int], list[float]] = {}
+        for i in range(len(prompt_edges) - 1):
+            for j in range(len(output_edges) - 1):
+                buckets[(i, j)] = []
+
+        for req in requests:
+            pi = self._find_bin(req.prompt_tokens, prompt_edges)
+            oi = self._find_bin(req.output_tokens, output_edges)
+            val = getattr(req, field_name)
+            buckets[(pi, oi)].append(val)
+
+        # Build cells
+        cells: list[HeatmapCell] = []
+        hotspot_count = 0
+        all_values: list[float] = []
+
+        for i in range(len(prompt_edges) - 1):
+            for j in range(len(output_edges) - 1):
+                vals = buckets[(i, j)]
+                if vals:
+                    agg_val = _aggregate(vals, config.metric)
+                    is_hotspot = (
+                        config.sla_threshold_ms is not None
+                        and agg_val > config.sla_threshold_ms
+                    )
+                    if is_hotspot:
+                        hotspot_count += 1
+                    all_values.append(agg_val)
+                else:
+                    agg_val = 0.0
+                    is_hotspot = False
+
+                cells.append(HeatmapCell(
+                    prompt_bin_start=prompt_edges[i],
+                    prompt_bin_end=prompt_edges[i + 1],
+                    output_bin_start=output_edges[j],
+                    output_bin_end=output_edges[j + 1],
+                    value=agg_val,
+                    count=len(vals),
+                    is_hotspot=is_hotspot,
+                ))
+
+        min_val = min(all_values) if all_values else None
+        max_val = max(all_values) if all_values else None
+
+        # Recommendation
+        if hotspot_count > 0:
+            recommendation = (
+                f"{hotspot_count} hotspot(s) detected exceeding "
+                f"{config.sla_threshold_ms}ms SLA threshold. "
+                f"Investigate high-latency token ranges."
+            )
+        elif all_values:
+            recommendation = (
+                f"No hotspots detected. Latency range: "
+                f"{min_val:.1f}ms – {max_val:.1f}ms."
+            )
+        else:
+            recommendation = "No requests in benchmark data."
+
+        return HeatmapReport(
+            config=config,
+            grid=HeatmapGrid(
+                cells=cells,
+                rows=len(prompt_edges) - 1,
+                cols=len(output_edges) - 1,
+            ),
+            total_requests=len(requests),
+            hotspot_count=hotspot_count,
+            min_value=min_val,
+            max_value=max_val,
+            recommendation=recommendation,
+        )
+
+    @staticmethod
+    def _build_edges(lo: int, hi: int, num_bins: int) -> list[int]:
+        """Build bin edges. Returns num_bins+1 edge values."""
+        if lo == hi:
+            return [lo, lo + 1]
+        step = (hi - lo) / num_bins
+        edges = [int(lo + step * i) for i in range(num_bins)]
+        edges.append(hi + 1)  # exclusive upper bound
+        return edges
+
+    @staticmethod
+    def _find_bin(value: int, edges: list[int]) -> int:
+        """Find bin index for a value given sorted edges."""
+        for i in range(len(edges) - 1):
+            if value < edges[i + 1]:
+                return i
+        return len(edges) - 2  # last bin
+
+
+def generate_heatmap(
+    benchmark_path: str | Path,
+    prompt_bins: int = 10,
+    output_bins: int = 10,
+    metric: str = "p95",
+    field: str = "total_latency_ms",
+    sla_threshold_ms: float | None = None,
+) -> dict:
+    """Programmatic API for heatmap generation.
+
+    Args:
+        benchmark_path: Path to benchmark JSON file.
+        prompt_bins: Number of prompt token bins.
+        output_bins: Number of output token bins.
+        metric: Aggregation metric (mean, p50, p95, p99).
+        field: Latency field (ttft_ms, tpot_ms, total_latency_ms).
+        sla_threshold_ms: Optional SLA threshold for hotspot detection.
+
+    Returns:
+        Dictionary representation of the HeatmapReport.
+    """
+    import json as json_mod
+
+    path = Path(benchmark_path)
+    raw = json_mod.loads(path.read_text())
+    data = BenchmarkData.model_validate(raw)
+
+    config = HeatmapConfig(
+        prompt_bins=prompt_bins,
+        output_bins=output_bins,
+        metric=AggregationMetric(metric),
+        field=LatencyField(field),
+        sla_threshold_ms=sla_threshold_ms,
+    )
+
+    generator = HeatmapGenerator()
+    report = generator.generate(data, config)
+    return report.model_dump()

--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -1,0 +1,360 @@
+"""Tests for the heatmap module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.heatmap import (
+    AggregationMetric,
+    HeatmapConfig,
+    HeatmapGenerator,
+    LatencyField,
+    _aggregate,
+    _percentile,
+    generate_heatmap,
+)
+
+
+def _make_benchmark(requests: list[dict]) -> BenchmarkData:
+    """Create a BenchmarkData with the given request dicts."""
+    reqs = [
+        BenchmarkRequest(
+            request_id=f"req-{i}",
+            prompt_tokens=r["prompt_tokens"],
+            output_tokens=r["output_tokens"],
+            ttft_ms=r.get("ttft_ms", 10.0),
+            tpot_ms=r.get("tpot_ms", 5.0),
+            total_latency_ms=r.get("total_latency_ms", 100.0),
+            timestamp=1000000.0 + i,
+        )
+        for i, r in enumerate(requests)
+    ]
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=1,
+            num_decode_instances=1,
+            total_instances=2,
+            measured_qps=10.0,
+        ),
+        requests=reqs,
+    )
+
+
+def _make_benchmark_file(requests: list[dict], tmp_path: Path) -> Path:
+    """Write a benchmark JSON file and return its path."""
+    data = _make_benchmark(requests)
+    p = tmp_path / "bench.json"
+    p.write_text(json.dumps(data.model_dump()))
+    return p
+
+
+class TestPercentile:
+    """Tests for the _percentile helper."""
+
+    def test_single_value(self):
+        assert _percentile([5.0], 50) == 5.0
+
+    def test_p50(self):
+        result = _percentile([1.0, 2.0, 3.0, 4.0, 5.0], 50)
+        assert result == 3.0
+
+    def test_p95_interpolates(self):
+        values = list(range(1, 101))
+        result = _percentile([float(v) for v in values], 95)
+        assert 94.0 <= result <= 96.0
+
+    def test_empty(self):
+        assert _percentile([], 50) == 0.0
+
+
+class TestAggregate:
+    """Tests for the _aggregate helper."""
+
+    def test_mean(self):
+        assert _aggregate([2.0, 4.0, 6.0], AggregationMetric.MEAN) == 4.0
+
+    def test_p50(self):
+        result = _aggregate([1.0, 2.0, 3.0], AggregationMetric.P50)
+        assert result == 2.0
+
+    def test_p95(self):
+        result = _aggregate([float(i) for i in range(100)], AggregationMetric.P95)
+        assert result > 90
+
+    def test_p99(self):
+        result = _aggregate([float(i) for i in range(100)], AggregationMetric.P99)
+        assert result > 95
+
+    def test_empty(self):
+        assert _aggregate([], AggregationMetric.MEAN) == 0.0
+
+
+class TestHeatmapGenerator:
+    """Tests for HeatmapGenerator."""
+
+    def test_empty_data(self):
+        data = BenchmarkData.model_construct(
+            metadata=BenchmarkMetadata(
+                num_prefill_instances=1,
+                num_decode_instances=1,
+                total_instances=2,
+                measured_qps=10.0,
+            ),
+            requests=[],
+        )
+        gen = HeatmapGenerator()
+        report = gen.generate(data)
+        assert report.total_requests == 0
+        assert report.grid.cells == []
+        assert report.recommendation == "No requests in benchmark data."
+
+    def test_basic_generation(self):
+        requests = [
+            {"prompt_tokens": 100, "output_tokens": 50, "total_latency_ms": 100.0},
+            {"prompt_tokens": 200, "output_tokens": 100, "total_latency_ms": 200.0},
+            {"prompt_tokens": 300, "output_tokens": 150, "total_latency_ms": 300.0},
+        ]
+        data = _make_benchmark(requests)
+        gen = HeatmapGenerator()
+        config = HeatmapConfig(prompt_bins=3, output_bins=3)
+        report = gen.generate(data, config)
+
+        assert report.total_requests == 3
+        assert report.grid.rows == 3
+        assert report.grid.cols == 3
+        assert len(report.grid.cells) == 9
+
+    def test_hotspot_detection(self):
+        requests = [
+            {"prompt_tokens": 100, "output_tokens": 50, "total_latency_ms": 50.0},
+            {"prompt_tokens": 200, "output_tokens": 100, "total_latency_ms": 500.0},
+        ]
+        data = _make_benchmark(requests)
+        gen = HeatmapGenerator()
+        config = HeatmapConfig(
+            prompt_bins=2,
+            output_bins=2,
+            sla_threshold_ms=200.0,
+        )
+        report = gen.generate(data, config)
+
+        assert report.hotspot_count >= 1
+        hotspots = [c for c in report.grid.cells if c.is_hotspot]
+        assert len(hotspots) >= 1
+        assert any(c.value > 200.0 for c in hotspots)
+
+    def test_no_hotspot_without_threshold(self):
+        requests = [
+            {"prompt_tokens": 100, "output_tokens": 50, "total_latency_ms": 999.0},
+        ]
+        data = _make_benchmark(requests)
+        gen = HeatmapGenerator()
+        config = HeatmapConfig(prompt_bins=1, output_bins=1)
+        report = gen.generate(data, config)
+
+        assert report.hotspot_count == 0
+
+    def test_different_metrics(self):
+        requests = [
+            {"prompt_tokens": 100, "output_tokens": 50, "total_latency_ms": 100.0},
+            {"prompt_tokens": 100, "output_tokens": 50, "total_latency_ms": 200.0},
+        ]
+        data = _make_benchmark(requests)
+        gen = HeatmapGenerator()
+
+        mean_config = HeatmapConfig(
+            prompt_bins=1, output_bins=1, metric=AggregationMetric.MEAN,
+        )
+        p95_config = HeatmapConfig(
+            prompt_bins=1, output_bins=1, metric=AggregationMetric.P95,
+        )
+        mean_report = gen.generate(data, mean_config)
+        p95_report = gen.generate(data, p95_config)
+
+        mean_cell = [c for c in mean_report.grid.cells if c.count > 0][0]
+        p95_cell = [c for c in p95_report.grid.cells if c.count > 0][0]
+        assert mean_cell.value == 150.0
+        assert p95_cell.value >= 190.0
+
+    def test_different_fields(self):
+        requests = [
+            {
+                "prompt_tokens": 100, "output_tokens": 50,
+                "ttft_ms": 10.0, "tpot_ms": 5.0, "total_latency_ms": 100.0,
+            },
+        ]
+        data = _make_benchmark(requests)
+        gen = HeatmapGenerator()
+
+        ttft_report = gen.generate(
+            data,
+            HeatmapConfig(
+                prompt_bins=1, output_bins=1,
+                field=LatencyField.TTFT, metric=AggregationMetric.MEAN,
+            ),
+        )
+        tpot_report = gen.generate(
+            data,
+            HeatmapConfig(
+                prompt_bins=1, output_bins=1,
+                field=LatencyField.TPOT, metric=AggregationMetric.MEAN,
+            ),
+        )
+
+        ttft_cell = [c for c in ttft_report.grid.cells if c.count > 0][0]
+        tpot_cell = [c for c in tpot_report.grid.cells if c.count > 0][0]
+        assert ttft_cell.value == 10.0
+        assert tpot_cell.value == 5.0
+
+    def test_single_value_range(self):
+        """All requests have same token counts."""
+        requests = [
+            {"prompt_tokens": 100, "output_tokens": 50, "total_latency_ms": 100.0},
+            {"prompt_tokens": 100, "output_tokens": 50, "total_latency_ms": 200.0},
+        ]
+        data = _make_benchmark(requests)
+        gen = HeatmapGenerator()
+        config = HeatmapConfig(prompt_bins=2, output_bins=2, metric=AggregationMetric.MEAN)
+        report = gen.generate(data, config)
+
+        # Should still work with degenerate ranges
+        assert report.total_requests == 2
+        non_empty = [c for c in report.grid.cells if c.count > 0]
+        assert len(non_empty) >= 1
+        total_count = sum(c.count for c in report.grid.cells)
+        assert total_count == 2
+
+    def test_min_max_values(self):
+        requests = [
+            {"prompt_tokens": 100, "output_tokens": 50, "total_latency_ms": 50.0},
+            {"prompt_tokens": 200, "output_tokens": 100, "total_latency_ms": 500.0},
+        ]
+        data = _make_benchmark(requests)
+        gen = HeatmapGenerator()
+        config = HeatmapConfig(prompt_bins=2, output_bins=2, metric=AggregationMetric.MEAN)
+        report = gen.generate(data, config)
+
+        assert report.min_value is not None
+        assert report.max_value is not None
+        assert report.min_value <= report.max_value
+
+    def test_recommendation_no_hotspots(self):
+        requests = [
+            {"prompt_tokens": 100, "output_tokens": 50, "total_latency_ms": 50.0},
+        ]
+        data = _make_benchmark(requests)
+        gen = HeatmapGenerator()
+        config = HeatmapConfig(prompt_bins=1, output_bins=1, sla_threshold_ms=1000.0)
+        report = gen.generate(data, config)
+
+        assert "No hotspots" in report.recommendation
+
+    def test_recommendation_with_hotspots(self):
+        requests = [
+            {"prompt_tokens": 100, "output_tokens": 50, "total_latency_ms": 500.0},
+        ]
+        data = _make_benchmark(requests)
+        gen = HeatmapGenerator()
+        config = HeatmapConfig(prompt_bins=1, output_bins=1, sla_threshold_ms=100.0)
+        report = gen.generate(data, config)
+
+        assert "hotspot" in report.recommendation.lower()
+
+    def test_many_requests_all_bins_covered(self):
+        """With enough spread requests, most bins should have data."""
+        requests = [
+            {
+                "prompt_tokens": 50 + i * 10,
+                "output_tokens": 20 + i * 5,
+                "total_latency_ms": 50.0 + i * 10,
+            }
+            for i in range(100)
+        ]
+        data = _make_benchmark(requests)
+        gen = HeatmapGenerator()
+        config = HeatmapConfig(prompt_bins=5, output_bins=5)
+        report = gen.generate(data, config)
+
+        assert report.total_requests == 100
+        non_empty = [c for c in report.grid.cells if c.count > 0]
+        assert len(non_empty) >= 5  # at least some bins filled
+
+    def test_default_config(self):
+        requests = [
+            {"prompt_tokens": 100, "output_tokens": 50, "total_latency_ms": 100.0},
+        ]
+        data = _make_benchmark(requests)
+        gen = HeatmapGenerator()
+        report = gen.generate(data)  # no config = defaults
+
+        assert report.config.prompt_bins == 10
+        assert report.config.output_bins == 10
+        assert report.config.metric == AggregationMetric.P95
+        assert report.config.field == LatencyField.TOTAL
+
+    def test_model_serialization(self):
+        requests = [
+            {"prompt_tokens": 100, "output_tokens": 50, "total_latency_ms": 100.0},
+        ]
+        data = _make_benchmark(requests)
+        gen = HeatmapGenerator()
+        report = gen.generate(data, HeatmapConfig(prompt_bins=2, output_bins=2))
+
+        d = report.model_dump()
+        assert "config" in d
+        assert "grid" in d
+        assert "cells" in d["grid"]
+        assert "total_requests" in d
+
+
+class TestProgrammaticAPI:
+    """Tests for generate_heatmap() function."""
+
+    def test_basic(self, tmp_path):
+        requests = [
+            {"prompt_tokens": 100, "output_tokens": 50, "total_latency_ms": 100.0},
+            {"prompt_tokens": 200, "output_tokens": 100, "total_latency_ms": 200.0},
+        ]
+        bench_file = _make_benchmark_file(requests, tmp_path)
+        result = generate_heatmap(str(bench_file), prompt_bins=2, output_bins=2)
+
+        assert isinstance(result, dict)
+        assert result["total_requests"] == 2
+        assert "grid" in result
+
+    def test_with_sla_threshold(self, tmp_path):
+        requests = [
+            {"prompt_tokens": 100, "output_tokens": 50, "total_latency_ms": 500.0},
+        ]
+        bench_file = _make_benchmark_file(requests, tmp_path)
+        result = generate_heatmap(
+            str(bench_file),
+            prompt_bins=1,
+            output_bins=1,
+            sla_threshold_ms=100.0,
+        )
+
+        assert result["hotspot_count"] >= 1
+
+    def test_custom_field(self, tmp_path):
+        requests = [
+            {
+                "prompt_tokens": 100, "output_tokens": 50,
+                "ttft_ms": 25.0, "tpot_ms": 5.0, "total_latency_ms": 100.0,
+            },
+        ]
+        bench_file = _make_benchmark_file(requests, tmp_path)
+        result = generate_heatmap(
+            str(bench_file),
+            prompt_bins=1,
+            output_bins=1,
+            field="ttft_ms",
+            metric="mean",
+        )
+
+        cells = result["grid"]["cells"]
+        non_empty = [c for c in cells if c["count"] > 0]
+        assert len(non_empty) == 1
+        assert non_empty[0]["value"] == 25.0


### PR DESCRIPTION
## Summary

Add latency heatmap data generation for visualizing how latency varies across prompt/output token combinations.

### Changes

- `HeatmapGenerator` class in `heatmap.py`
- `HeatmapConfig`, `HeatmapCell`, `HeatmapGrid`, `HeatmapReport` Pydantic models
- 2D grid mapping (prompt_tokens bins × output_tokens bins) to aggregated latency metrics
- Configurable bin count, aggregation metric (mean, P50, P95, P99), and target latency field (TTFT, TPOT, total)
- Hotspot detection: identify cells exceeding SLA thresholds
- CLI `heatmap` subcommand with `--benchmark`, `--bins`, `--metric`, `--field`, table + JSON output
- Programmatic `generate_heatmap()` API
- Update ROADMAP.md: mark M38 as completed (PR #91), add M39
- 25 new tests (911 total)

Closes #92