### PR TITLE
feat: M49 Saturation Point Detection (#114)

### DIFF
--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -212,6 +212,13 @@ from xpyd_plan.root_cause import (
     RootCauseReport,
     analyze_root_cause,
 )
+from xpyd_plan.saturation import (
+    SaturationDetector,
+    SaturationPoint,
+    SaturationReport,
+    SaturationThreshold,
+    detect_saturation,
+)
 from xpyd_plan.scaling import (
     ScalingAnalyzer,
     ScalingCurve,
@@ -407,6 +414,11 @@ __all__ = [
     "WorkloadProfile",
     "WorkloadReport",
     "classify_workload",
+    "SaturationDetector",
+    "SaturationPoint",
+    "SaturationReport",
+    "SaturationThreshold",
+    "detect_saturation",
     "ScalingAnalyzer",
     "ScalingCurve",
     "ScalingPoint",

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -33,6 +33,7 @@ from xpyd_plan.cli._pipeline import _cmd_pipeline
 from xpyd_plan.cli._plan_benchmarks import _cmd_plan_benchmarks, add_plan_benchmarks_parser
 from xpyd_plan.cli._recommend import _cmd_recommend
 from xpyd_plan.cli._root_cause import _cmd_root_cause, add_root_cause_parser
+from xpyd_plan.cli._saturation import _cmd_saturation, add_saturation_parser
 from xpyd_plan.cli._scaling import _cmd_scaling, add_scaling_parser
 from xpyd_plan.cli._scorecard import _cmd_scorecard, add_scorecard_parser
 from xpyd_plan.cli._sla_tier import add_sla_tier_parser
@@ -864,6 +865,7 @@ def main(argv: list[str] | None = None) -> None:
     add_metrics_parser(subparsers)
 
     # --- scaling subcommand ---
+    add_saturation_parser(subparsers)
     add_scaling_parser(subparsers)
 
     # --- correlation subcommand ---
@@ -955,6 +957,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_ab_test(args)
     elif args.command == "workload":
         _cmd_workload(args)
+    elif args.command == "saturation":
+        _cmd_saturation(args)
     elif args.command == "scaling":
         _cmd_scaling(args)
     elif args.command == "metrics":

--- a/src/xpyd_plan/cli/_saturation.py
+++ b/src/xpyd_plan/cli/_saturation.py
@@ -1,0 +1,115 @@
+"""CLI saturation command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.saturation import SaturationDetector
+
+
+def _cmd_saturation(args: argparse.Namespace) -> None:
+    """Handle the 'saturation' subcommand."""
+    console = Console()
+
+    if len(args.benchmark) < 2:
+        console.print("[red]Error: need at least 2 benchmark files for saturation analysis[/red]")
+        sys.exit(1)
+
+    benchmarks = []
+    for path in args.benchmark:
+        benchmarks.append(load_benchmark_auto(path))
+
+    detector = SaturationDetector(increase_threshold=args.increase_threshold)
+    report = detector.analyze(benchmarks)
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Table: QPS points
+    table = Table(title="Saturation Analysis — QPS vs Latency")
+    table.add_column("QPS", justify="right")
+    table.add_column("P:D", justify="center")
+    table.add_column("Requests", justify="right")
+    table.add_column("TTFT P95", justify="right")
+    table.add_column("TPOT P95", justify="right")
+    table.add_column("Total P95", justify="right")
+    table.add_column("TTFT P99", justify="right")
+    table.add_column("TPOT P99", justify="right")
+    table.add_column("Total P99", justify="right")
+
+    for point in report.points:
+        table.add_row(
+            f"{point.measured_qps:.1f}",
+            f"{point.num_prefill}:{point.num_decode}",
+            str(point.request_count),
+            f"{point.ttft_p95_ms:.1f}",
+            f"{point.tpot_p95_ms:.1f}",
+            f"{point.total_latency_p95_ms:.1f}",
+            f"{point.ttft_p99_ms:.1f}",
+            f"{point.tpot_p99_ms:.1f}",
+            f"{point.total_latency_p99_ms:.1f}",
+        )
+
+    console.print(table)
+
+    # Saturation thresholds
+    if report.thresholds:
+        console.print()
+        thresh_table = Table(title="Detected Saturation Thresholds")
+        thresh_table.add_column("Metric", justify="left")
+        thresh_table.add_column("Safe QPS", justify="right")
+        thresh_table.add_column("Saturated QPS", justify="right")
+        thresh_table.add_column("Latency (safe)", justify="right")
+        thresh_table.add_column("Latency (saturated)", justify="right")
+        thresh_table.add_column("Increase", justify="right")
+
+        for t in report.thresholds:
+            thresh_table.add_row(
+                t.metric,
+                f"{t.safe_qps:.1f}",
+                f"{t.saturated_qps:.1f}",
+                f"{t.latency_at_safe:.1f} ms",
+                f"{t.latency_at_saturated:.1f} ms",
+                f"[red]+{t.increase_pct:.1f}%[/red]",
+            )
+
+        console.print(thresh_table)
+
+    console.print()
+    console.print(f"[bold]{report.recommendation}[/bold]")
+
+
+def add_saturation_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the saturation subcommand parser."""
+    parser = subparsers.add_parser(
+        "saturation",
+        help="Detect QPS saturation point from benchmarks at different load levels",
+    )
+    parser.add_argument(
+        "--benchmark",
+        nargs="+",
+        required=True,
+        help="Benchmark JSON files (at least 2, different QPS levels)",
+    )
+    parser.add_argument(
+        "--increase-threshold",
+        type=float,
+        default=0.5,
+        help="Relative latency increase threshold for saturation detection (default: 0.5 = 50%%)",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_saturation)

--- a/src/xpyd_plan/saturation.py
+++ b/src/xpyd_plan/saturation.py
@@ -1,0 +1,227 @@
+"""Saturation point detection — find the QPS level where the system saturates.
+
+Given multiple benchmark files at increasing QPS levels (same P:D configuration),
+identify the QPS threshold where latency degrades beyond acceptable limits.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData
+
+
+class SaturationPoint(BaseModel):
+    """A single QPS data point with latency metrics."""
+
+    measured_qps: float = Field(..., gt=0, description="Measured QPS for this benchmark")
+    num_prefill: int = Field(..., ge=1)
+    num_decode: int = Field(..., ge=1)
+    ttft_p95_ms: float = Field(..., ge=0)
+    tpot_p95_ms: float = Field(..., ge=0)
+    total_latency_p95_ms: float = Field(..., ge=0)
+    ttft_p99_ms: float = Field(..., ge=0)
+    tpot_p99_ms: float = Field(..., ge=0)
+    total_latency_p99_ms: float = Field(..., ge=0)
+    request_count: int = Field(..., ge=1)
+
+
+class SaturationThreshold(BaseModel):
+    """Detected saturation threshold for a specific metric."""
+
+    metric: str = Field(..., description="Metric name (e.g., ttft_p95_ms)")
+    saturated_qps: float = Field(
+        ..., gt=0, description="QPS at which saturation was detected"
+    )
+    safe_qps: float = Field(
+        ..., gt=0, description="Highest QPS before saturation"
+    )
+    latency_at_safe: float = Field(..., ge=0, description="Latency at safe QPS")
+    latency_at_saturated: float = Field(..., ge=0, description="Latency at saturated QPS")
+    increase_pct: float = Field(
+        ..., description="Percentage increase from safe to saturated"
+    )
+
+
+class SaturationReport(BaseModel):
+    """Complete saturation analysis report."""
+
+    points: list[SaturationPoint] = Field(..., min_length=2)
+    thresholds: list[SaturationThreshold] = Field(
+        default_factory=list,
+        description="Detected saturation thresholds per metric",
+    )
+    overall_safe_qps: float | None = Field(
+        None,
+        description="Conservative safe QPS (minimum across all metrics, None if no saturation)",
+    )
+    recommendation: str = Field(..., description="Human-readable recommendation")
+
+
+class SaturationDetector:
+    """Detect QPS saturation point from multiple benchmark runs.
+
+    Saturation is detected when the latency increase between consecutive QPS
+    levels exceeds a configurable threshold (default: 50% relative increase).
+    """
+
+    def __init__(self, increase_threshold: float = 0.5) -> None:
+        """Initialize with saturation detection threshold.
+
+        Args:
+            increase_threshold: Relative latency increase between consecutive
+                QPS points that triggers saturation detection. Default 0.5 (50%).
+                Must be > 0.
+        """
+        if increase_threshold <= 0:
+            msg = f"increase_threshold must be > 0, got {increase_threshold}"
+            raise ValueError(msg)
+        self.increase_threshold = increase_threshold
+
+    def analyze(self, benchmarks: list[BenchmarkData]) -> SaturationReport:
+        """Analyze saturation across multiple benchmark runs at different QPS levels.
+
+        Args:
+            benchmarks: List of benchmark datasets at different QPS levels.
+                Must contain at least 2 benchmarks with distinct measured_qps.
+
+        Returns:
+            SaturationReport with detected saturation thresholds.
+
+        Raises:
+            ValueError: If fewer than 2 benchmarks or all have same QPS.
+        """
+        if len(benchmarks) < 2:
+            msg = "Need at least 2 benchmark datasets for saturation analysis"
+            raise ValueError(msg)
+
+        # Sort by QPS
+        sorted_benchmarks = sorted(benchmarks, key=lambda b: b.metadata.measured_qps)
+
+        # Check distinct QPS values
+        qps_values = {b.metadata.measured_qps for b in sorted_benchmarks}
+        if len(qps_values) < 2:
+            msg = "Need benchmarks with at least 2 distinct measured_qps values"
+            raise ValueError(msg)
+
+        # Build saturation points
+        points: list[SaturationPoint] = []
+        for bench in sorted_benchmarks:
+            meta = bench.metadata
+            ttfts = [r.ttft_ms for r in bench.requests]
+            tpots = [r.tpot_ms for r in bench.requests]
+            totals = [r.total_latency_ms for r in bench.requests]
+
+            points.append(
+                SaturationPoint(
+                    measured_qps=meta.measured_qps,
+                    num_prefill=meta.num_prefill_instances,
+                    num_decode=meta.num_decode_instances,
+                    ttft_p95_ms=round(float(np.percentile(ttfts, 95)), 2),
+                    tpot_p95_ms=round(float(np.percentile(tpots, 95)), 2),
+                    total_latency_p95_ms=round(float(np.percentile(totals, 95)), 2),
+                    ttft_p99_ms=round(float(np.percentile(ttfts, 99)), 2),
+                    tpot_p99_ms=round(float(np.percentile(tpots, 99)), 2),
+                    total_latency_p99_ms=round(float(np.percentile(totals, 99)), 2),
+                    request_count=len(bench.requests),
+                )
+            )
+
+        # Detect saturation per metric
+        metrics = [
+            "ttft_p95_ms",
+            "tpot_p95_ms",
+            "total_latency_p95_ms",
+            "ttft_p99_ms",
+            "tpot_p99_ms",
+            "total_latency_p99_ms",
+        ]
+
+        thresholds: list[SaturationThreshold] = []
+        for metric in metrics:
+            threshold = self._detect_metric_saturation(points, metric)
+            if threshold is not None:
+                thresholds.append(threshold)
+
+        # Overall safe QPS
+        overall_safe_qps: float | None = None
+        if thresholds:
+            overall_safe_qps = min(t.safe_qps for t in thresholds)
+
+        recommendation = self._build_recommendation(points, thresholds, overall_safe_qps)
+
+        return SaturationReport(
+            points=points,
+            thresholds=thresholds,
+            overall_safe_qps=overall_safe_qps,
+            recommendation=recommendation,
+        )
+
+    def _detect_metric_saturation(
+        self, points: list[SaturationPoint], metric: str
+    ) -> SaturationThreshold | None:
+        """Detect saturation for a single metric.
+
+        Returns the first QPS transition where latency increase exceeds threshold.
+        """
+        for i in range(1, len(points)):
+            prev_val = getattr(points[i - 1], metric)
+            curr_val = getattr(points[i], metric)
+
+            if prev_val <= 0:
+                continue
+
+            increase_pct = (curr_val - prev_val) / prev_val
+
+            if increase_pct >= self.increase_threshold:
+                return SaturationThreshold(
+                    metric=metric,
+                    saturated_qps=points[i].measured_qps,
+                    safe_qps=points[i - 1].measured_qps,
+                    latency_at_safe=round(prev_val, 2),
+                    latency_at_saturated=round(curr_val, 2),
+                    increase_pct=round(increase_pct * 100, 1),
+                )
+
+        return None
+
+    def _build_recommendation(
+        self,
+        points: list[SaturationPoint],
+        thresholds: list[SaturationThreshold],
+        overall_safe_qps: float | None,
+    ) -> str:
+        """Generate a human-readable recommendation."""
+        if not thresholds:
+            max_qps = points[-1].measured_qps
+            return (
+                f"No saturation detected up to {max_qps:.1f} QPS. "
+                f"The system handles all tested load levels without significant "
+                f"latency degradation."
+            )
+
+        saturated_metrics = [t.metric for t in thresholds]
+        return (
+            f"Saturation detected. Safe operating QPS: {overall_safe_qps:.1f}. "
+            f"Metrics degrading: {', '.join(saturated_metrics)}. "
+            f"Do not exceed {overall_safe_qps:.1f} QPS to maintain latency stability."
+        )
+
+
+def detect_saturation(
+    benchmarks: list[BenchmarkData],
+    increase_threshold: float = 0.5,
+) -> dict:
+    """Programmatic API for saturation detection.
+
+    Args:
+        benchmarks: List of benchmark datasets at different QPS levels.
+        increase_threshold: Relative latency increase threshold for detection.
+
+    Returns:
+        Dictionary representation of SaturationReport.
+    """
+    detector = SaturationDetector(increase_threshold=increase_threshold)
+    report = detector.analyze(benchmarks)
+    return report.model_dump()

--- a/tests/test_saturation.py
+++ b/tests/test_saturation.py
@@ -1,0 +1,268 @@
+"""Tests for saturation point detection."""
+
+from __future__ import annotations
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.saturation import SaturationDetector, detect_saturation
+
+
+def _make_benchmark(
+    qps: float,
+    num_prefill: int = 2,
+    num_decode: int = 2,
+    num_requests: int = 100,
+    base_ttft: float = 50.0,
+    base_tpot: float = 10.0,
+    base_total: float = 200.0,
+    ttft_scale: float = 1.0,
+    tpot_scale: float = 1.0,
+    total_scale: float = 1.0,
+) -> BenchmarkData:
+    """Create a synthetic benchmark with controllable latency scaling."""
+    import random
+
+    random.seed(42)
+    requests = []
+    for i in range(num_requests):
+        noise = random.uniform(0.8, 1.2)
+        requests.append(
+            BenchmarkRequest(
+                request_id=f"req-{qps}-{i}",
+                prompt_tokens=100,
+                output_tokens=50,
+                ttft_ms=base_ttft * ttft_scale * noise,
+                tpot_ms=base_tpot * tpot_scale * noise,
+                total_latency_ms=base_total * total_scale * noise,
+                timestamp=1000.0 + i * (1.0 / qps),
+            )
+        )
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=num_prefill,
+            num_decode_instances=num_decode,
+            total_instances=num_prefill + num_decode,
+            measured_qps=qps,
+        ),
+        requests=requests,
+    )
+
+
+class TestSaturationDetector:
+    """Tests for SaturationDetector."""
+
+    def test_init_default(self) -> None:
+        detector = SaturationDetector()
+        assert detector.increase_threshold == 0.5
+
+    def test_init_custom_threshold(self) -> None:
+        detector = SaturationDetector(increase_threshold=0.3)
+        assert detector.increase_threshold == 0.3
+
+    def test_init_invalid_threshold(self) -> None:
+        with pytest.raises(ValueError, match="increase_threshold must be > 0"):
+            SaturationDetector(increase_threshold=0)
+        with pytest.raises(ValueError, match="increase_threshold must be > 0"):
+            SaturationDetector(increase_threshold=-0.1)
+
+    def test_too_few_benchmarks(self) -> None:
+        detector = SaturationDetector()
+        bench = _make_benchmark(qps=10.0)
+        with pytest.raises(ValueError, match="at least 2"):
+            detector.analyze([bench])
+
+    def test_same_qps(self) -> None:
+        detector = SaturationDetector()
+        b1 = _make_benchmark(qps=10.0)
+        b2 = _make_benchmark(qps=10.0)
+        with pytest.raises(ValueError, match="at least 2 distinct"):
+            detector.analyze([b1, b2])
+
+    def test_no_saturation(self) -> None:
+        """When latency stays stable across QPS levels, no saturation detected."""
+        detector = SaturationDetector()
+        benchmarks = [
+            _make_benchmark(qps=10.0, ttft_scale=1.0, tpot_scale=1.0, total_scale=1.0),
+            _make_benchmark(qps=20.0, ttft_scale=1.05, tpot_scale=1.05, total_scale=1.05),
+            _make_benchmark(qps=30.0, ttft_scale=1.1, tpot_scale=1.1, total_scale=1.1),
+        ]
+        report = detector.analyze(benchmarks)
+        assert len(report.thresholds) == 0
+        assert report.overall_safe_qps is None
+        assert "No saturation" in report.recommendation
+
+    def test_saturation_detected(self) -> None:
+        """When latency spikes, saturation is detected."""
+        detector = SaturationDetector(increase_threshold=0.5)
+        benchmarks = [
+            _make_benchmark(qps=10.0, ttft_scale=1.0, tpot_scale=1.0, total_scale=1.0),
+            _make_benchmark(qps=20.0, ttft_scale=1.2, tpot_scale=1.2, total_scale=1.2),
+            _make_benchmark(qps=30.0, ttft_scale=3.0, tpot_scale=3.0, total_scale=3.0),
+        ]
+        report = detector.analyze(benchmarks)
+        assert len(report.thresholds) > 0
+        assert report.overall_safe_qps == 20.0
+        # All thresholds should have saturated_qps == 30.0
+        for t in report.thresholds:
+            assert t.saturated_qps == 30.0
+            assert t.safe_qps == 20.0
+            assert t.increase_pct > 0
+
+    def test_points_sorted_by_qps(self) -> None:
+        """Points should be sorted by QPS regardless of input order."""
+        detector = SaturationDetector()
+        benchmarks = [
+            _make_benchmark(qps=30.0),
+            _make_benchmark(qps=10.0),
+            _make_benchmark(qps=20.0),
+        ]
+        report = detector.analyze(benchmarks)
+        qps_values = [p.measured_qps for p in report.points]
+        assert qps_values == sorted(qps_values)
+
+    def test_report_has_correct_point_count(self) -> None:
+        detector = SaturationDetector()
+        benchmarks = [
+            _make_benchmark(qps=5.0),
+            _make_benchmark(qps=15.0),
+            _make_benchmark(qps=25.0),
+            _make_benchmark(qps=35.0),
+        ]
+        report = detector.analyze(benchmarks)
+        assert len(report.points) == 4
+
+    def test_early_saturation(self) -> None:
+        """Saturation at the first QPS transition."""
+        detector = SaturationDetector(increase_threshold=0.3)
+        benchmarks = [
+            _make_benchmark(qps=5.0, ttft_scale=1.0),
+            _make_benchmark(qps=10.0, ttft_scale=2.0),
+        ]
+        report = detector.analyze(benchmarks)
+        assert len(report.thresholds) > 0
+        assert report.overall_safe_qps == 5.0
+
+    def test_partial_metric_saturation(self) -> None:
+        """Only some metrics saturate."""
+        detector = SaturationDetector(increase_threshold=0.5)
+        benchmarks = [
+            _make_benchmark(qps=10.0, ttft_scale=1.0, tpot_scale=1.0, total_scale=1.0),
+            _make_benchmark(qps=20.0, ttft_scale=2.0, tpot_scale=1.1, total_scale=1.1),
+        ]
+        report = detector.analyze(benchmarks)
+        # TTFT should saturate, TPOT and total should not
+        saturated_metrics = {t.metric for t in report.thresholds}
+        assert "ttft_p95_ms" in saturated_metrics
+        assert "tpot_p95_ms" not in saturated_metrics
+
+    def test_overall_safe_qps_is_minimum(self) -> None:
+        """Overall safe QPS is the minimum across all saturated metrics."""
+        detector = SaturationDetector(increase_threshold=0.5)
+        benchmarks = [
+            _make_benchmark(qps=10.0, ttft_scale=1.0, tpot_scale=1.0, total_scale=1.0),
+            _make_benchmark(qps=20.0, ttft_scale=2.0, tpot_scale=2.0, total_scale=2.0),
+        ]
+        report = detector.analyze(benchmarks)
+        if report.thresholds:
+            min_safe = min(t.safe_qps for t in report.thresholds)
+            assert report.overall_safe_qps == min_safe
+
+    def test_recommendation_includes_safe_qps(self) -> None:
+        detector = SaturationDetector(increase_threshold=0.5)
+        benchmarks = [
+            _make_benchmark(qps=10.0, ttft_scale=1.0),
+            _make_benchmark(qps=20.0, ttft_scale=3.0),
+        ]
+        report = detector.analyze(benchmarks)
+        assert "10.0" in report.recommendation
+
+    def test_point_request_count(self) -> None:
+        detector = SaturationDetector()
+        benchmarks = [
+            _make_benchmark(qps=10.0, num_requests=50),
+            _make_benchmark(qps=20.0, num_requests=200),
+        ]
+        report = detector.analyze(benchmarks)
+        assert report.points[0].request_count == 50
+        assert report.points[1].request_count == 200
+
+    def test_point_pd_config(self) -> None:
+        detector = SaturationDetector()
+        benchmarks = [
+            _make_benchmark(qps=10.0, num_prefill=3, num_decode=5),
+            _make_benchmark(qps=20.0, num_prefill=3, num_decode=5),
+        ]
+        report = detector.analyze(benchmarks)
+        for p in report.points:
+            assert p.num_prefill == 3
+            assert p.num_decode == 5
+
+    def test_high_threshold_no_saturation(self) -> None:
+        """With very high threshold, moderate increases don't trigger."""
+        detector = SaturationDetector(increase_threshold=5.0)
+        benchmarks = [
+            _make_benchmark(qps=10.0, ttft_scale=1.0),
+            _make_benchmark(qps=20.0, ttft_scale=3.0),
+        ]
+        report = detector.analyze(benchmarks)
+        assert len(report.thresholds) == 0
+
+    def test_low_threshold_sensitive(self) -> None:
+        """Low threshold detects even minor increases."""
+        detector = SaturationDetector(increase_threshold=0.1)
+        benchmarks = [
+            _make_benchmark(qps=10.0, ttft_scale=1.0),
+            _make_benchmark(qps=20.0, ttft_scale=1.15),
+        ]
+        report = detector.analyze(benchmarks)
+        assert len(report.thresholds) > 0
+
+    def test_increase_pct_correct(self) -> None:
+        """Verify the reported increase percentage is approximately correct."""
+        detector = SaturationDetector(increase_threshold=0.5)
+        benchmarks = [
+            _make_benchmark(qps=10.0, ttft_scale=1.0, tpot_scale=1.0, total_scale=1.0),
+            _make_benchmark(qps=20.0, ttft_scale=2.0, tpot_scale=1.0, total_scale=1.0),
+        ]
+        report = detector.analyze(benchmarks)
+        ttft_thresholds = [t for t in report.thresholds if "ttft" in t.metric]
+        assert len(ttft_thresholds) > 0
+        for t in ttft_thresholds:
+            # ~100% increase (2x)
+            assert t.increase_pct > 50
+
+
+class TestDetectSaturationAPI:
+    """Tests for the programmatic API."""
+
+    def test_returns_dict(self) -> None:
+        benchmarks = [
+            _make_benchmark(qps=10.0),
+            _make_benchmark(qps=20.0),
+        ]
+        result = detect_saturation(benchmarks)
+        assert isinstance(result, dict)
+        assert "points" in result
+        assert "thresholds" in result
+        assert "overall_safe_qps" in result
+        assert "recommendation" in result
+
+    def test_custom_threshold(self) -> None:
+        benchmarks = [
+            _make_benchmark(qps=10.0, ttft_scale=1.0),
+            _make_benchmark(qps=20.0, ttft_scale=2.0),
+        ]
+        result = detect_saturation(benchmarks, increase_threshold=0.5)
+        assert len(result["thresholds"]) > 0
+
+    def test_matches_class_output(self) -> None:
+        benchmarks = [
+            _make_benchmark(qps=10.0),
+            _make_benchmark(qps=20.0),
+            _make_benchmark(qps=30.0),
+        ]
+        detector = SaturationDetector()
+        report = detector.analyze(benchmarks)
+        api_result = detect_saturation(benchmarks)
+        assert api_result == report.model_dump()


### PR DESCRIPTION
## Summary
Add saturation point detection — find the QPS level where the system saturates based on multiple benchmark files at different QPS levels.

Closes #114

## Changes
- `SaturationDetector` class in `saturation.py`
- `SaturationPoint`, `SaturationThreshold`, `SaturationReport` Pydantic models
- Detect QPS where latency degrades beyond configurable threshold (default 50%)
- Per-metric saturation detection (TTFT/TPOT/total at P95/P99)
- Conservative overall safe QPS (minimum across all metrics)
- CLI `saturation` subcommand with `--benchmark`, `--increase-threshold`, table + JSON output
- Programmatic `detect_saturation()` API
- 21 new tests (1141 total)