### PR TITLE
feat: add efficiency scorecard (M44)

### DIFF
--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -204,6 +204,14 @@ from xpyd_plan.scaling import (
     ScalingReport,
     analyze_scaling,
 )
+from xpyd_plan.scorecard import (
+    ConfigScorecard,
+    DimensionScore,
+    ScorecardCalculator,
+    ScorecardReport,
+    ScoreGrade,
+    calculate_scorecard,
+)
 from xpyd_plan.tail import (
     LongTailProfile,
     TailAnalyzer,
@@ -373,6 +381,12 @@ __all__ = [
     "ScalingPoint",
     "ScalingReport",
     "analyze_scaling",
+    "ConfigScorecard",
+    "DimensionScore",
+    "ScoreGrade",
+    "ScorecardCalculator",
+    "ScorecardReport",
+    "calculate_scorecard",
     "MetricLine",
     "MetricsExporter",
     "MetricsReport",

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -32,6 +32,7 @@ from xpyd_plan.cli._pipeline import _cmd_pipeline
 from xpyd_plan.cli._recommend import _cmd_recommend
 from xpyd_plan.cli._root_cause import _cmd_root_cause, add_root_cause_parser
 from xpyd_plan.cli._scaling import _cmd_scaling, add_scaling_parser
+from xpyd_plan.cli._scorecard import _cmd_scorecard, add_scorecard_parser
 from xpyd_plan.cli._tail import _cmd_tail, add_tail_parser
 from xpyd_plan.cli._timeline import _cmd_timeline, add_timeline_parser
 from xpyd_plan.cli._trend import _cmd_trend
@@ -876,6 +877,9 @@ def main(argv: list[str] | None = None) -> None:
     # --- tail subcommand ---
     add_tail_parser(subparsers)
 
+    # --- scorecard subcommand ---
+    add_scorecard_parser(subparsers)
+
     # --- discover subcommand ---
     add_discover_parser(subparsers)
     add_heatmap_parser(subparsers)
@@ -951,6 +955,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_root_cause(args)
     elif args.command == "tail":
         _cmd_tail(args)
+    elif args.command == "scorecard":
+        _cmd_scorecard(args)
     elif args.command == "discover":
         _cmd_discover(args)
     elif args.command == "heatmap":

--- a/src/xpyd_plan/cli/_scorecard.py
+++ b/src/xpyd_plan/cli/_scorecard.py
@@ -1,0 +1,118 @@
+"""CLI scorecard command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.analyzer import BenchmarkAnalyzer
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.models import SLAConfig
+from xpyd_plan.scorecard import ScorecardCalculator, ScoreGrade
+
+
+def _cmd_scorecard(args: argparse.Namespace) -> None:
+    """Handle the 'scorecard' subcommand."""
+    console = Console()
+
+    data = load_benchmark_auto(args.benchmark)
+    sla = SLAConfig(
+        ttft_ms=getattr(args, "sla_ttft", None),
+        tpot_ms=getattr(args, "sla_tpot", None),
+        max_latency_ms=getattr(args, "sla_total", None),
+    )
+
+    analyzer = BenchmarkAnalyzer()
+    analyzer._data = data
+    analysis = analyzer.find_optimal_ratio(sla)
+
+    calc = ScorecardCalculator(
+        sla_weight=args.sla_weight,
+        utilization_weight=args.util_weight,
+        waste_weight=args.waste_weight,
+    )
+    report = calc.score(analysis)
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    table = Table(title="Efficiency Scorecard")
+    table.add_column("Ratio", justify="left")
+    table.add_column("Score", justify="right")
+    table.add_column("Grade", justify="center")
+    table.add_column("SLA", justify="center")
+    table.add_column("SLA Score", justify="right")
+    table.add_column("Util Score", justify="right")
+    table.add_column("Waste Score", justify="right")
+
+    for sc in report.scorecards:
+        grade_style = {
+            ScoreGrade.A: "bold green",
+            ScoreGrade.B: "green",
+            ScoreGrade.C: "yellow",
+            ScoreGrade.D: "red",
+            ScoreGrade.F: "bold red",
+        }[sc.grade]
+
+        sla_icon = "[green]✓[/green]" if sc.sla_passed else "[red]✗[/red]"
+
+        table.add_row(
+            sc.ratio,
+            f"[{grade_style}]{sc.composite_score:.1f}[/{grade_style}]",
+            f"[{grade_style}]{sc.grade.value}[/{grade_style}]",
+            sla_icon,
+            f"{sc.dimensions[0].score:.0f}",
+            f"{sc.dimensions[1].score:.0f}",
+            f"{sc.dimensions[2].score:.0f}",
+        )
+
+    console.print(table)
+    console.print(f"\n[bold]{report.summary}[/bold]")
+
+
+def add_scorecard_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the scorecard subcommand parser."""
+    parser = subparsers.add_parser(
+        "scorecard",
+        help="Compute efficiency scorecards for P:D configurations",
+    )
+    parser.add_argument(
+        "--benchmark", required=True,
+        help="Path to benchmark JSON file",
+    )
+    parser.add_argument(
+        "--sla-ttft", type=float, default=None,
+        help="TTFT SLA limit in ms",
+    )
+    parser.add_argument(
+        "--sla-tpot", type=float, default=None,
+        help="TPOT SLA limit in ms",
+    )
+    parser.add_argument(
+        "--sla-total", type=float, default=None,
+        help="Total latency SLA limit in ms",
+    )
+    parser.add_argument(
+        "--sla-weight", type=float, default=0.4,
+        help="Weight for SLA compliance (default: 0.4)",
+    )
+    parser.add_argument(
+        "--util-weight", type=float, default=0.3,
+        help="Weight for utilization (default: 0.3)",
+    )
+    parser.add_argument(
+        "--waste-weight", type=float, default=0.3,
+        help="Weight for resource waste (default: 0.3)",
+    )
+    parser.add_argument(
+        "--output-format", choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_scorecard)

--- a/src/xpyd_plan/scorecard.py
+++ b/src/xpyd_plan/scorecard.py
@@ -1,0 +1,266 @@
+"""Efficiency scorecard — composite 0-100 score for P:D configurations.
+
+Combines SLA compliance, resource utilization, and cost efficiency into
+a single comparable score, enabling quick ranking of configurations.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+from .benchmark_models import AnalysisResult, RatioCandidate
+
+
+class ScoreGrade(str, Enum):
+    """Letter grade for a configuration."""
+
+    A = "A"
+    B = "B"
+    C = "C"
+    D = "D"
+    F = "F"
+
+
+class DimensionScore(BaseModel):
+    """Score for a single evaluation dimension (0-100)."""
+
+    name: str = Field(..., description="Dimension name")
+    score: float = Field(..., ge=0, le=100, description="Score 0-100")
+    weight: float = Field(..., ge=0, le=1, description="Weight in composite")
+    details: str = Field("", description="Human-readable explanation")
+
+
+class ConfigScorecard(BaseModel):
+    """Scorecard for a single P:D configuration."""
+
+    ratio: str = Field(..., description="P:D ratio string (e.g. '2P:4D')")
+    num_prefill: int = Field(..., ge=1)
+    num_decode: int = Field(..., ge=1)
+    composite_score: float = Field(..., ge=0, le=100, description="Weighted composite score")
+    grade: ScoreGrade = Field(..., description="Letter grade")
+    dimensions: list[DimensionScore] = Field(..., description="Per-dimension scores")
+    sla_passed: bool = Field(..., description="Whether SLA constraints were met")
+
+
+class ScorecardReport(BaseModel):
+    """Complete scorecard report across all evaluated configurations."""
+
+    scorecards: list[ConfigScorecard] = Field(..., description="Scored configs, best first")
+    best_ratio: str = Field(..., description="Ratio with highest composite score")
+    best_score: float = Field(..., ge=0, le=100)
+    summary: str = Field(..., description="Human-readable summary")
+
+
+def _grade_from_score(score: float) -> ScoreGrade:
+    """Convert numeric score to letter grade."""
+    if score >= 90:
+        return ScoreGrade.A
+    if score >= 75:
+        return ScoreGrade.B
+    if score >= 60:
+        return ScoreGrade.C
+    if score >= 40:
+        return ScoreGrade.D
+    return ScoreGrade.F
+
+
+def _sla_score(candidate: RatioCandidate) -> tuple[float, str]:
+    """Score SLA compliance (0-100).
+
+    100 = all constraints met, 0 = all failed.
+    Uses meets_sla and individual metric booleans.
+    """
+    sla = candidate.sla_check
+    if sla is None:
+        return 50.0, "No SLA check data"
+
+    checks = [sla.meets_ttft, sla.meets_tpot, sla.meets_total_latency]
+    passed_count = sum(1 for c in checks if c)
+    total_count = len(checks)
+
+    if sla.meets_all:
+        score = 100.0
+    else:
+        # Partial credit: each passing check contributes proportionally
+        score = (passed_count / total_count) * 60.0
+
+    detail = (
+        f"SLA {'PASS' if sla.meets_all else 'FAIL'} "
+        f"({passed_count}/{total_count} metrics pass)"
+    )
+    return round(score, 2), detail
+
+
+def _utilization_score(candidate: RatioCandidate) -> tuple[float, str]:
+    """Score utilization efficiency (0-100).
+
+    Optimal is 70-90%. Penalize both under and over-utilization.
+    """
+    p_util = min(candidate.prefill_utilization, 1.0)
+    d_util = min(candidate.decode_utilization, 1.0)
+
+    def _util_to_score(u: float) -> float:
+        if u <= 0:
+            return 0.0
+        if u <= 0.8:
+            return u / 0.8 * 100.0
+        if u <= 0.95:
+            return 100.0
+        return max(70.0, 100.0 - (u - 0.95) * 600.0)
+
+    p_score = _util_to_score(p_util)
+    d_score = _util_to_score(d_util)
+    avg = (p_score + d_score) / 2
+
+    detail = (
+        f"Prefill util {p_util:.0%} (score {p_score:.0f}), "
+        f"Decode util {d_util:.0%} (score {d_score:.0f})"
+    )
+    return round(avg, 2), detail
+
+
+def _waste_score(candidate: RatioCandidate) -> tuple[float, str]:
+    """Score resource waste (0-100, higher = less waste = better)."""
+    waste = candidate.waste_rate
+
+    score = max(0.0, 100.0 * (1.0 - waste))
+    detail = f"Waste rate {waste:.1%}"
+    return round(score, 2), detail
+
+
+class ScorecardCalculator:
+    """Calculate efficiency scorecards for P:D configurations."""
+
+    def __init__(
+        self,
+        sla_weight: float = 0.4,
+        utilization_weight: float = 0.3,
+        waste_weight: float = 0.3,
+    ) -> None:
+        """Initialize calculator with dimension weights.
+
+        Args:
+            sla_weight: Weight for SLA compliance dimension (0-1).
+            utilization_weight: Weight for utilization dimension (0-1).
+            waste_weight: Weight for waste dimension (0-1).
+
+        Raises:
+            ValueError: If weights don't sum to ~1.0 or any weight is negative.
+        """
+        if any(w < 0 for w in (sla_weight, utilization_weight, waste_weight)):
+            raise ValueError("Weights must be non-negative")
+        total = sla_weight + utilization_weight + waste_weight
+        if abs(total - 1.0) > 0.01:
+            raise ValueError(f"Weights must sum to 1.0, got {total}")
+        self.sla_weight = sla_weight
+        self.utilization_weight = utilization_weight
+        self.waste_weight = waste_weight
+
+    def score(self, analysis: AnalysisResult) -> ScorecardReport:
+        """Score all ratio candidates from an analysis result.
+
+        Args:
+            analysis: AnalysisResult from BenchmarkAnalyzer.
+
+        Returns:
+            ScorecardReport with ranked configurations.
+
+        Raises:
+            ValueError: If no candidates to score.
+        """
+        if not analysis.candidates:
+            raise ValueError("No ratio candidates to score")
+
+        scorecards: list[ConfigScorecard] = []
+
+        for cand in analysis.candidates:
+            sla_s, sla_d = _sla_score(cand)
+            util_s, util_d = _utilization_score(cand)
+            waste_s, waste_d = _waste_score(cand)
+
+            dimensions = [
+                DimensionScore(
+                    name="SLA Compliance",
+                    score=sla_s,
+                    weight=self.sla_weight,
+                    details=sla_d,
+                ),
+                DimensionScore(
+                    name="Utilization",
+                    score=util_s,
+                    weight=self.utilization_weight,
+                    details=util_d,
+                ),
+                DimensionScore(
+                    name="Resource Waste",
+                    score=waste_s,
+                    weight=self.waste_weight,
+                    details=waste_d,
+                ),
+            ]
+
+            composite = sum(d.score * d.weight for d in dimensions)
+            composite = round(min(100.0, max(0.0, composite)), 2)
+
+            scorecards.append(ConfigScorecard(
+                ratio=cand.ratio_str,
+                num_prefill=cand.num_prefill,
+                num_decode=cand.num_decode,
+                composite_score=composite,
+                grade=_grade_from_score(composite),
+                dimensions=dimensions,
+                sla_passed=cand.meets_sla,
+            ))
+
+        scorecards.sort(key=lambda s: s.composite_score, reverse=True)
+
+        best = scorecards[0]
+        passing = [s for s in scorecards if s.sla_passed]
+        if passing:
+            best_passing = passing[0]
+            summary = (
+                f"Best configuration: {best_passing.ratio} "
+                f"(score {best_passing.composite_score:.0f}, grade {best_passing.grade.value}). "
+                f"{len(passing)}/{len(scorecards)} configurations pass SLA."
+            )
+        else:
+            summary = (
+                f"No configuration passes SLA. "
+                f"Highest score: {best.ratio} ({best.composite_score:.0f}, "
+                f"grade {best.grade.value})."
+            )
+
+        return ScorecardReport(
+            scorecards=scorecards,
+            best_ratio=best.ratio,
+            best_score=best.composite_score,
+            summary=summary,
+        )
+
+
+def calculate_scorecard(
+    analysis: AnalysisResult,
+    sla_weight: float = 0.4,
+    utilization_weight: float = 0.3,
+    waste_weight: float = 0.3,
+) -> dict:
+    """Programmatic API for efficiency scorecard.
+
+    Args:
+        analysis: AnalysisResult from BenchmarkAnalyzer.
+        sla_weight: Weight for SLA compliance (0-1).
+        utilization_weight: Weight for utilization (0-1).
+        waste_weight: Weight for waste (0-1).
+
+    Returns:
+        Dictionary representation of the ScorecardReport.
+    """
+    calc = ScorecardCalculator(
+        sla_weight=sla_weight,
+        utilization_weight=utilization_weight,
+        waste_weight=waste_weight,
+    )
+    report = calc.score(analysis)
+    return report.model_dump()

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -1,0 +1,293 @@
+"""Tests for efficiency scorecard module."""
+
+from __future__ import annotations
+
+import pytest
+
+from xpyd_plan.benchmark_models import AnalysisResult, RatioCandidate, SLACheck
+from xpyd_plan.scorecard import (
+    ScorecardCalculator,
+    ScoreGrade,
+    _grade_from_score,
+    _sla_score,
+    _utilization_score,
+    _waste_score,
+    calculate_scorecard,
+)
+
+
+def _make_sla_check(
+    meets_ttft: bool = True,
+    meets_tpot: bool = True,
+    meets_total: bool = True,
+) -> SLACheck:
+    return SLACheck(
+        ttft_p95_ms=10.0,
+        ttft_p99_ms=15.0,
+        tpot_p95_ms=5.0,
+        tpot_p99_ms=8.0,
+        total_latency_p95_ms=100.0,
+        total_latency_p99_ms=150.0,
+        meets_ttft=meets_ttft,
+        meets_tpot=meets_tpot,
+        meets_total_latency=meets_total,
+        meets_all=meets_ttft and meets_tpot and meets_total,
+    )
+
+
+def _make_candidate(
+    num_prefill: int = 2,
+    num_decode: int = 4,
+    prefill_util: float = 0.7,
+    decode_util: float = 0.8,
+    waste_rate: float = 0.1,
+    meets_sla: bool = True,
+    sla_check: SLACheck | None = None,
+) -> RatioCandidate:
+    return RatioCandidate(
+        num_prefill=num_prefill,
+        num_decode=num_decode,
+        prefill_utilization=prefill_util,
+        decode_utilization=decode_util,
+        waste_rate=waste_rate,
+        meets_sla=meets_sla,
+        sla_check=sla_check or _make_sla_check(),
+    )
+
+
+def _make_analysis(*candidates: RatioCandidate) -> AnalysisResult:
+    cands = list(candidates) if candidates else [_make_candidate()]
+    return AnalysisResult(
+        candidates=cands,
+        total_instances=cands[0].num_prefill + cands[0].num_decode,
+        best=cands[0] if cands[0].meets_sla else None,
+    )
+
+
+class TestGradeFromScore:
+    def test_grade_a(self) -> None:
+        assert _grade_from_score(95.0) == ScoreGrade.A
+        assert _grade_from_score(90.0) == ScoreGrade.A
+
+    def test_grade_b(self) -> None:
+        assert _grade_from_score(80.0) == ScoreGrade.B
+        assert _grade_from_score(75.0) == ScoreGrade.B
+
+    def test_grade_c(self) -> None:
+        assert _grade_from_score(60.0) == ScoreGrade.C
+        assert _grade_from_score(70.0) == ScoreGrade.C
+
+    def test_grade_d(self) -> None:
+        assert _grade_from_score(40.0) == ScoreGrade.D
+        assert _grade_from_score(55.0) == ScoreGrade.D
+
+    def test_grade_f(self) -> None:
+        assert _grade_from_score(0.0) == ScoreGrade.F
+        assert _grade_from_score(39.0) == ScoreGrade.F
+
+
+class TestSlaScore:
+    def test_all_pass(self) -> None:
+        cand = _make_candidate(sla_check=_make_sla_check())
+        score, detail = _sla_score(cand)
+        assert score == 100.0
+        assert "PASS" in detail
+
+    def test_all_fail(self) -> None:
+        sla = _make_sla_check(meets_ttft=False, meets_tpot=False, meets_total=False)
+        cand = _make_candidate(meets_sla=False, sla_check=sla)
+        score, detail = _sla_score(cand)
+        assert score == 0.0
+        assert "FAIL" in detail
+
+    def test_partial_pass(self) -> None:
+        sla = _make_sla_check(meets_ttft=True, meets_tpot=False, meets_total=True)
+        cand = _make_candidate(meets_sla=False, sla_check=sla)
+        score, _ = _sla_score(cand)
+        assert 0 < score < 100
+
+    def test_no_sla_check(self) -> None:
+        cand = _make_candidate(sla_check=None)
+        # Override sla_check to None
+        cand = RatioCandidate(
+            num_prefill=2, num_decode=4,
+            prefill_utilization=0.7, decode_utilization=0.8,
+            waste_rate=0.1, meets_sla=True, sla_check=None,
+        )
+        score, detail = _sla_score(cand)
+        assert score == 50.0
+        assert "No SLA" in detail
+
+
+class TestUtilizationScore:
+    def test_optimal_utilization(self) -> None:
+        cand = _make_candidate(prefill_util=0.85, decode_util=0.85)
+        score, _ = _utilization_score(cand)
+        assert score == 100.0
+
+    def test_low_utilization(self) -> None:
+        cand = _make_candidate(prefill_util=0.2, decode_util=0.2)
+        score, _ = _utilization_score(cand)
+        assert score < 50
+
+    def test_zero_utilization(self) -> None:
+        cand = _make_candidate(prefill_util=0.0, decode_util=0.0)
+        score, _ = _utilization_score(cand)
+        assert score == 0.0
+
+    def test_high_utilization_slight_penalty(self) -> None:
+        cand = _make_candidate(prefill_util=0.99, decode_util=0.99)
+        score, _ = _utilization_score(cand)
+        assert 70 <= score < 100
+
+
+class TestWasteScore:
+    def test_no_waste(self) -> None:
+        cand = _make_candidate(waste_rate=0.0)
+        score, _ = _waste_score(cand)
+        assert score == 100.0
+
+    def test_full_waste(self) -> None:
+        cand = _make_candidate(waste_rate=1.0)
+        score, _ = _waste_score(cand)
+        assert score == 0.0
+
+    def test_half_waste(self) -> None:
+        cand = _make_candidate(waste_rate=0.5)
+        score, _ = _waste_score(cand)
+        assert score == 50.0
+
+
+class TestScorecardCalculator:
+    def test_basic_scoring(self) -> None:
+        analysis = _make_analysis(_make_candidate())
+        calc = ScorecardCalculator()
+        report = calc.score(analysis)
+        assert len(report.scorecards) == 1
+        assert report.best_ratio == "2P:4D"
+        assert report.best_score > 0
+
+    def test_multiple_candidates_ranked(self) -> None:
+        good = _make_candidate(
+            num_prefill=2, num_decode=4,
+            prefill_util=0.85, decode_util=0.85,
+            waste_rate=0.05, meets_sla=True,
+        )
+        bad = _make_candidate(
+            num_prefill=1, num_decode=5,
+            prefill_util=0.2, decode_util=0.2,
+            waste_rate=0.6, meets_sla=False,
+            sla_check=_make_sla_check(
+                meets_ttft=False, meets_tpot=False, meets_total=False,
+            ),
+        )
+        analysis = _make_analysis(good, bad)
+        report = ScorecardCalculator().score(analysis)
+        assert report.scorecards[0].ratio == "2P:4D"
+        assert report.scorecards[0].composite_score > report.scorecards[1].composite_score
+
+    def test_no_candidates_raises(self) -> None:
+        analysis = AnalysisResult(candidates=[], total_instances=6)
+        with pytest.raises(ValueError, match="No ratio candidates"):
+            ScorecardCalculator().score(analysis)
+
+    def test_invalid_weights_negative(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            ScorecardCalculator(sla_weight=-0.1, utilization_weight=0.6, waste_weight=0.5)
+
+    def test_invalid_weights_sum(self) -> None:
+        with pytest.raises(ValueError, match="sum to 1.0"):
+            ScorecardCalculator(sla_weight=0.5, utilization_weight=0.5, waste_weight=0.5)
+
+    def test_custom_weights(self) -> None:
+        analysis = _make_analysis(_make_candidate())
+        report = ScorecardCalculator(
+            sla_weight=0.8, utilization_weight=0.1, waste_weight=0.1,
+        ).score(analysis)
+        assert report.best_score > 0
+
+    def test_all_fail_sla_summary(self) -> None:
+        sla = _make_sla_check(meets_ttft=False, meets_tpot=False, meets_total=False)
+        cand = _make_candidate(meets_sla=False, sla_check=sla)
+        report = ScorecardCalculator().score(_make_analysis(cand))
+        assert "No configuration passes SLA" in report.summary
+
+    def test_grade_assignment(self) -> None:
+        analysis = _make_analysis(_make_candidate(
+            prefill_util=0.85, decode_util=0.85,
+            waste_rate=0.0, meets_sla=True,
+        ))
+        report = ScorecardCalculator().score(analysis)
+        assert report.scorecards[0].grade in (ScoreGrade.A, ScoreGrade.B)
+
+    def test_dimensions_have_correct_weights(self) -> None:
+        report = ScorecardCalculator(
+            sla_weight=0.5, utilization_weight=0.3, waste_weight=0.2,
+        ).score(_make_analysis())
+        dims = report.scorecards[0].dimensions
+        assert dims[0].weight == 0.5
+        assert dims[1].weight == 0.3
+        assert dims[2].weight == 0.2
+
+
+class TestCalculateScorecard:
+    def test_programmatic_api(self) -> None:
+        analysis = _make_analysis(_make_candidate())
+        result = calculate_scorecard(analysis)
+        assert "scorecards" in result
+        assert "best_ratio" in result
+        assert "best_score" in result
+        assert "summary" in result
+        assert len(result["scorecards"]) == 1
+
+    def test_custom_weights_api(self) -> None:
+        analysis = _make_analysis(_make_candidate())
+        result = calculate_scorecard(
+            analysis, sla_weight=0.6, utilization_weight=0.2, waste_weight=0.2,
+        )
+        assert result["best_score"] > 0
+
+
+class TestConfigScorecard:
+    def test_sla_passed_flag(self) -> None:
+        cand_pass = _make_candidate(meets_sla=True)
+        cand_fail = _make_candidate(
+            num_prefill=1, num_decode=5, meets_sla=False,
+            sla_check=_make_sla_check(
+                meets_ttft=False, meets_tpot=False, meets_total=False,
+            ),
+        )
+        report = ScorecardCalculator().score(_make_analysis(cand_pass, cand_fail))
+        pass_cards = [s for s in report.scorecards if s.sla_passed]
+        fail_cards = [s for s in report.scorecards if not s.sla_passed]
+        assert len(pass_cards) == 1
+        assert len(fail_cards) == 1
+
+
+class TestEdgeCases:
+    def test_single_candidate(self) -> None:
+        report = ScorecardCalculator().score(_make_analysis(_make_candidate()))
+        assert len(report.scorecards) == 1
+        assert report.best_ratio == report.scorecards[0].ratio
+
+    def test_score_bounds(self) -> None:
+        """Composite score must always be 0-100."""
+        cand = _make_candidate(
+            prefill_util=0.0, decode_util=0.0,
+            waste_rate=1.0, meets_sla=False,
+            sla_check=_make_sla_check(
+                meets_ttft=False, meets_tpot=False, meets_total=False,
+            ),
+        )
+        report = ScorecardCalculator().score(_make_analysis(cand))
+        for sc in report.scorecards:
+            assert 0 <= sc.composite_score <= 100
+
+    def test_perfect_candidate(self) -> None:
+        cand = _make_candidate(
+            prefill_util=0.85, decode_util=0.85,
+            waste_rate=0.0, meets_sla=True,
+        )
+        report = ScorecardCalculator().score(_make_analysis(cand))
+        assert report.scorecards[0].composite_score == 100.0
+        assert report.scorecards[0].grade == ScoreGrade.A


### PR DESCRIPTION
Closes #104

## Changes
- `ScorecardCalculator` class in `scorecard.py`
- `ConfigScorecard`, `DimensionScore`, `ScoreGrade`, `ScorecardReport` Pydantic models
- Composite 0-100 score combining SLA compliance (40%), utilization (30%), and waste (30%)
- Configurable dimension weights
- Letter grading: A (90+), B (75+), C (60+), D (40+), F (<40)
- CLI `scorecard` subcommand with `--benchmark`, `--sla-*`, `--*-weight`, table + JSON output
- Programmatic `calculate_scorecard()` API
- 31 new tests (1046 total, all passing)

## Test Results
```
1046 passed in 23.98s
```

## Lint
```
ruff check src tests — All checks passed!
isort --check src tests — All checks passed!
```