### PR TITLE
feat: M47 Capacity Forecasting

### DIFF
--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -104,6 +104,14 @@ from xpyd_plan.fleet import (
     GPUTypeConfig,
     calculate_fleet,
 )
+from xpyd_plan.forecaster import (
+    CapacityExhaustion,
+    CapacityForecaster,
+    ForecastMethod,
+    ForecastPoint,
+    ForecastReport,
+    forecast_capacity,
+)
 from xpyd_plan.generator import (
     AnomalyConfig,
     AnomalyType,
@@ -459,4 +467,10 @@ __all__ = [
     "ThresholdAdvisor",
     "ThresholdSuggestion",
     "advise_thresholds",
+    "CapacityForecaster",
+    "ForecastMethod",
+    "ForecastPoint",
+    "ForecastReport",
+    "CapacityExhaustion",
+    "forecast_capacity",
 ]

--- a/src/xpyd_plan/cli/_forecast.py
+++ b/src/xpyd_plan/cli/_forecast.py
@@ -1,0 +1,124 @@
+"""CLI subcommand: forecast — capacity forecasting from trend data."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.forecaster import CapacityForecaster, ForecastMethod
+from xpyd_plan.trend import TrendTracker
+
+
+def add_forecast_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Register the ``forecast`` subcommand."""
+    p = subparsers.add_parser(
+        "forecast",
+        help="Forecast capacity from historical trend data",
+    )
+    p.add_argument(
+        "--trend-db",
+        required=True,
+        help="Path to TrendTracker SQLite database",
+    )
+    p.add_argument(
+        "--horizon-days",
+        type=int,
+        default=30,
+        help="Planning horizon in days (default: 30)",
+    )
+    p.add_argument(
+        "--method",
+        choices=["linear", "exponential"],
+        default="linear",
+        help="Extrapolation method (default: linear)",
+    )
+    p.add_argument("--sla-ttft", type=float, default=None, help="TTFT P95 SLA threshold (ms)")
+    p.add_argument("--sla-tpot", type=float, default=None, help="TPOT P95 SLA threshold (ms)")
+    p.add_argument(
+        "--sla-total", type=float, default=None,
+        help="Total latency P95 SLA threshold (ms)",
+    )
+    p.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    p.set_defaults(func=_run_forecast)
+
+
+def _run_forecast(args: argparse.Namespace) -> None:
+    tracker = TrendTracker(db_path=args.trend_db)
+    try:
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast(
+            horizon_days=args.horizon_days,
+            method=ForecastMethod(args.method),
+            sla_ttft_ms=args.sla_ttft,
+            sla_tpot_ms=args.sla_tpot,
+            sla_total_ms=args.sla_total,
+        )
+    finally:
+        tracker.close()
+
+    if args.output_format == "json":
+        print(json.dumps(report.model_dump(), indent=2))
+        return
+
+    console = Console()
+
+    # Summary
+    title = (
+        f"\n[bold]Capacity Forecast[/bold]"
+        f" ({report.method.value}, {report.horizon_days}-day horizon)"
+    )
+    console.print(title)
+    console.print(f"Historical entries: {report.num_historical_entries}")
+
+    if report.num_historical_entries < 2:
+        console.print("[yellow]Not enough historical data (need >= 2 entries).[/yellow]")
+        return
+
+    # Projections table
+    if report.projections:
+        tbl = Table(title="Projected Latency (P95)")
+        tbl.add_column("Days", justify="right")
+        tbl.add_column("TTFT (ms)", justify="right")
+        tbl.add_column("TPOT (ms)", justify="right")
+        tbl.add_column("Total (ms)", justify="right")
+        for p in report.projections:
+            tbl.add_row(
+                str(p.days_from_now),
+                f"{p.ttft_p95_ms:.1f}",
+                f"{p.tpot_p95_ms:.1f}",
+                f"{p.total_latency_p95_ms:.1f}",
+            )
+        console.print(tbl)
+
+    # Exhaustions
+    if report.exhaustions:
+        tbl2 = Table(title="SLA Breach Forecast")
+        tbl2.add_column("Metric")
+        tbl2.add_column("Current (ms)", justify="right")
+        tbl2.add_column("Threshold (ms)", justify="right")
+        tbl2.add_column("Days to Breach", justify="right")
+        tbl2.add_column("Status")
+        for e in report.exhaustions:
+            dtb = f"{e.days_to_breach:.1f}" if e.days_to_breach is not None else "—"
+            status = "[red]BREACH[/red]" if e.breaches_within_horizon else "[green]SAFE[/green]"
+            tbl2.add_row(
+                e.metric, f"{e.current_value_ms:.1f}",
+                f"{e.threshold_ms:.1f}", dtb, status,
+            )
+        console.print(tbl2)
+
+    if report.has_breach:
+        console.print(
+            f"\n[red bold]⚠ Earliest projected breach in"
+            f" {report.earliest_breach_days:.1f} days[/red bold]"
+        )
+    else:
+        console.print("\n[green]✓ No SLA breach projected within planning horizon.[/green]")

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -21,6 +21,7 @@ from xpyd_plan.cli._drift import _cmd_drift, add_drift_parser
 from xpyd_plan.cli._export import _cmd_export
 from xpyd_plan.cli._filter import _cmd_filter
 from xpyd_plan.cli._fleet import _cmd_fleet
+from xpyd_plan.cli._forecast import add_forecast_parser
 from xpyd_plan.cli._generate import _cmd_generate
 from xpyd_plan.cli._heatmap import _cmd_heatmap, add_heatmap_parser
 from xpyd_plan.cli._interpolate import _cmd_interpolate
@@ -892,6 +893,9 @@ def main(argv: list[str] | None = None) -> None:
     # --- threshold-advisor subcommand ---
     add_threshold_advisor_parser(subparsers)
 
+    # --- forecast subcommand ---
+    add_forecast_parser(subparsers)
+
     args = parser.parse_args(argv)
 
     if args.command == "config":
@@ -973,6 +977,10 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_plan_benchmarks(args)
     elif args.command == "threshold-advisor":
         _cmd_threshold_advisor(args)
+    elif args.command == "forecast":
+        from xpyd_plan.cli._forecast import _run_forecast
+
+        _run_forecast(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/forecaster.py
+++ b/src/xpyd_plan/forecaster.py
@@ -1,0 +1,283 @@
+"""Capacity forecasting from historical trend data.
+
+Project future latency and QPS trajectories using historical benchmark
+trends.  Estimate time-to-SLA-breach so users can proactively scale
+before degradation occurs.
+"""
+
+from __future__ import annotations
+
+import math
+from enum import Enum
+from pathlib import Path
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from xpyd_plan.trend import TrendTracker
+
+
+class ForecastMethod(str, Enum):
+    """Extrapolation method."""
+
+    LINEAR = "linear"
+    EXPONENTIAL = "exponential"
+
+
+class ForecastPoint(BaseModel):
+    """A single projected data point."""
+
+    days_from_now: float = Field(..., description="Days into the future")
+    ttft_p95_ms: float = Field(..., ge=0)
+    tpot_p95_ms: float = Field(..., ge=0)
+    total_latency_p95_ms: float = Field(..., ge=0)
+
+
+class CapacityExhaustion(BaseModel):
+    """When a specific SLA metric is projected to breach its threshold."""
+
+    metric: str = Field(..., description="Metric name (e.g. ttft_p95_ms)")
+    current_value_ms: float = Field(..., ge=0)
+    threshold_ms: float = Field(..., ge=0)
+    days_to_breach: float | None = Field(
+        None, description="Days until breach; None if no breach within horizon"
+    )
+    breaches_within_horizon: bool = Field(False)
+
+
+class ForecastReport(BaseModel):
+    """Complete forecast report."""
+
+    method: ForecastMethod
+    horizon_days: int = Field(..., ge=1)
+    num_historical_entries: int = Field(..., ge=0)
+    projections: list[ForecastPoint] = Field(default_factory=list)
+    exhaustions: list[CapacityExhaustion] = Field(default_factory=list)
+    has_breach: bool = Field(False, description="True if any metric breaches within horizon")
+    earliest_breach_days: float | None = Field(
+        None, description="Days to earliest breach; None if no breach"
+    )
+
+
+class CapacityForecaster:
+    """Forecast capacity from historical trend data."""
+
+    METRICS = ["ttft_p95_ms", "tpot_p95_ms", "total_latency_p95_ms"]
+
+    def __init__(self, tracker: TrendTracker) -> None:
+        self._tracker = tracker
+
+    def forecast(
+        self,
+        horizon_days: int = 30,
+        method: ForecastMethod = ForecastMethod.LINEAR,
+        sla_ttft_ms: float | None = None,
+        sla_tpot_ms: float | None = None,
+        sla_total_ms: float | None = None,
+        num_points: int = 10,
+    ) -> ForecastReport:
+        """Run capacity forecast.
+
+        Parameters
+        ----------
+        horizon_days:
+            How many days to project into the future.
+        method:
+            Extrapolation method (linear or exponential).
+        sla_ttft_ms, sla_tpot_ms, sla_total_ms:
+            SLA thresholds; if provided, compute time-to-breach.
+        num_points:
+            Number of projection points to generate.
+        """
+        entries = self._tracker.list_entries()
+
+        if len(entries) < 2:
+            return ForecastReport(
+                method=method,
+                horizon_days=horizon_days,
+                num_historical_entries=len(entries),
+            )
+
+        # Build time series: days relative to first entry
+        timestamps = np.array([e.timestamp for e in entries])
+        days = (timestamps - timestamps[0]) / 86400.0
+
+        metric_series: dict[str, np.ndarray] = {}
+        for m in self.METRICS:
+            metric_series[m] = np.array([getattr(e, m) for e in entries])
+
+        # Current values (last entry)
+        current = {m: float(metric_series[m][-1]) for m in self.METRICS}
+        last_day = float(days[-1])
+
+        # Fit models
+        models: dict[str, tuple] = {}
+        for m in self.METRICS:
+            models[m] = self._fit(days, metric_series[m], method)
+
+        # Generate projection points
+        step = horizon_days / num_points
+        projections: list[ForecastPoint] = []
+        for i in range(1, num_points + 1):
+            d = step * i
+            future_day = last_day + d
+            values = {}
+            for m in self.METRICS:
+                values[m] = max(0.0, self._predict(models[m], future_day, method))
+            projections.append(
+                ForecastPoint(
+                    days_from_now=round(d, 2),
+                    ttft_p95_ms=round(values["ttft_p95_ms"], 2),
+                    tpot_p95_ms=round(values["tpot_p95_ms"], 2),
+                    total_latency_p95_ms=round(values["total_latency_p95_ms"], 2),
+                )
+            )
+
+        # Compute exhaustions
+        thresholds = {
+            "ttft_p95_ms": sla_ttft_ms,
+            "tpot_p95_ms": sla_tpot_ms,
+            "total_latency_p95_ms": sla_total_ms,
+        }
+
+        exhaustions: list[CapacityExhaustion] = []
+        for m in self.METRICS:
+            thresh = thresholds[m]
+            if thresh is None:
+                continue
+
+            dtb = self._days_to_breach(
+                models[m], method, last_day, thresh, horizon_days
+            )
+            exhaustions.append(
+                CapacityExhaustion(
+                    metric=m,
+                    current_value_ms=round(current[m], 2),
+                    threshold_ms=thresh,
+                    days_to_breach=round(dtb, 2) if dtb is not None else None,
+                    breaches_within_horizon=dtb is not None,
+                )
+            )
+
+        has_breach = any(e.breaches_within_horizon for e in exhaustions)
+        breach_days = [
+            e.days_to_breach for e in exhaustions if e.days_to_breach is not None
+        ]
+        earliest = min(breach_days) if breach_days else None
+
+        return ForecastReport(
+            method=method,
+            horizon_days=horizon_days,
+            num_historical_entries=len(entries),
+            projections=projections,
+            exhaustions=exhaustions,
+            has_breach=has_breach,
+            earliest_breach_days=earliest,
+        )
+
+    @staticmethod
+    def _fit(
+        days: np.ndarray, values: np.ndarray, method: ForecastMethod
+    ) -> tuple:
+        """Fit a model and return parameters."""
+        if method == ForecastMethod.LINEAR:
+            # y = a*x + b
+            coeffs = np.polyfit(days, values, 1)
+            return tuple(coeffs)  # (slope, intercept)
+        else:
+            # Exponential: y = b * exp(a*x)
+            # Fit in log space: ln(y) = a*x + ln(b)
+            safe_values = np.clip(values, 1e-9, None)
+            log_v = np.log(safe_values)
+            coeffs = np.polyfit(days, log_v, 1)
+            return (coeffs[0], math.exp(coeffs[1]))  # (rate, base)
+
+    @staticmethod
+    def _predict(params: tuple, day: float, method: ForecastMethod) -> float:
+        if method == ForecastMethod.LINEAR:
+            slope, intercept = params
+            return slope * day + intercept
+        else:
+            rate, base = params
+            return base * math.exp(rate * day)
+
+    def _days_to_breach(
+        self,
+        params: tuple,
+        method: ForecastMethod,
+        last_day: float,
+        threshold: float,
+        horizon_days: int,
+    ) -> float | None:
+        """Compute days from now until predicted value exceeds threshold."""
+        # Check if already breached
+        current_val = self._predict(params, last_day, method)
+        if current_val >= threshold:
+            return 0.0
+
+        if method == ForecastMethod.LINEAR:
+            slope, intercept = params
+            if slope <= 0:
+                return None  # improving, won't breach
+            # threshold = slope * (last_day + d) + intercept
+            breach_day = (threshold - intercept) / slope
+            d = breach_day - last_day
+            if d < 0 or d > horizon_days:
+                return None
+            return d
+
+        else:
+            rate, base = params
+            if rate <= 0:
+                return None  # improving
+            if base <= 0:
+                return None
+            # threshold = base * exp(rate * (last_day + d))
+            try:
+                breach_day = math.log(threshold / base) / rate
+            except (ValueError, ZeroDivisionError):
+                return None
+            d = breach_day - last_day
+            if d < 0 or d > horizon_days:
+                return None
+            return d
+
+
+def forecast_capacity(
+    trend_db: str | Path,
+    horizon_days: int = 30,
+    method: str = "linear",
+    sla_ttft_ms: float | None = None,
+    sla_tpot_ms: float | None = None,
+    sla_total_ms: float | None = None,
+) -> dict:
+    """Programmatic API for capacity forecasting.
+
+    Parameters
+    ----------
+    trend_db:
+        Path to TrendTracker SQLite database.
+    horizon_days:
+        Planning horizon in days.
+    method:
+        "linear" or "exponential".
+    sla_ttft_ms, sla_tpot_ms, sla_total_ms:
+        Optional SLA thresholds for breach estimation.
+
+    Returns
+    -------
+    dict with forecast report data.
+    """
+    tracker = TrendTracker(db_path=trend_db)
+    try:
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast(
+            horizon_days=horizon_days,
+            method=ForecastMethod(method),
+            sla_ttft_ms=sla_ttft_ms,
+            sla_tpot_ms=sla_tpot_ms,
+            sla_total_ms=sla_total_ms,
+        )
+        return report.model_dump()
+    finally:
+        tracker.close()

--- a/tests/test_forecaster.py
+++ b/tests/test_forecaster.py
@@ -1,0 +1,315 @@
+"""Tests for capacity forecasting (M47)."""
+
+from __future__ import annotations
+
+import pytest
+
+from xpyd_plan.benchmark_models import (
+    BenchmarkData,
+    BenchmarkMetadata,
+    BenchmarkRequest,
+)
+from xpyd_plan.forecaster import (
+    CapacityForecaster,
+    ForecastMethod,
+    ForecastReport,
+    forecast_capacity,
+)
+from xpyd_plan.trend import TrendTracker
+
+
+def _make_benchmark(
+    qps: float,
+    n_prefill: int,
+    n_decode: int,
+    ttft_base: float,
+    tpot_base: float,
+    n_requests: int = 100,
+) -> BenchmarkData:
+    """Create a synthetic BenchmarkData with controllable latencies."""
+    reqs = []
+    for i in range(n_requests):
+        reqs.append(
+            BenchmarkRequest(
+                request_id=f"r{i}",
+                prompt_tokens=100,
+                output_tokens=50,
+                ttft_ms=ttft_base + (i % 10),
+                tpot_ms=tpot_base + (i % 5),
+                total_latency_ms=ttft_base + tpot_base * 50 + (i % 15),
+                timestamp=1000.0 + i,
+            )
+        )
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=n_prefill,
+            num_decode_instances=n_decode,
+            total_instances=n_prefill + n_decode,
+            measured_qps=qps,
+        ),
+        requests=reqs,
+    )
+
+
+def _build_tracker_with_trend(
+    num_entries: int = 5,
+    ttft_start: float = 50.0,
+    ttft_increment: float = 5.0,
+    tpot_start: float = 20.0,
+    tpot_increment: float = 2.0,
+    day_gap: float = 1.0,
+) -> TrendTracker:
+    """Build an in-memory TrendTracker with a known upward trend."""
+    tracker = TrendTracker(db_path=":memory:")
+    base_ts = 1_700_000_000.0
+    for i in range(num_entries):
+        bm = _make_benchmark(
+            qps=100.0,
+            n_prefill=2,
+            n_decode=6,
+            ttft_base=ttft_start + ttft_increment * i,
+            tpot_base=tpot_start + tpot_increment * i,
+        )
+        tracker.add(bm, label=f"run-{i}", timestamp=base_ts + i * day_gap * 86400)
+    return tracker
+
+
+# --- Basic construction ---
+
+
+class TestCapacityForecasterBasic:
+    def test_empty_tracker(self):
+        tracker = TrendTracker(db_path=":memory:")
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast()
+        assert report.num_historical_entries == 0
+        assert report.projections == []
+        assert not report.has_breach
+
+    def test_single_entry(self):
+        tracker = TrendTracker(db_path=":memory:")
+        bm = _make_benchmark(100, 2, 6, 50, 20)
+        tracker.add(bm, label="only")
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast()
+        assert report.num_historical_entries == 1
+        assert report.projections == []
+
+    def test_two_entries_produce_projections(self):
+        tracker = _build_tracker_with_trend(num_entries=2)
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast(horizon_days=10, num_points=5)
+        assert report.num_historical_entries == 2
+        assert len(report.projections) == 5
+
+    def test_projection_days_increase(self):
+        tracker = _build_tracker_with_trend()
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast(horizon_days=30, num_points=10)
+        days = [p.days_from_now for p in report.projections]
+        assert days == sorted(days)
+        assert days[-1] == pytest.approx(30.0, abs=0.1)
+
+
+# --- Linear forecasting ---
+
+
+class TestLinearForecast:
+    def test_increasing_trend_projects_higher(self):
+        tracker = _build_tracker_with_trend(ttft_increment=10.0)
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast(method=ForecastMethod.LINEAR, num_points=3)
+        # Last entry TTFT base is 50 + 10*4 = 90; projections should be higher
+        last_proj = report.projections[-1]
+        assert last_proj.ttft_p95_ms > 90.0
+
+    def test_breach_detected(self):
+        tracker = _build_tracker_with_trend(
+            ttft_start=50.0, ttft_increment=10.0, num_entries=5
+        )
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast(
+            horizon_days=30,
+            sla_ttft_ms=120.0,
+            method=ForecastMethod.LINEAR,
+        )
+        assert report.has_breach
+        assert report.earliest_breach_days is not None
+        assert report.earliest_breach_days > 0
+
+    def test_no_breach_when_threshold_high(self):
+        tracker = _build_tracker_with_trend(
+            ttft_start=50.0, ttft_increment=1.0, num_entries=5
+        )
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast(
+            horizon_days=10,
+            sla_ttft_ms=999.0,
+            method=ForecastMethod.LINEAR,
+        )
+        ttft_exhaustion = [e for e in report.exhaustions if e.metric == "ttft_p95_ms"]
+        assert len(ttft_exhaustion) == 1
+        assert not ttft_exhaustion[0].breaches_within_horizon
+
+    def test_already_breached(self):
+        # Start high, so current already exceeds threshold
+        tracker = _build_tracker_with_trend(ttft_start=200.0, ttft_increment=10.0)
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast(sla_ttft_ms=100.0)
+        ttft_ex = [e for e in report.exhaustions if e.metric == "ttft_p95_ms"][0]
+        assert ttft_ex.breaches_within_horizon
+        assert ttft_ex.days_to_breach == 0.0
+
+
+# --- Exponential forecasting ---
+
+
+class TestExponentialForecast:
+    def test_exponential_produces_projections(self):
+        tracker = _build_tracker_with_trend()
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast(method=ForecastMethod.EXPONENTIAL, num_points=5)
+        assert len(report.projections) == 5
+        # Values should be positive
+        for p in report.projections:
+            assert p.ttft_p95_ms >= 0
+            assert p.tpot_p95_ms >= 0
+
+    def test_exponential_breach(self):
+        tracker = _build_tracker_with_trend(
+            ttft_start=50, ttft_increment=15, num_entries=5
+        )
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast(
+            method=ForecastMethod.EXPONENTIAL,
+            sla_ttft_ms=200.0,
+            horizon_days=60,
+        )
+        assert any(e.metric == "ttft_p95_ms" for e in report.exhaustions)
+
+
+# --- Multiple SLA metrics ---
+
+
+class TestMultipleSLAMetrics:
+    def test_all_three_thresholds(self):
+        tracker = _build_tracker_with_trend()
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast(
+            sla_ttft_ms=200.0,
+            sla_tpot_ms=100.0,
+            sla_total_ms=5000.0,
+        )
+        assert len(report.exhaustions) == 3
+        metrics = {e.metric for e in report.exhaustions}
+        assert metrics == {"ttft_p95_ms", "tpot_p95_ms", "total_latency_p95_ms"}
+
+    def test_partial_thresholds(self):
+        tracker = _build_tracker_with_trend()
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast(sla_ttft_ms=200.0)
+        assert len(report.exhaustions) == 1
+        assert report.exhaustions[0].metric == "ttft_p95_ms"
+
+
+# --- ForecastReport model ---
+
+
+class TestForecastReportModel:
+    def test_serialization(self):
+        tracker = _build_tracker_with_trend()
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast(sla_ttft_ms=200.0, num_points=3)
+        d = report.model_dump()
+        assert "method" in d
+        assert "projections" in d
+        assert "exhaustions" in d
+        assert "has_breach" in d
+
+    def test_method_enum(self):
+        report = ForecastReport(
+            method=ForecastMethod.LINEAR,
+            horizon_days=30,
+            num_historical_entries=0,
+        )
+        assert report.method == ForecastMethod.LINEAR
+
+
+# --- Programmatic API ---
+
+
+class TestForecastCapacityAPI:
+    def test_api_with_file(self, tmp_path):
+        db_path = tmp_path / "trend.db"
+        tracker = TrendTracker(db_path=str(db_path))
+        base_ts = 1_700_000_000.0
+        for i in range(3):
+            bm = _make_benchmark(100, 2, 6, 50 + i * 10, 20 + i * 3)
+            tracker.add(bm, label=f"r{i}", timestamp=base_ts + i * 86400)
+        tracker.close()
+
+        result = forecast_capacity(
+            trend_db=str(db_path),
+            horizon_days=14,
+            method="linear",
+            sla_ttft_ms=150.0,
+        )
+        assert isinstance(result, dict)
+        assert result["num_historical_entries"] == 3
+        assert "projections" in result
+        assert "exhaustions" in result
+
+    def test_api_exponential(self, tmp_path):
+        db_path = tmp_path / "trend.db"
+        tracker = TrendTracker(db_path=str(db_path))
+        base_ts = 1_700_000_000.0
+        for i in range(4):
+            bm = _make_benchmark(100, 2, 6, 50 + i * 5, 20 + i * 2)
+            tracker.add(bm, label=f"r{i}", timestamp=base_ts + i * 86400)
+        tracker.close()
+
+        result = forecast_capacity(
+            trend_db=str(db_path),
+            method="exponential",
+        )
+        assert result["method"] == "exponential"
+
+
+# --- Edge cases ---
+
+
+class TestEdgeCases:
+    def test_flat_trend_no_breach(self):
+        """No degradation → no breach."""
+        tracker = _build_tracker_with_trend(ttft_increment=0.0, tpot_increment=0.0)
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast(sla_ttft_ms=200.0, sla_tpot_ms=200.0)
+        assert not report.has_breach
+
+    def test_improving_trend_no_breach(self):
+        """Negative trend (improving) → no breach."""
+        tracker = _build_tracker_with_trend(
+            ttft_start=100.0, ttft_increment=-5.0, tpot_start=50.0, tpot_increment=-2.0
+        )
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast(sla_ttft_ms=200.0)
+        assert not report.has_breach
+
+    def test_projection_values_nonnegative(self):
+        """Even with negative trend, projections should be >= 0."""
+        tracker = _build_tracker_with_trend(
+            ttft_start=100.0, ttft_increment=-20.0, num_entries=5
+        )
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast(horizon_days=100, num_points=20)
+        for p in report.projections:
+            assert p.ttft_p95_ms >= 0
+            assert p.tpot_p95_ms >= 0
+            assert p.total_latency_p95_ms >= 0
+
+    def test_horizon_one_day(self):
+        tracker = _build_tracker_with_trend()
+        forecaster = CapacityForecaster(tracker)
+        report = forecaster.forecast(horizon_days=1, num_points=2)
+        assert len(report.projections) == 2
+        assert report.projections[-1].days_from_now == pytest.approx(1.0, abs=0.1)


### PR DESCRIPTION
## Summary

Forecast capacity from historical trend data. Project future latency trajectories and estimate time-to-SLA-breach so users can proactively scale before degradation occurs.

## Changes

- `CapacityForecaster` class in `forecaster.py`
- `ForecastPoint`, `ForecastReport`, `CapacityExhaustion`, `ForecastMethod` Pydantic models
- Linear and exponential extrapolation from TrendTracker SQLite data
- Time-to-SLA-breach estimation for TTFT, TPOT, total_latency P95
- Configurable planning horizon (default 30 days)
- CLI `forecast` subcommand with `--trend-db`, `--horizon-days`, `--method`, table + JSON output
- Programmatic `forecast_capacity()` API
- 20 new tests (1102 total)

Closes #110