### PR TITLE
feat: M46 SLA Threshold Tuning Advisor

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -586,9 +586,9 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Programmatic `calculate_scorecard()` API
 - 31 new tests (1046 total)
 
-### M45 ⏳ Benchmark Plan Generator
+### M45 ✅ Benchmark Plan Generator
 
-*In Progress — PR #TBD*
+*Completed — PR #107*
 
 - `BenchmarkPlanGenerator` class in `plan_generator.py`
 - `PlannedRatio`, `BenchmarkPlan`, `RatioPriority` Pydantic models
@@ -598,3 +598,15 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `plan-benchmarks` subcommand with `--total-instances`, `--max-runs`, table + JSON output
 - Programmatic `generate_benchmark_plan()` API
 - 19 new tests (1065 total)
+
+### M46 ⏳ SLA Threshold Tuning Advisor
+
+*In Progress — PR #TBD*
+
+- `ThresholdAdvisor` class in `threshold_advisor.py`
+- `ThresholdSuggestion`, `AdvisorReport`, `SweetSpot`, `PassRateTarget` Pydantic models
+- For each latency metric, compute the threshold needed to achieve target pass rates
+- Sweet-spot detection: identify inflection points where small threshold relaxation yields large compliance gains
+- CLI `threshold-advisor` subcommand with `--benchmark`, `--pass-rates`, table + JSON output
+- Programmatic `advise_thresholds()` API
+- 19 new tests (1084 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -227,6 +227,14 @@ from xpyd_plan.tail import (
     TailReport,
     analyze_tail,
 )
+from xpyd_plan.threshold_advisor import (
+    AdvisorReport,
+    PassRateTarget,
+    SweetSpot,
+    ThresholdAdvisor,
+    ThresholdSuggestion,
+    advise_thresholds,
+)
 from xpyd_plan.timeline import (
     LatencyTrend,
     LatencyTrendDirection,
@@ -445,4 +453,10 @@ __all__ = [
     "PlannedRatio",
     "RatioPriority",
     "generate_benchmark_plan",
+    "AdvisorReport",
+    "PassRateTarget",
+    "SweetSpot",
+    "ThresholdAdvisor",
+    "ThresholdSuggestion",
+    "advise_thresholds",
 ]

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -35,6 +35,7 @@ from xpyd_plan.cli._root_cause import _cmd_root_cause, add_root_cause_parser
 from xpyd_plan.cli._scaling import _cmd_scaling, add_scaling_parser
 from xpyd_plan.cli._scorecard import _cmd_scorecard, add_scorecard_parser
 from xpyd_plan.cli._tail import _cmd_tail, add_tail_parser
+from xpyd_plan.cli._threshold_advisor import _cmd_threshold_advisor, add_threshold_advisor_parser
 from xpyd_plan.cli._timeline import _cmd_timeline, add_timeline_parser
 from xpyd_plan.cli._trend import _cmd_trend
 from xpyd_plan.cli._validate import _cmd_validate
@@ -888,6 +889,9 @@ def main(argv: list[str] | None = None) -> None:
     # --- plan-benchmarks subcommand ---
     add_plan_benchmarks_parser(subparsers)
 
+    # --- threshold-advisor subcommand ---
+    add_threshold_advisor_parser(subparsers)
+
     args = parser.parse_args(argv)
 
     if args.command == "config":
@@ -967,6 +971,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_heatmap(args)
     elif args.command == "plan-benchmarks":
         _cmd_plan_benchmarks(args)
+    elif args.command == "threshold-advisor":
+        _cmd_threshold_advisor(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/cli/_threshold_advisor.py
+++ b/src/xpyd_plan/cli/_threshold_advisor.py
@@ -1,0 +1,91 @@
+"""CLI threshold-advisor command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.analyzer import BenchmarkAnalyzer
+from xpyd_plan.threshold_advisor import ThresholdAdvisor
+
+
+def _cmd_threshold_advisor(args: argparse.Namespace) -> None:
+    """Handle the 'threshold-advisor' subcommand."""
+    console = Console()
+
+    analyzer = BenchmarkAnalyzer(args.benchmark)
+    data = analyzer.data
+
+    pass_rates = [float(x) for x in args.pass_rates.split(",")]
+    advisor = ThresholdAdvisor(data, pass_rates=pass_rates)
+    report = advisor.advise()
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Suggestions table
+    table = Table(title="SLA Threshold Recommendations")
+    table.add_column("Metric", justify="left")
+    table.add_column("Pass Rate", justify="right")
+    table.add_column("Threshold (ms)", justify="right")
+
+    for s in report.suggestions:
+        table.add_row(
+            s.metric,
+            f"{s.pass_rate:.0%}",
+            f"{s.threshold_ms:.2f}",
+        )
+
+    console.print(table)
+
+    # Sweet spots
+    if report.sweet_spots:
+        console.print()
+        st = Table(title="Sweet Spots (high gain per ms relaxation)")
+        st.add_column("Metric", justify="left")
+        st.add_column("Threshold (ms)", justify="right")
+        st.add_column("Pass Rate Range", justify="center")
+        st.add_column("Gain", justify="right")
+
+        for spot in report.sweet_spots:
+            st.add_row(
+                spot.metric,
+                f"{spot.threshold_ms:.2f}",
+                f"{spot.pass_rate_below:.1%} → {spot.pass_rate_above:.1%}",
+                f"+{spot.gain:.1%}",
+            )
+        console.print(st)
+
+
+def add_threshold_advisor_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the threshold-advisor subcommand parser."""
+    parser = subparsers.add_parser(
+        "threshold-advisor",
+        help="Recommend optimal SLA thresholds from benchmark data",
+    )
+    parser.add_argument(
+        "--benchmark",
+        type=str,
+        required=True,
+        help="Path to benchmark JSON file",
+    )
+    parser.add_argument(
+        "--pass-rates",
+        type=str,
+        default="0.90,0.95,0.99",
+        help="Comma-separated target pass rates (default: 0.90,0.95,0.99)",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_threshold_advisor)

--- a/src/xpyd_plan/threshold_advisor.py
+++ b/src/xpyd_plan/threshold_advisor.py
@@ -1,0 +1,168 @@
+"""SLA Threshold Tuning Advisor — recommend optimal SLA targets from benchmark data.
+
+Analyzes latency distributions and recommends SLA thresholds at various
+pass-rate targets, identifying sweet spots where small threshold relaxation
+yields large compliance gains.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData
+
+
+class PassRateTarget(BaseModel):
+    """A target pass rate for threshold computation."""
+
+    pass_rate: float = Field(..., ge=0.0, le=1.0, description="Target pass rate (0-1)")
+
+
+class ThresholdSuggestion(BaseModel):
+    """A suggested threshold for a specific metric and pass rate."""
+
+    metric: str = Field(..., description="Latency metric name (ttft_ms, tpot_ms, total_latency_ms)")
+    pass_rate: float = Field(..., ge=0.0, le=1.0, description="Target pass rate")
+    threshold_ms: float = Field(..., ge=0, description="Recommended threshold in ms")
+
+
+class SweetSpot(BaseModel):
+    """A sweet spot where small threshold change yields large compliance gain."""
+
+    metric: str = Field(..., description="Latency metric name")
+    threshold_ms: float = Field(..., ge=0, description="Threshold at the sweet spot")
+    pass_rate_below: float = Field(
+        ..., ge=0.0, le=1.0, description="Pass rate just below this threshold"
+    )
+    pass_rate_above: float = Field(
+        ..., ge=0.0, le=1.0, description="Pass rate at/above this threshold"
+    )
+    gain: float = Field(..., description="Pass rate gain across the sweet spot")
+
+
+class AdvisorReport(BaseModel):
+    """Complete threshold advisor report."""
+
+    total_requests: int = Field(..., ge=0)
+    suggestions: list[ThresholdSuggestion] = Field(default_factory=list)
+    sweet_spots: list[SweetSpot] = Field(default_factory=list)
+
+
+class ThresholdAdvisor:
+    """Analyze benchmark data and recommend SLA thresholds."""
+
+    METRICS = ("ttft_ms", "tpot_ms", "total_latency_ms")
+
+    def __init__(
+        self,
+        data: BenchmarkData,
+        pass_rates: list[float] | None = None,
+    ) -> None:
+        self._data = data
+        self._pass_rates = pass_rates or [0.90, 0.95, 0.99]
+        # Validate pass rates
+        for pr in self._pass_rates:
+            if not 0.0 < pr <= 1.0:
+                msg = f"pass_rate must be in (0, 1], got {pr}"
+                raise ValueError(msg)
+
+    def advise(self) -> AdvisorReport:
+        """Generate threshold recommendations."""
+        requests = self._data.requests
+        if not requests:
+            return AdvisorReport(total_requests=0)
+
+        suggestions: list[ThresholdSuggestion] = []
+        sweet_spots: list[SweetSpot] = []
+
+        for metric in self.METRICS:
+            values = np.array([getattr(r, metric) for r in requests])
+            values.sort()
+
+            # Compute thresholds for each pass rate
+            for pr in self._pass_rates:
+                # The threshold that achieves this pass rate is the percentile
+                threshold = float(np.percentile(values, pr * 100))
+                suggestions.append(
+                    ThresholdSuggestion(
+                        metric=metric,
+                        pass_rate=pr,
+                        threshold_ms=round(threshold, 2),
+                    )
+                )
+
+            # Detect sweet spots: scan sorted values for large jumps in pass rate
+            # relative to small threshold changes
+            sweet_spots.extend(self._find_sweet_spots(metric, values))
+
+        return AdvisorReport(
+            total_requests=len(requests),
+            suggestions=suggestions,
+            sweet_spots=sweet_spots,
+        )
+
+    def _find_sweet_spots(
+        self, metric: str, sorted_values: np.ndarray
+    ) -> list[SweetSpot]:
+        """Find inflection points where pass rate jumps significantly."""
+        n = len(sorted_values)
+        if n < 10:
+            return []
+
+        spots: list[SweetSpot] = []
+        # Sample ~100 evenly spaced threshold points
+        num_samples = min(100, n)
+        indices = np.linspace(0, n - 1, num_samples, dtype=int)
+
+        best_gain = 0.0
+        best_spot: SweetSpot | None = None
+
+        for i in range(1, len(indices)):
+            idx_prev = indices[i - 1]
+            idx_curr = indices[i]
+            pr_prev = (idx_prev + 1) / n
+            pr_curr = (idx_curr + 1) / n
+            gain = pr_curr - pr_prev
+
+            threshold_diff = sorted_values[idx_curr] - sorted_values[idx_prev]
+            if threshold_diff <= 0:
+                continue
+
+            # Gain rate: pass-rate gain per ms of threshold relaxation
+            gain_rate = gain / threshold_diff
+
+            if gain >= 0.03 and gain_rate > 0.001:
+                spot = SweetSpot(
+                    metric=metric,
+                    threshold_ms=round(float(sorted_values[idx_curr]), 2),
+                    pass_rate_below=round(pr_prev, 4),
+                    pass_rate_above=round(pr_curr, 4),
+                    gain=round(gain, 4),
+                )
+                if gain > best_gain:
+                    best_gain = gain
+                    best_spot = spot
+
+        if best_spot is not None:
+            spots.append(best_spot)
+
+        return spots
+
+
+def advise_thresholds(
+    data: BenchmarkData,
+    pass_rates: list[float] | None = None,
+) -> dict:
+    """Programmatic API for threshold advising.
+
+    Args:
+        data: Benchmark data to analyze.
+        pass_rates: Target pass rates (default: [0.90, 0.95, 0.99]).
+
+    Returns:
+        Dictionary with advisor report.
+    """
+    advisor = ThresholdAdvisor(data, pass_rates=pass_rates)
+    report = advisor.advise()
+    return report.model_dump()

--- a/tests/test_threshold_advisor.py
+++ b/tests/test_threshold_advisor.py
@@ -1,0 +1,242 @@
+"""Tests for threshold_advisor module."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.threshold_advisor import (
+    AdvisorReport,
+    SweetSpot,
+    ThresholdAdvisor,
+    ThresholdSuggestion,
+    advise_thresholds,
+)
+
+
+def _make_requests(n: int = 100, seed: int = 42) -> list[BenchmarkRequest]:
+    """Generate synthetic benchmark requests."""
+    import numpy as np
+
+    rng = np.random.default_rng(seed)
+    requests = []
+    for i in range(n):
+        ttft = float(rng.lognormal(mean=3.0, sigma=0.5))
+        tpot = float(rng.lognormal(mean=1.5, sigma=0.3))
+        total = ttft + tpot * rng.integers(10, 200)
+        requests.append(
+            BenchmarkRequest(
+                request_id=f"req-{i}",
+                prompt_tokens=int(rng.integers(10, 500)),
+                output_tokens=int(rng.integers(10, 200)),
+                ttft_ms=round(ttft, 2),
+                tpot_ms=round(tpot, 2),
+                total_latency_ms=round(total, 2),
+                timestamp=1000.0 + i,
+            )
+        )
+    return requests
+
+
+def _make_data(n: int = 100, seed: int = 42) -> BenchmarkData:
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=2,
+            total_instances=4,
+            measured_qps=10.0,
+        ),
+        requests=_make_requests(n, seed),
+    )
+
+
+class TestThresholdAdvisor:
+    """Tests for ThresholdAdvisor class."""
+
+    def test_basic_advise(self) -> None:
+        data = _make_data(100)
+        advisor = ThresholdAdvisor(data)
+        report = advisor.advise()
+
+        assert isinstance(report, AdvisorReport)
+        assert report.total_requests == 100
+        # 3 metrics × 3 pass rates = 9 suggestions
+        assert len(report.suggestions) == 9
+
+    def test_suggestions_have_correct_metrics(self) -> None:
+        data = _make_data(100)
+        advisor = ThresholdAdvisor(data)
+        report = advisor.advise()
+
+        metrics = {s.metric for s in report.suggestions}
+        assert metrics == {"ttft_ms", "tpot_ms", "total_latency_ms"}
+
+    def test_suggestions_increase_with_pass_rate(self) -> None:
+        data = _make_data(200)
+        advisor = ThresholdAdvisor(data, pass_rates=[0.50, 0.90, 0.99])
+        report = advisor.advise()
+
+        for metric in ThresholdAdvisor.METRICS:
+            metric_suggestions = [
+                s for s in report.suggestions if s.metric == metric
+            ]
+            thresholds = [s.threshold_ms for s in metric_suggestions]
+            # Higher pass rate requires higher (looser) threshold
+            assert thresholds == sorted(thresholds), (
+                f"{metric}: thresholds should increase with pass rate"
+            )
+
+    def test_custom_pass_rates(self) -> None:
+        data = _make_data(50)
+        advisor = ThresholdAdvisor(data, pass_rates=[0.80, 0.95])
+        report = advisor.advise()
+
+        # 3 metrics × 2 pass rates = 6
+        assert len(report.suggestions) == 6
+        pass_rates = {s.pass_rate for s in report.suggestions}
+        assert pass_rates == {0.80, 0.95}
+
+    def test_small_data(self) -> None:
+        """With very few requests, advisor still works."""
+        data = _make_data(3, seed=1)
+        advisor = ThresholdAdvisor(data)
+        report = advisor.advise()
+        assert report.total_requests == 3
+        assert len(report.suggestions) == 9
+
+    def test_invalid_pass_rate_zero(self) -> None:
+        data = _make_data(10)
+        with pytest.raises(ValueError, match="pass_rate must be in"):
+            ThresholdAdvisor(data, pass_rates=[0.0])
+
+    def test_invalid_pass_rate_negative(self) -> None:
+        data = _make_data(10)
+        with pytest.raises(ValueError, match="pass_rate must be in"):
+            ThresholdAdvisor(data, pass_rates=[-0.1])
+
+    def test_suggestion_model_fields(self) -> None:
+        data = _make_data(50)
+        advisor = ThresholdAdvisor(data)
+        report = advisor.advise()
+
+        for s in report.suggestions:
+            assert isinstance(s, ThresholdSuggestion)
+            assert s.threshold_ms >= 0
+            assert 0 < s.pass_rate <= 1.0
+            assert s.metric in ThresholdAdvisor.METRICS
+
+    def test_sweet_spot_model(self) -> None:
+        """Sweet spots, if found, have valid structure."""
+        data = _make_data(500, seed=7)
+        advisor = ThresholdAdvisor(data)
+        report = advisor.advise()
+
+        for spot in report.sweet_spots:
+            assert isinstance(spot, SweetSpot)
+            assert spot.gain > 0
+            assert spot.pass_rate_above > spot.pass_rate_below
+            assert spot.threshold_ms >= 0
+
+    def test_single_request(self) -> None:
+        data = BenchmarkData(
+            metadata=BenchmarkMetadata(
+                num_prefill_instances=1,
+                num_decode_instances=1,
+                total_instances=2,
+                measured_qps=1.0,
+            ),
+            requests=[
+                BenchmarkRequest(
+                    request_id="r1",
+                    prompt_tokens=10,
+                    output_tokens=10,
+                    ttft_ms=50.0,
+                    tpot_ms=5.0,
+                    total_latency_ms=100.0,
+                    timestamp=1000.0,
+                )
+            ],
+        )
+        advisor = ThresholdAdvisor(data)
+        report = advisor.advise()
+        assert report.total_requests == 1
+        assert len(report.suggestions) == 9
+
+    def test_uniform_latencies(self) -> None:
+        """All identical latencies should produce same threshold for all pass rates."""
+        requests = [
+            BenchmarkRequest(
+                request_id=f"r{i}",
+                prompt_tokens=10,
+                output_tokens=10,
+                ttft_ms=50.0,
+                tpot_ms=5.0,
+                total_latency_ms=100.0,
+                timestamp=1000.0 + i,
+            )
+            for i in range(100)
+        ]
+        data = BenchmarkData(
+            metadata=BenchmarkMetadata(
+                num_prefill_instances=1,
+                num_decode_instances=1,
+                total_instances=2,
+                measured_qps=10.0,
+            ),
+            requests=requests,
+        )
+        advisor = ThresholdAdvisor(data)
+        report = advisor.advise()
+
+        for metric in ThresholdAdvisor.METRICS:
+            thresholds = [
+                s.threshold_ms for s in report.suggestions if s.metric == metric
+            ]
+            # All thresholds should be equal (same value)
+            assert len(set(thresholds)) == 1
+
+    def test_large_dataset(self) -> None:
+        data = _make_data(1000, seed=99)
+        advisor = ThresholdAdvisor(data, pass_rates=[0.90, 0.95, 0.99])
+        report = advisor.advise()
+        assert report.total_requests == 1000
+        assert len(report.suggestions) == 9
+
+
+class TestAdviseThresholds:
+    """Tests for the programmatic API."""
+
+    def test_returns_dict(self) -> None:
+        data = _make_data(50)
+        result = advise_thresholds(data)
+        assert isinstance(result, dict)
+        assert "total_requests" in result
+        assert "suggestions" in result
+        assert "sweet_spots" in result
+
+    def test_custom_pass_rates(self) -> None:
+        data = _make_data(50)
+        result = advise_thresholds(data, pass_rates=[0.80])
+        assert len(result["suggestions"]) == 3  # 3 metrics × 1 pass rate
+
+    def test_json_serializable(self) -> None:
+        data = _make_data(50)
+        result = advise_thresholds(data)
+        # Should not raise
+        json.dumps(result)
+
+    def test_result_structure(self) -> None:
+        data = _make_data(100)
+        result = advise_thresholds(data)
+        for s in result["suggestions"]:
+            assert "metric" in s
+            assert "pass_rate" in s
+            assert "threshold_ms" in s
+
+    def test_pass_rate_1_0(self) -> None:
+        """Pass rate 1.0 should return the max value."""
+        data = _make_data(100)
+        result = advise_thresholds(data, pass_rates=[1.0])
+        assert len(result["suggestions"]) == 3


### PR DESCRIPTION
## Summary

Recommend optimal SLA thresholds from benchmark data by analyzing latency distributions at various pass-rate targets.

## Changes

- `ThresholdAdvisor` class in `threshold_advisor.py`
- `ThresholdSuggestion`, `AdvisorReport`, `SweetSpot`, `PassRateTarget` Pydantic models
- For each latency metric (TTFT, TPOT, total_latency), compute the threshold needed to achieve target pass rates
- Sweet-spot detection: identify inflection points where small threshold relaxation yields large compliance gains
- CLI `threshold-advisor` subcommand with `--benchmark`, `--pass-rates`, table + JSON output
- Programmatic `advise_thresholds()` API
- 17 new tests (1082 total)

Closes #108