### PR TITLE
feat: M48 Multi-SLA Tier Analysis

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -624,3 +624,17 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `forecast` subcommand with `--trend-db`, `--horizon-days`, `--method`, table + JSON output
 - Programmatic `forecast_capacity()` API
 - ~20 new tests
+
+### M48 ✅ Multi-SLA Tier Analysis
+
+*Completed — PR #113*
+
+- `SLATierAnalyzer` class in `sla_tier.py`
+- `SLATier`, `TierResult`, `MultiTierReport` Pydantic models
+- Analyze benchmark data against multiple named SLA policies simultaneously
+- Per-tier optimal P:D ratio finding
+- Unified ratio identification (single P:D ratio satisfying all tiers)
+- YAML tier definition loading (`load_tiers_from_yaml()`)
+- CLI `sla-tier` subcommand with `--benchmark`, `--tiers`, table + JSON output
+- Programmatic `analyze_sla_tiers()` API
+- 18 new tests (1120 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -227,6 +227,14 @@ from xpyd_plan.scorecard import (
     ScoreGrade,
     calculate_scorecard,
 )
+from xpyd_plan.sla_tier import (
+    MultiTierReport,
+    SLATier,
+    SLATierAnalyzer,
+    TierResult,
+    analyze_sla_tiers,
+    load_tiers_from_yaml,
+)
 from xpyd_plan.tail import (
     LongTailProfile,
     TailAnalyzer,
@@ -473,4 +481,10 @@ __all__ = [
     "ForecastReport",
     "CapacityExhaustion",
     "forecast_capacity",
+    "SLATier",
+    "SLATierAnalyzer",
+    "TierResult",
+    "MultiTierReport",
+    "analyze_sla_tiers",
+    "load_tiers_from_yaml",
 ]

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -35,6 +35,7 @@ from xpyd_plan.cli._recommend import _cmd_recommend
 from xpyd_plan.cli._root_cause import _cmd_root_cause, add_root_cause_parser
 from xpyd_plan.cli._scaling import _cmd_scaling, add_scaling_parser
 from xpyd_plan.cli._scorecard import _cmd_scorecard, add_scorecard_parser
+from xpyd_plan.cli._sla_tier import add_sla_tier_parser
 from xpyd_plan.cli._tail import _cmd_tail, add_tail_parser
 from xpyd_plan.cli._threshold_advisor import _cmd_threshold_advisor, add_threshold_advisor_parser
 from xpyd_plan.cli._timeline import _cmd_timeline, add_timeline_parser
@@ -895,6 +896,7 @@ def main(argv: list[str] | None = None) -> None:
 
     # --- forecast subcommand ---
     add_forecast_parser(subparsers)
+    add_sla_tier_parser(subparsers)
 
     args = parser.parse_args(argv)
 
@@ -981,6 +983,10 @@ def main(argv: list[str] | None = None) -> None:
         from xpyd_plan.cli._forecast import _run_forecast
 
         _run_forecast(args)
+    elif args.command == "sla-tier":
+        from xpyd_plan.cli._sla_tier import _run_sla_tier
+
+        _run_sla_tier(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/cli/_sla_tier.py
+++ b/src/xpyd_plan/cli/_sla_tier.py
@@ -1,0 +1,88 @@
+"""CLI subcommand for multi-SLA tier analysis."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from rich.console import Console
+from rich.table import Table
+
+
+def add_sla_tier_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Register the sla-tier subcommand."""
+    p = subparsers.add_parser(
+        "sla-tier",
+        help="Analyze benchmark data against multiple SLA tiers",
+    )
+    p.add_argument("--benchmark", required=True, help="Path to benchmark JSON file")
+    p.add_argument("--tiers", required=True, help="Path to YAML tier definitions")
+    p.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+
+
+def _run_sla_tier(args: argparse.Namespace) -> None:
+    """Execute sla-tier subcommand."""
+    from xpyd_plan.analyzer import BenchmarkAnalyzer
+    from xpyd_plan.sla_tier import SLATierAnalyzer, load_tiers_from_yaml
+
+    tiers = load_tiers_from_yaml(args.tiers)
+
+    analyzer = BenchmarkAnalyzer()
+    data = analyzer.load_data(args.benchmark)
+
+    tier_analyzer = SLATierAnalyzer(data)
+    report = tier_analyzer.analyze(tiers)
+
+    if args.output_format == "json":
+        print(json.dumps(report.model_dump(), indent=2))
+        return
+
+    console = Console()
+
+    table = Table(title="Multi-SLA Tier Analysis")
+    table.add_column("Tier", style="cyan")
+    table.add_column("SLA (TTFT/TPOT/Total)", style="white")
+    table.add_column("Percentile", style="white")
+    table.add_column("Best Ratio", style="green")
+    table.add_column("Waste", style="yellow")
+    table.add_column("Meets SLA", style="white")
+
+    for tr in report.tier_results:
+        sla = tr.tier.sla
+        sla_str = "/".join(
+            str(v) if v is not None else "-"
+            for v in [sla.ttft_ms, sla.tpot_ms, sla.max_latency_ms]
+        )
+        if tr.best:
+            ratio_str = tr.best.ratio_str
+            waste_str = f"{tr.best.waste_rate:.1%}"
+            meets = "✓"
+        else:
+            ratio_str = "—"
+            waste_str = "—"
+            meets = "✗"
+        table.add_row(
+            tr.tier.name,
+            sla_str,
+            f"P{sla.sla_percentile:g}",
+            ratio_str,
+            waste_str,
+            meets,
+        )
+
+    console.print(table)
+
+    if report.unified_best:
+        console.print(
+            f"\n[bold green]Unified recommendation:[/] {report.unified_best.ratio_str} "
+            f"(waste: {report.unified_best.waste_rate:.1%}) — meets ALL tiers"
+        )
+    else:
+        console.print(
+            "\n[bold red]No single P:D ratio satisfies all tiers simultaneously.[/]"
+        )

--- a/src/xpyd_plan/sla_tier.py
+++ b/src/xpyd_plan/sla_tier.py
@@ -1,0 +1,207 @@
+"""Multi-SLA tier analysis — find optimal P:D ratios for multiple SLA policies.
+
+When serving heterogeneous traffic classes (e.g., premium vs standard),
+different SLA policies apply.  This module analyzes a single benchmark
+dataset against multiple named SLA tiers and produces a unified report
+showing per-tier optimal ratios and whether a single P:D ratio can
+satisfy all tiers simultaneously.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field
+
+from .analyzer import BenchmarkAnalyzer
+from .benchmark_models import BenchmarkData, RatioCandidate
+from .models import SLAConfig
+
+
+class SLATier(BaseModel):
+    """A named SLA policy tier."""
+
+    name: str = Field(..., description="Tier name, e.g. 'premium', 'standard'")
+    sla: SLAConfig = Field(..., description="SLA constraints for this tier")
+
+
+class TierResult(BaseModel):
+    """Analysis result for a single SLA tier."""
+
+    tier: SLATier
+    best: RatioCandidate | None = Field(
+        None, description="Optimal P:D ratio for this tier (None if no ratio meets SLA)"
+    )
+    candidates: list[RatioCandidate] = Field(default_factory=list)
+
+
+class MultiTierReport(BaseModel):
+    """Report covering all SLA tiers."""
+
+    tier_results: list[TierResult] = Field(default_factory=list)
+    unified_best: RatioCandidate | None = Field(
+        None,
+        description="Single P:D ratio meeting ALL tiers with minimum waste (None if impossible)",
+    )
+    total_instances: int = Field(..., ge=2)
+
+
+class SLATierAnalyzer:
+    """Analyze benchmark data against multiple SLA tiers."""
+
+    def __init__(self, data: BenchmarkData) -> None:
+        self._data = data
+
+    def analyze(self, tiers: list[SLATier]) -> MultiTierReport:
+        """Run analysis for each tier and find unified optimum.
+
+        Args:
+            tiers: List of SLA tiers to evaluate.
+
+        Returns:
+            MultiTierReport with per-tier results and unified recommendation.
+
+        Raises:
+            ValueError: If tiers is empty.
+        """
+        if not tiers:
+            raise ValueError("At least one SLA tier is required.")
+
+        analyzer = BenchmarkAnalyzer()
+        analyzer._data = self._data
+
+        total = self._data.metadata.total_instances
+        tier_results: list[TierResult] = []
+
+        for tier in tiers:
+            result = analyzer.find_optimal_ratio(
+                total_instances=total,
+                sla=tier.sla,
+            )
+            tier_results.append(
+                TierResult(
+                    tier=tier,
+                    best=result.best,
+                    candidates=result.candidates,
+                )
+            )
+
+        # Find unified ratio: meets ALL tiers, minimum waste
+        unified_best = self._find_unified(tier_results, total)
+
+        return MultiTierReport(
+            tier_results=tier_results,
+            unified_best=unified_best,
+            total_instances=total,
+        )
+
+    def _find_unified(
+        self, tier_results: list[TierResult], total: int
+    ) -> RatioCandidate | None:
+        """Find the single P:D ratio that meets all tiers with minimum waste."""
+        if not tier_results:
+            return None
+
+        # Collect candidate keys that pass each tier
+        passing_sets: list[set[str]] = []
+        # Map ratio_str -> RatioCandidate (from any tier, since metrics are same)
+        candidate_map: dict[str, RatioCandidate] = {}
+
+        for tr in tier_results:
+            passing = set()
+            for c in tr.candidates:
+                if c.meets_sla:
+                    passing.add(c.ratio_str)
+                    candidate_map[c.ratio_str] = c
+            passing_sets.append(passing)
+
+        # Intersection: must pass ALL tiers
+        if not passing_sets:
+            return None
+        common = passing_sets[0]
+        for s in passing_sets[1:]:
+            common = common & s
+
+        if not common:
+            return None
+
+        # Pick lowest waste among common
+        best: RatioCandidate | None = None
+        for key in common:
+            c = candidate_map[key]
+            if best is None or c.waste_rate < best.waste_rate:
+                best = c
+
+        return best
+
+
+def load_tiers_from_yaml(path: str | Path) -> list[SLATier]:
+    """Load SLA tier definitions from a YAML file.
+
+    Expected format::
+
+        tiers:
+          - name: premium
+            ttft_ms: 100
+            tpot_ms: 20
+            max_latency_ms: 2000
+            percentile: 99
+          - name: standard
+            ttft_ms: 500
+            tpot_ms: 50
+            percentile: 95
+    """
+    path = Path(path)
+    with open(path) as f:
+        raw = yaml.safe_load(f)
+
+    if not isinstance(raw, dict) or "tiers" not in raw:
+        raise ValueError(f"YAML file must contain a 'tiers' key: {path}")
+
+    tiers: list[SLATier] = []
+    for entry in raw["tiers"]:
+        sla = SLAConfig(
+            ttft_ms=entry.get("ttft_ms"),
+            tpot_ms=entry.get("tpot_ms"),
+            max_latency_ms=entry.get("max_latency_ms"),
+            sla_percentile=entry.get("percentile", 95.0),
+        )
+        tiers.append(SLATier(name=entry["name"], sla=sla))
+
+    return tiers
+
+
+def analyze_sla_tiers(
+    benchmark_path: str | Path,
+    tiers: list[SLATier] | None = None,
+    tiers_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Programmatic API for multi-SLA tier analysis.
+
+    Args:
+        benchmark_path: Path to benchmark JSON file.
+        tiers: List of SLATier objects (mutually exclusive with tiers_path).
+        tiers_path: Path to YAML tier definitions (mutually exclusive with tiers).
+
+    Returns:
+        Dict with 'tier_results', 'unified_best', 'total_instances'.
+
+    Raises:
+        ValueError: If neither tiers nor tiers_path is provided, or both are.
+    """
+    if tiers is None and tiers_path is None:
+        raise ValueError("Provide either 'tiers' or 'tiers_path'.")
+    if tiers is not None and tiers_path is not None:
+        raise ValueError("Provide either 'tiers' or 'tiers_path', not both.")
+
+    if tiers_path is not None:
+        tiers = load_tiers_from_yaml(tiers_path)
+
+    analyzer = BenchmarkAnalyzer()
+    data = analyzer.load_data(benchmark_path)
+
+    tier_analyzer = SLATierAnalyzer(data)
+    report = tier_analyzer.analyze(tiers)  # type: ignore[arg-type]
+    return report.model_dump()

--- a/tests/test_sla_tier.py
+++ b/tests/test_sla_tier.py
@@ -1,0 +1,257 @@
+"""Tests for Multi-SLA Tier Analysis (M48)."""
+
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+import pytest
+import yaml
+
+from xpyd_plan.benchmark_models import BenchmarkData
+from xpyd_plan.models import SLAConfig
+from xpyd_plan.sla_tier import (
+    SLATier,
+    SLATierAnalyzer,
+    analyze_sla_tiers,
+    load_tiers_from_yaml,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_requests(
+    n: int = 100,
+    ttft_range: tuple[float, float] = (50, 500),
+    tpot_range: tuple[float, float] = (10, 40),
+    seed: int = 42,
+) -> list[dict]:
+    rng = random.Random(seed)
+    requests = []
+    base_ts = 1700000000.0
+    for i in range(n):
+        prompt_tokens = rng.randint(100, 2000)
+        output_tokens = rng.randint(50, 500)
+        ttft = rng.uniform(*ttft_range)
+        tpot = rng.uniform(*tpot_range)
+        total = ttft + tpot * output_tokens
+        requests.append({
+            "request_id": f"req-{i:04d}",
+            "prompt_tokens": prompt_tokens,
+            "output_tokens": output_tokens,
+            "ttft_ms": round(ttft, 2),
+            "tpot_ms": round(tpot, 2),
+            "total_latency_ms": round(total, 2),
+            "timestamp": base_ts + i * 0.1,
+        })
+    return requests
+
+
+def _make_benchmark_json(
+    tmp_path: Path,
+    n: int = 100,
+    num_p: int = 2,
+    num_d: int = 6,
+    qps: float = 10.0,
+    **kwargs,
+) -> Path:
+    data = {
+        "metadata": {
+            "num_prefill_instances": num_p,
+            "num_decode_instances": num_d,
+            "total_instances": num_p + num_d,
+            "measured_qps": qps,
+        },
+        "requests": _make_requests(n=n, **kwargs),
+    }
+    p = tmp_path / "bench.json"
+    p.write_text(json.dumps(data))
+    return p
+
+
+def _make_tiers_yaml(tmp_path: Path, tiers: list[dict]) -> Path:
+    p = tmp_path / "tiers.yaml"
+    p.write_text(yaml.dump({"tiers": tiers}))
+    return p
+
+
+def _load_data(tmp_path: Path, **kwargs) -> BenchmarkData:
+    p = _make_benchmark_json(tmp_path, **kwargs)
+    return BenchmarkData.model_validate(json.loads(p.read_text()))
+
+
+# ── SLATierAnalyzer Tests ───────────────────────────────────────────────
+
+
+class TestSLATierAnalyzer:
+    def test_single_tier(self, tmp_path: Path) -> None:
+        data = _load_data(tmp_path)
+        tiers = [SLATier(name="standard", sla=SLAConfig(ttft_ms=9999, tpot_ms=9999))]
+        report = SLATierAnalyzer(data).analyze(tiers)
+
+        assert len(report.tier_results) == 1
+        assert report.tier_results[0].tier.name == "standard"
+        assert report.tier_results[0].best is not None
+        assert report.total_instances == 8
+
+    def test_multiple_tiers(self, tmp_path: Path) -> None:
+        data = _load_data(tmp_path)
+        tiers = [
+            SLATier(name="premium", sla=SLAConfig(ttft_ms=9999, tpot_ms=9999, sla_percentile=99)),
+            SLATier(name="standard", sla=SLAConfig(ttft_ms=9999, tpot_ms=9999)),
+        ]
+        report = SLATierAnalyzer(data).analyze(tiers)
+
+        assert len(report.tier_results) == 2
+        assert report.tier_results[0].tier.name == "premium"
+        assert report.tier_results[1].tier.name == "standard"
+
+    def test_unified_best_exists(self, tmp_path: Path) -> None:
+        """When all tiers are relaxed, a unified ratio should exist."""
+        data = _load_data(tmp_path)
+        tiers = [
+            SLATier(name="t1", sla=SLAConfig(ttft_ms=9999, tpot_ms=9999)),
+            SLATier(name="t2", sla=SLAConfig(ttft_ms=9999, tpot_ms=9999)),
+        ]
+        report = SLATierAnalyzer(data).analyze(tiers)
+        assert report.unified_best is not None
+
+    def test_no_unified_when_impossible(self, tmp_path: Path) -> None:
+        """When one tier is impossibly tight, no unified ratio."""
+        data = _load_data(tmp_path)
+        tiers = [
+            SLATier(name="relax", sla=SLAConfig(ttft_ms=9999, tpot_ms=9999)),
+            SLATier(name="impossible", sla=SLAConfig(ttft_ms=0.001, tpot_ms=0.001)),
+        ]
+        report = SLATierAnalyzer(data).analyze(tiers)
+        assert report.unified_best is None
+
+    def test_empty_tiers_raises(self, tmp_path: Path) -> None:
+        data = _load_data(tmp_path)
+        with pytest.raises(ValueError, match="(?i)at least one"):
+            SLATierAnalyzer(data).analyze([])
+
+    def test_tier_result_has_candidates(self, tmp_path: Path) -> None:
+        data = _load_data(tmp_path)
+        tiers = [SLATier(name="t1", sla=SLAConfig(ttft_ms=9999, tpot_ms=9999))]
+        report = SLATierAnalyzer(data).analyze(tiers)
+        assert len(report.tier_results[0].candidates) > 0
+
+    def test_impossible_sla_no_best(self, tmp_path: Path) -> None:
+        data = _load_data(tmp_path)
+        tiers = [SLATier(name="impossible", sla=SLAConfig(ttft_ms=0.001))]
+        report = SLATierAnalyzer(data).analyze(tiers)
+        assert report.tier_results[0].best is None
+
+    def test_different_percentiles(self, tmp_path: Path) -> None:
+        data = _load_data(tmp_path)
+        tiers = [
+            SLATier(name="p95", sla=SLAConfig(ttft_ms=9999, sla_percentile=95)),
+            SLATier(name="p99", sla=SLAConfig(ttft_ms=9999, sla_percentile=99)),
+        ]
+        report = SLATierAnalyzer(data).analyze(tiers)
+        assert len(report.tier_results) == 2
+        # Both should pass with relaxed SLA
+        for tr in report.tier_results:
+            assert tr.best is not None
+
+
+# ── load_tiers_from_yaml Tests ──────────────────────────────────────────
+
+
+class TestLoadTiersFromYaml:
+    def test_basic_load(self, tmp_path: Path) -> None:
+        tiers_file = _make_tiers_yaml(tmp_path, [
+            {"name": "premium", "ttft_ms": 100, "tpot_ms": 20, "percentile": 99},
+            {"name": "standard", "ttft_ms": 500, "tpot_ms": 50},
+        ])
+        tiers = load_tiers_from_yaml(tiers_file)
+        assert len(tiers) == 2
+        assert tiers[0].name == "premium"
+        assert tiers[0].sla.ttft_ms == 100
+        assert tiers[0].sla.sla_percentile == 99
+        assert tiers[1].sla.sla_percentile == 95  # default
+
+    def test_invalid_yaml_missing_tiers_key(self, tmp_path: Path) -> None:
+        p = tmp_path / "bad.yaml"
+        p.write_text(yaml.dump({"policies": []}))
+        with pytest.raises(ValueError, match="tiers"):
+            load_tiers_from_yaml(p)
+
+    def test_optional_fields(self, tmp_path: Path) -> None:
+        tiers_file = _make_tiers_yaml(tmp_path, [
+            {"name": "minimal", "ttft_ms": 200},
+        ])
+        tiers = load_tiers_from_yaml(tiers_file)
+        assert tiers[0].sla.tpot_ms is None
+        assert tiers[0].sla.max_latency_ms is None
+
+
+# ── analyze_sla_tiers API Tests ─────────────────────────────────────────
+
+
+class TestAnalyzeSlaTiersAPI:
+    def test_with_tiers_path(self, tmp_path: Path) -> None:
+        bench_path = _make_benchmark_json(tmp_path)
+        tiers_file = _make_tiers_yaml(tmp_path, [
+            {"name": "t1", "ttft_ms": 9999, "tpot_ms": 9999},
+        ])
+        result = analyze_sla_tiers(benchmark_path=bench_path, tiers_path=tiers_file)
+        assert "tier_results" in result
+        assert "unified_best" in result
+        assert "total_instances" in result
+
+    def test_with_tiers_objects(self, tmp_path: Path) -> None:
+        bench_path = _make_benchmark_json(tmp_path)
+        tiers = [SLATier(name="t1", sla=SLAConfig(ttft_ms=9999))]
+        result = analyze_sla_tiers(benchmark_path=bench_path, tiers=tiers)
+        assert len(result["tier_results"]) == 1
+
+    def test_neither_tiers_raises(self, tmp_path: Path) -> None:
+        bench_path = _make_benchmark_json(tmp_path)
+        with pytest.raises(ValueError, match="Provide either"):
+            analyze_sla_tiers(benchmark_path=bench_path)
+
+    def test_both_tiers_raises(self, tmp_path: Path) -> None:
+        bench_path = _make_benchmark_json(tmp_path)
+        tiers_file = _make_tiers_yaml(tmp_path, [{"name": "t1", "ttft_ms": 100}])
+        tiers = [SLATier(name="t1", sla=SLAConfig(ttft_ms=100))]
+        with pytest.raises(ValueError, match="not both"):
+            analyze_sla_tiers(benchmark_path=bench_path, tiers=tiers, tiers_path=tiers_file)
+
+    def test_json_output_structure(self, tmp_path: Path) -> None:
+        bench_path = _make_benchmark_json(tmp_path)
+        tiers = [
+            SLATier(name="premium", sla=SLAConfig(ttft_ms=9999, tpot_ms=9999)),
+            SLATier(name="standard", sla=SLAConfig(ttft_ms=9999)),
+        ]
+        result = analyze_sla_tiers(benchmark_path=bench_path, tiers=tiers)
+        assert result["total_instances"] == 8
+        assert len(result["tier_results"]) == 2
+        # Each tier result has expected keys
+        for tr in result["tier_results"]:
+            assert "tier" in tr
+            assert "best" in tr
+            assert "candidates" in tr
+
+
+# ── Model Serialization Tests ───────────────────────────────────────────
+
+
+class TestModels:
+    def test_sla_tier_model(self) -> None:
+        tier = SLATier(name="premium", sla=SLAConfig(ttft_ms=100))
+        d = tier.model_dump()
+        assert d["name"] == "premium"
+        assert d["sla"]["ttft_ms"] == 100
+
+    def test_multi_tier_report_serialization(self, tmp_path: Path) -> None:
+        data = _load_data(tmp_path)
+        tiers = [SLATier(name="t1", sla=SLAConfig(ttft_ms=9999))]
+        report = SLATierAnalyzer(data).analyze(tiers)
+        d = report.model_dump()
+        assert isinstance(d, dict)
+        # Round-trip via JSON
+        json_str = json.dumps(d)
+        assert "tier_results" in json.loads(json_str)


### PR DESCRIPTION
## Summary

Add multi-SLA tier analysis capability — analyze benchmark data against multiple named SLA policies simultaneously.

## Changes

- `SLATier`, `TierResult`, `MultiTierReport` Pydantic models in `sla_tier.py`
- `SLATierAnalyzer` class: runs analysis per tier, finds unified optimal ratio
- YAML tier definition loading (`load_tiers_from_yaml()`)
- CLI `sla-tier` subcommand with `--benchmark`, `--tiers`, `--output-format table|json`
- Programmatic `analyze_sla_tiers()` API
- 18 new tests (1120 total, all passing)
- Lint clean (ruff + isort)

## Use Case

Users serving multiple traffic classes (e.g., premium low-latency vs standard best-effort) can now run a single command to find per-tier optimal P:D ratios and whether one unified ratio satisfies all tiers.

Closes #112