### PR TITLE
feat: M45 Benchmark Plan Generator

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -585,3 +585,16 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `scorecard` subcommand with `--benchmark`, `--sla-*`, `--*-weight`, table + JSON output
 - Programmatic `calculate_scorecard()` API
 - 31 new tests (1046 total)
+
+### M45 ⏳ Benchmark Plan Generator
+
+*In Progress — PR #TBD*
+
+- `BenchmarkPlanGenerator` class in `plan_generator.py`
+- `PlannedRatio`, `BenchmarkPlan`, `RatioPriority` Pydantic models
+- Prioritized ratio enumeration: balanced (critical), boundaries (high), quarters (high), rest (medium)
+- Refinement mode: given existing `AnalysisResult`, focus on neighbors of current best
+- Max-runs cap to limit recommended configurations
+- CLI `plan-benchmarks` subcommand with `--total-instances`, `--max-runs`, table + JSON output
+- Programmatic `generate_benchmark_plan()` API
+- 19 new tests (1065 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -182,6 +182,13 @@ from xpyd_plan.pipeline import (
     load_pipeline_config,
     run_pipeline,
 )
+from xpyd_plan.plan_generator import (
+    BenchmarkPlan,
+    BenchmarkPlanGenerator,
+    PlannedRatio,
+    RatioPriority,
+    generate_benchmark_plan,
+)
 from xpyd_plan.recommender import (
     ActionCategory,
     Recommendation,
@@ -433,4 +440,9 @@ __all__ = [
     "HeatmapReport",
     "LatencyField",
     "generate_heatmap",
+    "BenchmarkPlan",
+    "BenchmarkPlanGenerator",
+    "PlannedRatio",
+    "RatioPriority",
+    "generate_benchmark_plan",
 ]

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -29,6 +29,7 @@ from xpyd_plan.cli._metrics import _cmd_metrics, add_metrics_parser
 from xpyd_plan.cli._model_compare import _cmd_model_compare
 from xpyd_plan.cli._pareto import _cmd_pareto
 from xpyd_plan.cli._pipeline import _cmd_pipeline
+from xpyd_plan.cli._plan_benchmarks import _cmd_plan_benchmarks, add_plan_benchmarks_parser
 from xpyd_plan.cli._recommend import _cmd_recommend
 from xpyd_plan.cli._root_cause import _cmd_root_cause, add_root_cause_parser
 from xpyd_plan.cli._scaling import _cmd_scaling, add_scaling_parser
@@ -884,6 +885,9 @@ def main(argv: list[str] | None = None) -> None:
     add_discover_parser(subparsers)
     add_heatmap_parser(subparsers)
 
+    # --- plan-benchmarks subcommand ---
+    add_plan_benchmarks_parser(subparsers)
+
     args = parser.parse_args(argv)
 
     if args.command == "config":
@@ -961,6 +965,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_discover(args)
     elif args.command == "heatmap":
         _cmd_heatmap(args)
+    elif args.command == "plan-benchmarks":
+        _cmd_plan_benchmarks(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/cli/_plan_benchmarks.py
+++ b/src/xpyd_plan/cli/_plan_benchmarks.py
@@ -1,0 +1,75 @@
+"""CLI plan-benchmarks command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.plan_generator import BenchmarkPlanGenerator, RatioPriority
+
+
+def _cmd_plan_benchmarks(args: argparse.Namespace) -> None:
+    """Handle the 'plan-benchmarks' subcommand."""
+    console = Console()
+
+    generator = BenchmarkPlanGenerator(
+        total_instances=args.total_instances,
+        max_runs=getattr(args, "max_runs", None),
+    )
+    plan = generator.generate()
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(plan.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    table = Table(title=f"Benchmark Plan — {plan.total_instances} instances")
+    table.add_column("#", justify="right")
+    table.add_column("Ratio", justify="left")
+    table.add_column("Priority", justify="center")
+    table.add_column("Reason", justify="left")
+
+    priority_style = {
+        RatioPriority.CRITICAL: "bold red",
+        RatioPriority.HIGH: "bold yellow",
+        RatioPriority.MEDIUM: "green",
+        RatioPriority.LOW: "dim",
+    }
+
+    for i, r in enumerate(plan.ratios, 1):
+        style = priority_style[r.priority]
+        table.add_row(
+            str(i),
+            r.ratio_str,
+            f"[{style}]{r.priority.value}[/{style}]",
+            r.reason,
+        )
+
+    console.print(table)
+    console.print(f"\n[bold]{len(plan.ratios)} configurations recommended[/bold]")
+
+
+def add_plan_benchmarks_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the plan-benchmarks subcommand parser."""
+    parser = subparsers.add_parser(
+        "plan-benchmarks",
+        help="Recommend which P:D ratios to benchmark",
+    )
+    parser.add_argument(
+        "--total-instances", type=int, required=True,
+        help="Total number of instances available",
+    )
+    parser.add_argument(
+        "--max-runs", type=int, default=None,
+        help="Maximum number of benchmark runs to recommend",
+    )
+    parser.add_argument(
+        "--output-format", choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_plan_benchmarks)

--- a/src/xpyd_plan/plan_generator.py
+++ b/src/xpyd_plan/plan_generator.py
@@ -1,0 +1,239 @@
+"""Benchmark plan generator — recommend which P:D ratios to benchmark.
+
+Given a total instance count, generates a prioritized list of P:D
+configurations to benchmark, minimizing the number of runs needed to
+find the optimal ratio.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+from .benchmark_models import AnalysisResult
+
+
+class RatioPriority(str, Enum):
+    """Priority level for a recommended benchmark ratio."""
+
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class PlannedRatio(BaseModel):
+    """A single recommended P:D ratio to benchmark."""
+
+    num_prefill: int = Field(..., ge=1)
+    num_decode: int = Field(..., ge=1)
+    priority: RatioPriority
+    reason: str = Field(..., description="Why this ratio is recommended")
+
+    @property
+    def total(self) -> int:
+        return self.num_prefill + self.num_decode
+
+    @property
+    def ratio_str(self) -> str:
+        return f"{self.num_prefill}P:{self.num_decode}D"
+
+
+class BenchmarkPlan(BaseModel):
+    """Complete benchmark plan."""
+
+    total_instances: int = Field(..., ge=2)
+    max_runs: int | None = Field(None, description="Max runs cap (None = all)")
+    ratios: list[PlannedRatio] = Field(..., description="Ordered list of ratios to benchmark")
+    refined: bool = Field(False, description="Whether plan was refined using existing data")
+
+
+class BenchmarkPlanGenerator:
+    """Generates a prioritized benchmark plan for P:D ratio exploration."""
+
+    def __init__(
+        self,
+        total_instances: int,
+        max_runs: int | None = None,
+        existing_result: AnalysisResult | None = None,
+    ) -> None:
+        if total_instances < 2:
+            raise ValueError("total_instances must be >= 2")
+        if max_runs is not None and max_runs < 1:
+            raise ValueError("max_runs must be >= 1")
+        self.total = total_instances
+        self.max_runs = max_runs
+        self.existing_result = existing_result
+
+    def generate(self) -> BenchmarkPlan:
+        """Generate the benchmark plan."""
+        all_ratios = self._enumerate_ratios()
+
+        if self.existing_result and self.existing_result.best:
+            planned = self._refine_plan(all_ratios)
+            refined = True
+        else:
+            planned = self._initial_plan(all_ratios)
+            refined = False
+
+        # Deduplicate preserving order
+        seen: set[tuple[int, int]] = set()
+        unique: list[PlannedRatio] = []
+        for r in planned:
+            key = (r.num_prefill, r.num_decode)
+            if key not in seen:
+                seen.add(key)
+                unique.append(r)
+
+        if self.max_runs is not None:
+            unique = unique[: self.max_runs]
+
+        return BenchmarkPlan(
+            total_instances=self.total,
+            max_runs=self.max_runs,
+            ratios=unique,
+            refined=refined,
+        )
+
+    def _enumerate_ratios(self) -> list[tuple[int, int]]:
+        """Return all valid (P, D) splits."""
+        return [(p, self.total - p) for p in range(1, self.total)]
+
+    def _initial_plan(self, all_ratios: list[tuple[int, int]]) -> list[PlannedRatio]:
+        """Build prioritized plan without existing data."""
+        planned: list[PlannedRatio] = []
+
+        # Critical: balanced ratio
+        mid = self.total // 2
+        balanced = (mid, self.total - mid)
+        planned.append(
+            PlannedRatio(
+                num_prefill=balanced[0],
+                num_decode=balanced[1],
+                priority=RatioPriority.CRITICAL,
+                reason="balanced split — strong baseline",
+            )
+        )
+        # If total is even, also add the mirror
+        if self.total % 2 == 0 and balanced[0] != balanced[1]:
+            mirror = (balanced[1], balanced[0])
+            planned.append(
+                PlannedRatio(
+                    num_prefill=mirror[0],
+                    num_decode=mirror[1],
+                    priority=RatioPriority.CRITICAL,
+                    reason="balanced split (mirror) — strong baseline",
+                )
+            )
+
+        # High: boundary ratios
+        for p, d in [(1, self.total - 1), (self.total - 1, 1)]:
+            planned.append(
+                PlannedRatio(
+                    num_prefill=p,
+                    num_decode=d,
+                    priority=RatioPriority.HIGH,
+                    reason="boundary ratio — establishes extreme behavior",
+                )
+            )
+
+        # High: quarter points
+        q1 = max(1, self.total // 4)
+        q3 = max(1, 3 * self.total // 4)
+        for p in [q1, q3]:
+            d = self.total - p
+            if d >= 1:
+                planned.append(
+                    PlannedRatio(
+                        num_prefill=p,
+                        num_decode=d,
+                        priority=RatioPriority.HIGH,
+                        reason="quarter-point ratio — covers spread",
+                    )
+                )
+
+        # Medium: remaining ratios
+        seen = {(r.num_prefill, r.num_decode) for r in planned}
+        for p, d in all_ratios:
+            if (p, d) not in seen:
+                planned.append(
+                    PlannedRatio(
+                        num_prefill=p,
+                        num_decode=d,
+                        priority=RatioPriority.MEDIUM,
+                        reason="additional coverage",
+                    )
+                )
+
+        return planned
+
+    def _refine_plan(self, all_ratios: list[tuple[int, int]]) -> list[PlannedRatio]:
+        """Refine plan around existing best ratio."""
+        best = self.existing_result.best  # type: ignore[union-attr]
+        bp, bd = best.num_prefill, best.num_decode
+        planned: list[PlannedRatio] = []
+
+        # Critical: immediate neighbors of best
+        for delta in [-1, 1]:
+            np_, nd = bp + delta, bd - delta
+            if np_ >= 1 and nd >= 1:
+                planned.append(
+                    PlannedRatio(
+                        num_prefill=np_,
+                        num_decode=nd,
+                        priority=RatioPriority.CRITICAL,
+                        reason=f"neighbor of current best ({bp}P:{bd}D)",
+                    )
+                )
+
+        # High: two steps away
+        for delta in [-2, 2]:
+            np_, nd = bp + delta, bd - delta
+            if np_ >= 1 and nd >= 1:
+                planned.append(
+                    PlannedRatio(
+                        num_prefill=np_,
+                        num_decode=nd,
+                        priority=RatioPriority.HIGH,
+                        reason=f"near current best ({bp}P:{bd}D)",
+                    )
+                )
+
+        # Medium: everything else
+        seen = {(r.num_prefill, r.num_decode) for r in planned}
+        # Also exclude already-benchmarked ratios from existing result
+        if self.existing_result:
+            for c in self.existing_result.candidates:
+                seen.add((c.num_prefill, c.num_decode))
+
+        for p, d in all_ratios:
+            if (p, d) not in seen:
+                planned.append(
+                    PlannedRatio(
+                        num_prefill=p,
+                        num_decode=d,
+                        priority=RatioPriority.MEDIUM,
+                        reason="additional coverage",
+                    )
+                )
+
+        return planned
+
+
+def generate_benchmark_plan(
+    total_instances: int,
+    max_runs: int | None = None,
+    existing_result: AnalysisResult | None = None,
+) -> dict:
+    """Programmatic API for benchmark plan generation.
+
+    Returns a dict with the plan details.
+    """
+    generator = BenchmarkPlanGenerator(
+        total_instances=total_instances,
+        max_runs=max_runs,
+        existing_result=existing_result,
+    )
+    plan = generator.generate()
+    return plan.model_dump()

--- a/tests/test_plan_generator.py
+++ b/tests/test_plan_generator.py
@@ -1,0 +1,209 @@
+"""Tests for benchmark plan generator module."""
+
+from __future__ import annotations
+
+import pytest
+
+from xpyd_plan.benchmark_models import AnalysisResult, RatioCandidate, SLACheck
+from xpyd_plan.plan_generator import (
+    BenchmarkPlan,
+    BenchmarkPlanGenerator,
+    PlannedRatio,
+    RatioPriority,
+    generate_benchmark_plan,
+)
+
+
+def _make_sla_check() -> SLACheck:
+    return SLACheck(
+        ttft_p95_ms=10.0,
+        ttft_p99_ms=15.0,
+        tpot_p95_ms=5.0,
+        tpot_p99_ms=8.0,
+        total_latency_p95_ms=100.0,
+        total_latency_p99_ms=150.0,
+        meets_ttft=True,
+        meets_tpot=True,
+        meets_total_latency=True,
+        meets_all=True,
+    )
+
+
+def _make_candidate(p: int, d: int, meets: bool = True) -> RatioCandidate:
+    return RatioCandidate(
+        num_prefill=p,
+        num_decode=d,
+        prefill_utilization=0.7,
+        decode_utilization=0.8,
+        waste_rate=0.1,
+        meets_sla=meets,
+        sla_check=_make_sla_check(),
+    )
+
+
+class TestBenchmarkPlanGenerator:
+    """Tests for BenchmarkPlanGenerator."""
+
+    def test_minimum_instances(self) -> None:
+        gen = BenchmarkPlanGenerator(total_instances=2)
+        plan = gen.generate()
+        assert plan.total_instances == 2
+        assert len(plan.ratios) == 1  # Only 1P:1D possible
+        assert plan.ratios[0].num_prefill == 1
+        assert plan.ratios[0].num_decode == 1
+
+    def test_all_ratios_enumerated(self) -> None:
+        gen = BenchmarkPlanGenerator(total_instances=6)
+        plan = gen.generate()
+        # 5 possible ratios: 1:5, 2:4, 3:3, 4:2, 5:1
+        assert len(plan.ratios) == 5
+        totals = {r.num_prefill + r.num_decode for r in plan.ratios}
+        assert totals == {6}
+
+    def test_invalid_total_instances(self) -> None:
+        with pytest.raises(ValueError, match="total_instances must be >= 2"):
+            BenchmarkPlanGenerator(total_instances=1)
+
+    def test_invalid_max_runs(self) -> None:
+        with pytest.raises(ValueError, match="max_runs must be >= 1"):
+            BenchmarkPlanGenerator(total_instances=4, max_runs=0)
+
+    def test_max_runs_caps_output(self) -> None:
+        gen = BenchmarkPlanGenerator(total_instances=10, max_runs=3)
+        plan = gen.generate()
+        assert len(plan.ratios) == 3
+
+    def test_balanced_is_first(self) -> None:
+        gen = BenchmarkPlanGenerator(total_instances=8)
+        plan = gen.generate()
+        assert plan.ratios[0].num_prefill == 4
+        assert plan.ratios[0].num_decode == 4
+        assert plan.ratios[0].priority == RatioPriority.CRITICAL
+
+    def test_boundaries_included(self) -> None:
+        gen = BenchmarkPlanGenerator(total_instances=6)
+        plan = gen.generate()
+        ratios = {(r.num_prefill, r.num_decode) for r in plan.ratios}
+        assert (1, 5) in ratios
+        assert (5, 1) in ratios
+
+    def test_no_duplicates(self) -> None:
+        gen = BenchmarkPlanGenerator(total_instances=8)
+        plan = gen.generate()
+        pairs = [(r.num_prefill, r.num_decode) for r in plan.ratios]
+        assert len(pairs) == len(set(pairs))
+
+    def test_priority_ordering(self) -> None:
+        gen = BenchmarkPlanGenerator(total_instances=10)
+        plan = gen.generate()
+        # Critical should come before Medium
+        critical_idx = [
+            i for i, r in enumerate(plan.ratios)
+            if r.priority == RatioPriority.CRITICAL
+        ]
+        medium_idx = [
+            i for i, r in enumerate(plan.ratios)
+            if r.priority == RatioPriority.MEDIUM
+        ]
+        if critical_idx and medium_idx:
+            assert max(critical_idx) < min(medium_idx)
+
+    def test_refined_plan_with_existing_result(self) -> None:
+        best = _make_candidate(3, 5)
+        result = AnalysisResult(
+            best=best,
+            candidates=[best, _make_candidate(4, 4)],
+            total_instances=8,
+        )
+        gen = BenchmarkPlanGenerator(total_instances=8, existing_result=result)
+        plan = gen.generate()
+        assert plan.refined is True
+        # Neighbors of 3P:5D should be critical
+        critical = [r for r in plan.ratios if r.priority == RatioPriority.CRITICAL]
+        critical_pairs = {(r.num_prefill, r.num_decode) for r in critical}
+        assert (2, 6) in critical_pairs  # 3-1=2
+        assert (4, 4) in critical_pairs or len(critical) > 0
+
+    def test_refined_excludes_already_benchmarked(self) -> None:
+        best = _make_candidate(3, 5)
+        already = _make_candidate(4, 4)
+        result = AnalysisResult(
+            best=best,
+            candidates=[best, already],
+            total_instances=8,
+        )
+        gen = BenchmarkPlanGenerator(total_instances=8, existing_result=result)
+        plan = gen.generate()
+        medium_pairs = {
+            (r.num_prefill, r.num_decode)
+            for r in plan.ratios
+            if r.priority == RatioPriority.MEDIUM
+        }
+        # 3:5 and 4:4 are already benchmarked, should not appear in medium
+        assert (3, 5) not in medium_pairs
+        assert (4, 4) not in medium_pairs
+
+    def test_plan_model_fields(self) -> None:
+        gen = BenchmarkPlanGenerator(total_instances=4)
+        plan = gen.generate()
+        assert isinstance(plan, BenchmarkPlan)
+        assert plan.total_instances == 4
+        assert plan.refined is False
+        for r in plan.ratios:
+            assert isinstance(r, PlannedRatio)
+            assert r.num_prefill >= 1
+            assert r.num_decode >= 1
+
+    def test_ratio_str_property(self) -> None:
+        r = PlannedRatio(num_prefill=3, num_decode=5, priority=RatioPriority.HIGH, reason="test")
+        assert r.ratio_str == "3P:5D"
+        assert r.total == 8
+
+    def test_three_instances(self) -> None:
+        gen = BenchmarkPlanGenerator(total_instances=3)
+        plan = gen.generate()
+        # 2 possible ratios: 1:2, 2:1
+        assert len(plan.ratios) == 2
+
+    def test_large_instance_count(self) -> None:
+        gen = BenchmarkPlanGenerator(total_instances=20, max_runs=5)
+        plan = gen.generate()
+        assert len(plan.ratios) == 5
+        # First should be balanced (10:10)
+        assert plan.ratios[0].num_prefill == 10
+
+    def test_programmatic_api(self) -> None:
+        result = generate_benchmark_plan(total_instances=6, max_runs=3)
+        assert isinstance(result, dict)
+        assert result["total_instances"] == 6
+        assert len(result["ratios"]) == 3
+        assert result["refined"] is False
+
+    def test_programmatic_api_with_existing(self) -> None:
+        best = _make_candidate(2, 4)
+        analysis = AnalysisResult(
+            best=best,
+            candidates=[best],
+            total_instances=6,
+        )
+        result = generate_benchmark_plan(total_instances=6, existing_result=analysis)
+        assert result["refined"] is True
+
+    def test_max_runs_one(self) -> None:
+        gen = BenchmarkPlanGenerator(total_instances=10, max_runs=1)
+        plan = gen.generate()
+        assert len(plan.ratios) == 1
+        assert plan.ratios[0].priority == RatioPriority.CRITICAL
+
+    def test_even_vs_odd_total(self) -> None:
+        # Even: balanced is exactly half
+        gen_even = BenchmarkPlanGenerator(total_instances=8)
+        plan_even = gen_even.generate()
+        assert plan_even.ratios[0].num_prefill == 4
+        assert plan_even.ratios[0].num_decode == 4
+
+        # Odd: balanced is floor(N/2)
+        gen_odd = BenchmarkPlanGenerator(total_instances=7)
+        plan_odd = gen_odd.generate()
+        assert plan_odd.ratios[0].num_prefill == 3
+        assert plan_odd.ratios[0].num_decode == 4


### PR DESCRIPTION
## Summary

Recommend which P:D ratios to benchmark given a total instance count, minimizing the number of runs needed to find the optimal ratio.

## Changes

- `BenchmarkPlanGenerator` class in `plan_generator.py`
- `PlannedRatio`, `BenchmarkPlan`, `RatioPriority` Pydantic models
- Prioritized ratio enumeration: balanced (critical), boundaries (high), quarters (high), rest (medium)
- Refinement mode: given existing `AnalysisResult`, focus on neighbors of current best
- Max-runs cap to limit recommended configurations
- CLI `plan-benchmarks` subcommand with `--total-instances`, `--max-runs`, table + JSON output
- Programmatic `generate_benchmark_plan()` API
- 19 new tests (1065 total)

Closes #106