### PR TITLE
feat(drift): distribution drift detection using KS test (M41)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -517,9 +517,9 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Programmatic `generate_heatmap()` API
 - 25 new tests (911 total)
 
-### M40 — Request Timeline Analysis
+### M40 ✅ Request Timeline Analysis
 
-*In progress*
+*Completed — PR #96*
 
 - `TimelineAnalyzer` class in `timeline.py`
 - `TimeWindow`, `WarmupAnalysis`, `LatencyTrend`, `TimelineReport` Pydantic models
@@ -530,3 +530,16 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `timeline` subcommand with `--benchmark`, `--window-size`, `--warmup-factor`, table + JSON output
 - Programmatic `analyze_timeline()` API
 - 29 new tests (940 total)
+
+### M41 — Distribution Drift Detection
+
+*In progress*
+
+- `DriftDetector` class in `drift.py`
+- `DriftResult`, `DriftReport`, `DriftSeverity` Pydantic models
+- Kolmogorov-Smirnov two-sample test for TTFT, TPOT, and total_latency distributions
+- Severity classification: NONE (p>0.05), MINOR (p≤0.05, D<0.2), MODERATE (D≥0.2), MAJOR (D≥0.4)
+- Summary with which metrics drifted and by how much
+- CLI `drift` subcommand with `--baseline`, `--current`, table + JSON output
+- Programmatic `detect_drift()` API
+- ~22 new tests

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -83,6 +83,13 @@ from xpyd_plan.discovery import (
     ValidationStatus,
     discover_benchmarks,
 )
+from xpyd_plan.drift import (
+    DriftDetector,
+    DriftReport,
+    DriftResult,
+    DriftSeverity,
+    detect_drift,
+)
 from xpyd_plan.filter import (
     BenchmarkFilter,
     BenchmarkFilterResult,
@@ -360,6 +367,11 @@ __all__ = [
     "CorrelationReport",
     "CorrelationStrength",
     "analyze_correlation",
+    "DriftDetector",
+    "DriftReport",
+    "DriftResult",
+    "DriftSeverity",
+    "detect_drift",
     "LatencyTrend",
     "LatencyTrendDirection",
     "TimelineAnalyzer",

--- a/src/xpyd_plan/cli/_drift.py
+++ b/src/xpyd_plan/cli/_drift.py
@@ -1,0 +1,97 @@
+"""CLI drift command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.drift import DriftDetector, DriftSeverity
+
+
+def _cmd_drift(args: argparse.Namespace) -> None:
+    """Handle the 'drift' subcommand."""
+    console = Console()
+
+    baseline = load_benchmark_auto(args.baseline)
+    current = load_benchmark_auto(args.current)
+
+    detector = DriftDetector()
+    report = detector.detect(baseline, current)
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Table output
+    table = Table(title="Distribution Drift Detection")
+    table.add_column("Metric", justify="left")
+    table.add_column("KS Statistic", justify="right")
+    table.add_column("p-value", justify="right")
+    table.add_column("Severity", justify="center")
+    table.add_column("Baseline Mean", justify="right")
+    table.add_column("Current Mean", justify="right")
+    table.add_column("Shift", justify="right")
+
+    severity_style = {
+        DriftSeverity.NONE: "green",
+        DriftSeverity.MINOR: "yellow",
+        DriftSeverity.MODERATE: "dark_orange",
+        DriftSeverity.MAJOR: "bold red",
+    }
+
+    for r in report.results:
+        style = severity_style[r.severity]
+        shift_str = f"{r.mean_shift_ms:+.1f}ms"
+        table.add_row(
+            r.metric,
+            f"{r.ks_statistic:.4f}",
+            f"{r.p_value:.4f}",
+            f"[{style}]{r.severity.value}[/{style}]",
+            f"{r.baseline_mean_ms:.1f}ms",
+            f"{r.current_mean_ms:.1f}ms",
+            shift_str,
+        )
+
+    console.print(table)
+    console.print()
+
+    overall_style = severity_style[report.overall_severity]
+    console.print(
+        f"Overall: [{overall_style}]{report.overall_severity.value}[/{overall_style}]"
+    )
+    if report.drifted_metrics:
+        console.print(f"Drifted metrics: {', '.join(report.drifted_metrics)}")
+    console.print()
+    console.print(f"[bold]{report.recommendation}[/bold]")
+
+
+def add_drift_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the drift subcommand parser."""
+    parser = subparsers.add_parser(
+        "drift",
+        help="Detect distribution drift between two benchmark runs (KS test)",
+    )
+    parser.add_argument(
+        "--baseline",
+        required=True,
+        help="Path to baseline benchmark JSON file",
+    )
+    parser.add_argument(
+        "--current",
+        required=True,
+        help="Path to current benchmark JSON file",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_drift)

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -17,6 +17,7 @@ from xpyd_plan.cli._config import _add_config_flag, _apply_config_defaults, _cmd
 from xpyd_plan.cli._correlation import _cmd_correlation, add_correlation_parser
 from xpyd_plan.cli._dashboard import _cmd_dashboard
 from xpyd_plan.cli._discover import _cmd_discover, add_discover_parser
+from xpyd_plan.cli._drift import _cmd_drift, add_drift_parser
 from xpyd_plan.cli._export import _cmd_export
 from xpyd_plan.cli._filter import _cmd_filter
 from xpyd_plan.cli._fleet import _cmd_fleet
@@ -864,6 +865,9 @@ def main(argv: list[str] | None = None) -> None:
     # --- timeline subcommand ---
     add_timeline_parser(subparsers)
 
+    # --- drift subcommand ---
+    add_drift_parser(subparsers)
+
     # --- discover subcommand ---
     add_discover_parser(subparsers)
     add_heatmap_parser(subparsers)
@@ -933,6 +937,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_correlation(args)
     elif args.command == "timeline":
         _cmd_timeline(args)
+    elif args.command == "drift":
+        _cmd_drift(args)
     elif args.command == "discover":
         _cmd_discover(args)
     elif args.command == "heatmap":

--- a/src/xpyd_plan/drift.py
+++ b/src/xpyd_plan/drift.py
@@ -1,0 +1,236 @@
+"""Distribution drift detection between benchmark runs using KS test."""
+
+from __future__ import annotations
+
+import math
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData
+
+
+class DriftSeverity(str, Enum):
+    """Severity of distribution drift."""
+
+    NONE = "none"
+    MINOR = "minor"
+    MODERATE = "moderate"
+    MAJOR = "major"
+
+
+class DriftResult(BaseModel):
+    """Drift detection result for a single metric."""
+
+    metric: str = Field(..., description="Metric name (ttft, tpot, total_latency)")
+    ks_statistic: float = Field(..., ge=0, le=1, description="KS test statistic (D)")
+    p_value: float = Field(..., ge=0, le=1, description="KS test p-value")
+    severity: DriftSeverity = Field(..., description="Drift severity classification")
+    baseline_mean_ms: float = Field(..., ge=0, description="Baseline distribution mean")
+    current_mean_ms: float = Field(..., ge=0, description="Current distribution mean")
+    mean_shift_ms: float = Field(..., description="Mean shift (current - baseline)")
+
+
+class DriftReport(BaseModel):
+    """Complete drift detection report."""
+
+    results: list[DriftResult] = Field(..., description="Per-metric drift results")
+    overall_severity: DriftSeverity = Field(
+        ..., description="Worst severity across all metrics"
+    )
+    drifted_metrics: list[str] = Field(
+        ..., description="Metrics with severity > NONE"
+    )
+    recommendation: str = Field(..., description="Human-readable summary")
+
+
+def _ks_two_sample(
+    sample1: list[float], sample2: list[float]
+) -> tuple[float, float]:
+    """Two-sample Kolmogorov-Smirnov test.
+
+    Returns (D statistic, approximate p-value).
+    Uses the asymptotic Kolmogorov distribution approximation.
+    """
+    n1 = len(sample1)
+    n2 = len(sample2)
+    if n1 == 0 or n2 == 0:
+        return 0.0, 1.0
+
+    sorted1 = sorted(sample1)
+    sorted2 = sorted(sample2)
+
+    # Merge and compute empirical CDFs
+    all_values = sorted(set(sorted1 + sorted2))
+
+    d_max = 0.0
+    for v in all_values:
+        # CDF of sample1 at v
+        cdf1 = _bisect_right(sorted1, v) / n1
+        cdf2 = _bisect_right(sorted2, v) / n2
+        d_max = max(d_max, abs(cdf1 - cdf2))
+
+    # Approximate p-value using Kolmogorov distribution
+    en = math.sqrt(n1 * n2 / (n1 + n2))
+    lam = (en + 0.12 + 0.11 / en) * d_max
+
+    if lam == 0:
+        p_value = 1.0
+    else:
+        # Kolmogorov survival function approximation
+        p_value = 2.0 * sum(
+            ((-1) ** (i - 1)) * math.exp(-2.0 * (i * lam) ** 2)
+            for i in range(1, 101)
+        )
+        p_value = max(0.0, min(1.0, p_value))
+
+    return round(d_max, 6), round(p_value, 6)
+
+
+def _bisect_right(sorted_list: list[float], value: float) -> int:
+    """Binary search: count of elements <= value."""
+    lo, hi = 0, len(sorted_list)
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if sorted_list[mid] <= value:
+            lo = mid + 1
+        else:
+            hi = mid
+    return lo
+
+
+def _classify_severity(ks_d: float, p_value: float) -> DriftSeverity:
+    """Classify drift severity from KS statistic and p-value."""
+    if p_value > 0.05:
+        return DriftSeverity.NONE
+    if ks_d >= 0.4:
+        return DriftSeverity.MAJOR
+    if ks_d >= 0.2:
+        return DriftSeverity.MODERATE
+    return DriftSeverity.MINOR
+
+
+_SEVERITY_ORDER = {
+    DriftSeverity.NONE: 0,
+    DriftSeverity.MINOR: 1,
+    DriftSeverity.MODERATE: 2,
+    DriftSeverity.MAJOR: 3,
+}
+
+
+class DriftDetector:
+    """Detect distribution drift between two benchmark runs."""
+
+    def detect(
+        self, baseline: BenchmarkData, current: BenchmarkData
+    ) -> DriftReport:
+        """Run drift detection.
+
+        Args:
+            baseline: Reference benchmark data.
+            current: New benchmark data to compare against baseline.
+
+        Returns:
+            DriftReport with per-metric KS test results.
+
+        Raises:
+            ValueError: If either dataset has fewer than 2 requests.
+        """
+        if len(baseline.requests) < 2:
+            raise ValueError("Baseline must have at least 2 requests")
+        if len(current.requests) < 2:
+            raise ValueError("Current must have at least 2 requests")
+
+        metrics = [
+            ("ttft", "ttft_ms"),
+            ("tpot", "tpot_ms"),
+            ("total_latency", "total_latency_ms"),
+        ]
+
+        results: list[DriftResult] = []
+        for metric_name, attr in metrics:
+            baseline_vals = [getattr(r, attr) for r in baseline.requests]
+            current_vals = [getattr(r, attr) for r in current.requests]
+
+            ks_d, p_val = _ks_two_sample(baseline_vals, current_vals)
+            severity = _classify_severity(ks_d, p_val)
+
+            baseline_mean = sum(baseline_vals) / len(baseline_vals)
+            current_mean = sum(current_vals) / len(current_vals)
+
+            results.append(
+                DriftResult(
+                    metric=metric_name,
+                    ks_statistic=ks_d,
+                    p_value=p_val,
+                    severity=severity,
+                    baseline_mean_ms=round(baseline_mean, 3),
+                    current_mean_ms=round(current_mean, 3),
+                    mean_shift_ms=round(current_mean - baseline_mean, 3),
+                )
+            )
+
+        drifted = [r.metric for r in results if r.severity != DriftSeverity.NONE]
+        overall = max(results, key=lambda r: _SEVERITY_ORDER[r.severity]).severity
+
+        recommendation = self._build_recommendation(results, drifted, overall)
+
+        return DriftReport(
+            results=results,
+            overall_severity=overall,
+            drifted_metrics=drifted,
+            recommendation=recommendation,
+        )
+
+    def _build_recommendation(
+        self,
+        results: list[DriftResult],
+        drifted: list[str],
+        overall: DriftSeverity,
+    ) -> str:
+        """Build human-readable recommendation."""
+        if overall == DriftSeverity.NONE:
+            return (
+                "No significant distribution drift detected. "
+                "Latency distributions are statistically similar."
+            )
+
+        parts = [f"Distribution drift detected in: {', '.join(drifted)}."]
+
+        for r in results:
+            if r.severity != DriftSeverity.NONE:
+                direction = "increased" if r.mean_shift_ms > 0 else "decreased"
+                parts.append(
+                    f"  {r.metric}: {r.severity.value} drift "
+                    f"(D={r.ks_statistic:.3f}, p={r.p_value:.4f}), "
+                    f"mean {direction} by {abs(r.mean_shift_ms):.1f}ms"
+                )
+
+        if overall == DriftSeverity.MAJOR:
+            parts.append(
+                "Action recommended: investigate root cause of major distribution shift."
+            )
+        elif overall == DriftSeverity.MODERATE:
+            parts.append(
+                "Consider investigating the distribution change and its impact on SLA."
+            )
+
+        return " ".join(parts)
+
+
+def detect_drift(
+    baseline: BenchmarkData,
+    current: BenchmarkData,
+) -> dict:
+    """Programmatic API for drift detection.
+
+    Args:
+        baseline: Reference benchmark data.
+        current: New benchmark data.
+
+    Returns:
+        Dict with drift detection results.
+    """
+    detector = DriftDetector()
+    report = detector.detect(baseline, current)
+    return report.model_dump()

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -1,0 +1,278 @@
+"""Tests for distribution drift detection."""
+
+from __future__ import annotations
+
+import json
+import random
+import tempfile
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.drift import (
+    DriftDetector,
+    DriftSeverity,
+    _bisect_right,
+    _classify_severity,
+    _ks_two_sample,
+    detect_drift,
+)
+
+
+def _make_benchmark(
+    num_requests: int = 100,
+    ttft_base: float = 20.0,
+    tpot_base: float = 10.0,
+    total_base: float = 70.0,
+    noise: float = 5.0,
+    seed: int = 42,
+) -> BenchmarkData:
+    """Create a benchmark dataset with configurable latency distributions."""
+    rng = random.Random(seed)
+    requests_list = []
+    for i in range(num_requests):
+        requests_list.append(
+            BenchmarkRequest(
+                request_id=f"req-{i}",
+                prompt_tokens=100,
+                output_tokens=50,
+                ttft_ms=max(0.1, ttft_base + rng.gauss(0, noise)),
+                tpot_ms=max(0.1, tpot_base + rng.gauss(0, noise)),
+                total_latency_ms=max(0.1, total_base + rng.gauss(0, noise)),
+                timestamp=1000.0 + i,
+            )
+        )
+
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=2,
+            total_instances=4,
+            measured_qps=10.0,
+        ),
+        requests=requests_list,
+    )
+
+
+class TestKSTwoSample:
+    """Tests for the KS two-sample implementation."""
+
+    def test_identical_samples(self) -> None:
+        s = [1.0, 2.0, 3.0, 4.0, 5.0]
+        d, p = _ks_two_sample(s, s)
+        assert d == 0.0
+        assert p == 1.0
+
+    def test_completely_separated(self) -> None:
+        s1 = [1.0, 2.0, 3.0]
+        s2 = [10.0, 11.0, 12.0]
+        d, p = _ks_two_sample(s1, s2)
+        assert d == 1.0
+        assert p < 0.05
+
+    def test_empty_sample(self) -> None:
+        d, p = _ks_two_sample([], [1.0, 2.0])
+        assert d == 0.0
+        assert p == 1.0
+
+    def test_similar_samples(self) -> None:
+        rng = random.Random(42)
+        s1 = [rng.gauss(10, 1) for _ in range(100)]
+        s2 = [rng.gauss(10, 1) for _ in range(100)]
+        d, p = _ks_two_sample(s1, s2)
+        assert p > 0.05  # Should not reject null
+
+    def test_different_distributions(self) -> None:
+        rng = random.Random(42)
+        s1 = [rng.gauss(10, 1) for _ in range(200)]
+        s2 = [rng.gauss(20, 1) for _ in range(200)]
+        d, p = _ks_two_sample(s1, s2)
+        assert d > 0.5
+        assert p < 0.01
+
+
+class TestBisectRight:
+    def test_basic(self) -> None:
+        assert _bisect_right([1, 2, 3, 4, 5], 3) == 3
+
+    def test_value_not_present(self) -> None:
+        assert _bisect_right([1, 3, 5], 2) == 1
+
+    def test_empty(self) -> None:
+        assert _bisect_right([], 1) == 0
+
+
+class TestClassifySeverity:
+    def test_none(self) -> None:
+        assert _classify_severity(0.1, 0.5) == DriftSeverity.NONE
+
+    def test_minor(self) -> None:
+        assert _classify_severity(0.15, 0.01) == DriftSeverity.MINOR
+
+    def test_moderate(self) -> None:
+        assert _classify_severity(0.25, 0.01) == DriftSeverity.MODERATE
+
+    def test_major(self) -> None:
+        assert _classify_severity(0.5, 0.001) == DriftSeverity.MAJOR
+
+
+class TestDriftDetector:
+    def test_no_drift(self) -> None:
+        baseline = _make_benchmark(seed=42)
+        current = _make_benchmark(seed=43)
+        detector = DriftDetector()
+        report = detector.detect(baseline, current)
+        assert report.overall_severity == DriftSeverity.NONE
+        assert len(report.drifted_metrics) == 0
+
+    def test_major_drift(self) -> None:
+        baseline = _make_benchmark(total_base=70.0, seed=42)
+        current = _make_benchmark(total_base=200.0, seed=43)
+        detector = DriftDetector()
+        report = detector.detect(baseline, current)
+        assert report.overall_severity in (DriftSeverity.MODERATE, DriftSeverity.MAJOR)
+        assert "total_latency" in report.drifted_metrics
+
+    def test_ttft_drift(self) -> None:
+        baseline = _make_benchmark(ttft_base=20.0, seed=42)
+        current = _make_benchmark(ttft_base=100.0, seed=43)
+        detector = DriftDetector()
+        report = detector.detect(baseline, current)
+        assert "ttft" in report.drifted_metrics
+
+    def test_three_metrics_reported(self) -> None:
+        baseline = _make_benchmark(seed=42)
+        current = _make_benchmark(seed=43)
+        detector = DriftDetector()
+        report = detector.detect(baseline, current)
+        assert len(report.results) == 3
+        metrics = {r.metric for r in report.results}
+        assert metrics == {"ttft", "tpot", "total_latency"}
+
+    def test_too_few_baseline_requests(self) -> None:
+        baseline = _make_benchmark(num_requests=1)
+        current = _make_benchmark(num_requests=100)
+        detector = DriftDetector()
+        with pytest.raises(ValueError, match="Baseline must have at least 2"):
+            detector.detect(baseline, current)
+
+    def test_too_few_current_requests(self) -> None:
+        baseline = _make_benchmark(num_requests=100)
+        current = _make_benchmark(num_requests=1)
+        detector = DriftDetector()
+        with pytest.raises(ValueError, match="Current must have at least 2"):
+            detector.detect(baseline, current)
+
+    def test_recommendation_no_drift(self) -> None:
+        baseline = _make_benchmark(seed=42)
+        current = _make_benchmark(seed=43)
+        report = DriftDetector().detect(baseline, current)
+        assert "no significant" in report.recommendation.lower()
+
+    def test_recommendation_with_drift(self) -> None:
+        baseline = _make_benchmark(total_base=70.0, seed=42)
+        current = _make_benchmark(total_base=200.0, seed=43)
+        report = DriftDetector().detect(baseline, current)
+        assert "drift detected" in report.recommendation.lower()
+
+    def test_mean_shift_positive(self) -> None:
+        baseline = _make_benchmark(total_base=50.0, seed=42)
+        current = _make_benchmark(total_base=150.0, seed=43)
+        report = DriftDetector().detect(baseline, current)
+        total_result = next(r for r in report.results if r.metric == "total_latency")
+        assert total_result.mean_shift_ms > 0
+
+    def test_mean_shift_negative(self) -> None:
+        baseline = _make_benchmark(total_base=150.0, seed=42)
+        current = _make_benchmark(total_base=50.0, seed=43)
+        report = DriftDetector().detect(baseline, current)
+        total_result = next(r for r in report.results if r.metric == "total_latency")
+        assert total_result.mean_shift_ms < 0
+
+    def test_ks_statistic_range(self) -> None:
+        baseline = _make_benchmark(seed=42)
+        current = _make_benchmark(seed=43)
+        report = DriftDetector().detect(baseline, current)
+        for r in report.results:
+            assert 0.0 <= r.ks_statistic <= 1.0
+            assert 0.0 <= r.p_value <= 1.0
+
+
+class TestDetectDriftAPI:
+    def test_returns_dict(self) -> None:
+        baseline = _make_benchmark(seed=42)
+        current = _make_benchmark(seed=43)
+        result = detect_drift(baseline, current)
+        assert isinstance(result, dict)
+        assert "results" in result
+        assert "overall_severity" in result
+        assert "drifted_metrics" in result
+        assert "recommendation" in result
+
+    def test_drift_detected_in_api(self) -> None:
+        baseline = _make_benchmark(total_base=70.0, seed=42)
+        current = _make_benchmark(total_base=200.0, seed=43)
+        result = detect_drift(baseline, current)
+        assert result["overall_severity"] != "none"
+
+
+class TestDriftCLI:
+    def test_table_output(self) -> None:
+        import io
+        from contextlib import redirect_stdout
+
+        from xpyd_plan.cli._main import main
+
+        baseline = _make_benchmark(seed=42)
+        current = _make_benchmark(seed=43)
+
+        with (
+            tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as bf,
+            tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as cf,
+        ):
+            bf.write(baseline.model_dump_json(indent=2))
+            bf.flush()
+            cf.write(current.model_dump_json(indent=2))
+            cf.flush()
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                try:
+                    main(["drift", "--baseline", bf.name, "--current", cf.name])
+                except SystemExit:
+                    pass
+
+    def test_json_output(self) -> None:
+        import io
+        from contextlib import redirect_stdout
+
+        from xpyd_plan.cli._main import main
+
+        baseline = _make_benchmark(seed=42)
+        current = _make_benchmark(seed=43)
+
+        with (
+            tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as bf,
+            tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as cf,
+        ):
+            bf.write(baseline.model_dump_json(indent=2))
+            bf.flush()
+            cf.write(current.model_dump_json(indent=2))
+            cf.flush()
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                try:
+                    main([
+                        "drift", "--baseline", bf.name,
+                        "--current", cf.name,
+                        "--output-format", "json",
+                    ])
+                except SystemExit:
+                    pass
+
+            output = buf.getvalue()
+            if output.strip():
+                result = json.loads(output)
+                assert "results" in result
+                assert "overall_severity" in result


### PR DESCRIPTION
## Summary

Add distribution drift detection between benchmark runs using the Kolmogorov-Smirnov two-sample test.

### Changes
- `DriftDetector` class in `drift.py`
- `DriftResult`, `DriftReport`, `DriftSeverity` Pydantic models
- KS two-sample test for TTFT, TPOT, and total_latency distributions
- Severity classification: NONE (p>0.05), MINOR (p≤0.05, D<0.2), MODERATE (D≥0.2), MAJOR (D≥0.4)
- Summary with which metrics drifted and by how much
- CLI `drift` subcommand with `--baseline`, `--current`, table + JSON output
- Programmatic `detect_drift()` API
- 27 new tests (967 total)

Closes #97