### PR TITLE
feat: M50 Latency Decomposition Analysis

### DIFF
--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -75,6 +75,14 @@ from xpyd_plan.dashboard import (
     DashboardView,
     run_dashboard,
 )
+from xpyd_plan.decomposer import (
+    BottleneckType,
+    DecomposedRequest,
+    DecompositionReport,
+    LatencyDecomposer,
+    PhaseStats,
+    decompose_latency,
+)
 from xpyd_plan.discovery import (
     BenchmarkDiscovery,
     ConfigGroup,
@@ -499,4 +507,10 @@ __all__ = [
     "MultiTierReport",
     "analyze_sla_tiers",
     "load_tiers_from_yaml",
+    "BottleneckType",
+    "DecomposedRequest",
+    "DecompositionReport",
+    "LatencyDecomposer",
+    "PhaseStats",
+    "decompose_latency",
 ]

--- a/src/xpyd_plan/cli/_decompose.py
+++ b/src/xpyd_plan/cli/_decompose.py
@@ -1,0 +1,91 @@
+"""CLI decompose command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.decomposer import BottleneckType, LatencyDecomposer
+
+
+def _cmd_decompose(args: argparse.Namespace) -> None:
+    """Handle the 'decompose' subcommand."""
+    console = Console()
+
+    data = load_benchmark_auto(args.benchmark)
+    threshold = getattr(args, "bottleneck_threshold", 0.5)
+    decomposer = LatencyDecomposer(data, bottleneck_threshold=threshold)
+    report = decomposer.analyze()
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Phase stats table
+    table = Table(title="Latency Decomposition")
+    table.add_column("Phase", justify="left")
+    table.add_column("Mean Fraction", justify="right")
+    table.add_column("P50 Fraction", justify="right")
+    table.add_column("P95 Fraction", justify="right")
+    table.add_column("Mean (ms)", justify="right")
+    table.add_column("P50 (ms)", justify="right")
+    table.add_column("P95 (ms)", justify="right")
+
+    for ps in report.phase_stats:
+        table.add_row(
+            ps.phase.capitalize(),
+            f"{ps.mean_fraction:.1%}",
+            f"{ps.p50_fraction:.1%}",
+            f"{ps.p95_fraction:.1%}",
+            f"{ps.mean_ms:.1f}",
+            f"{ps.p50_ms:.1f}",
+            f"{ps.p95_ms:.1f}",
+        )
+
+    console.print(table)
+
+    # Bottleneck
+    style = {
+        BottleneckType.PREFILL_BOUND: "bold yellow",
+        BottleneckType.DECODE_BOUND: "bold cyan",
+        BottleneckType.OVERHEAD_BOUND: "bold red",
+        BottleneckType.BALANCED: "green",
+    }[report.bottleneck]
+
+    console.print(
+        f"\n[bold]Bottleneck:[/bold] [{style}]{report.bottleneck.value}[/{style}]"
+    )
+    console.print(f"[dim]{report.recommendation}[/dim]")
+
+
+def add_decompose_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the decompose subcommand parser."""
+    parser = subparsers.add_parser(
+        "decompose",
+        help="Decompose latency into prefill, decode, and overhead phases",
+    )
+    parser.add_argument(
+        "--benchmark",
+        required=True,
+        help="Path to benchmark JSON file",
+    )
+    parser.add_argument(
+        "--bottleneck-threshold",
+        type=float,
+        default=0.5,
+        help="Fraction threshold for bottleneck classification (default: 0.5)",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_decompose)

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -16,6 +16,7 @@ from xpyd_plan.cli._confidence import _cmd_confidence
 from xpyd_plan.cli._config import _add_config_flag, _apply_config_defaults, _cmd_config
 from xpyd_plan.cli._correlation import _cmd_correlation, add_correlation_parser
 from xpyd_plan.cli._dashboard import _cmd_dashboard
+from xpyd_plan.cli._decompose import _cmd_decompose, add_decompose_parser
 from xpyd_plan.cli._discover import _cmd_discover, add_discover_parser
 from xpyd_plan.cli._drift import _cmd_drift, add_drift_parser
 from xpyd_plan.cli._export import _cmd_export
@@ -899,6 +900,7 @@ def main(argv: list[str] | None = None) -> None:
     # --- forecast subcommand ---
     add_forecast_parser(subparsers)
     add_sla_tier_parser(subparsers)
+    add_decompose_parser(subparsers)
 
     args = parser.parse_args(argv)
 
@@ -991,6 +993,8 @@ def main(argv: list[str] | None = None) -> None:
         from xpyd_plan.cli._sla_tier import _run_sla_tier
 
         _run_sla_tier(args)
+    elif args.command == "decompose":
+        _cmd_decompose(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/decomposer.py
+++ b/src/xpyd_plan/decomposer.py
@@ -1,0 +1,210 @@
+"""Latency decomposition analysis for benchmark data."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from xpyd_plan.benchmark_models import BenchmarkData
+
+
+class BottleneckType(str, Enum):
+    """Classification of where latency is predominantly spent."""
+
+    PREFILL_BOUND = "prefill_bound"
+    DECODE_BOUND = "decode_bound"
+    OVERHEAD_BOUND = "overhead_bound"
+    BALANCED = "balanced"
+
+
+class DecomposedRequest(BaseModel):
+    """Latency decomposition for a single request."""
+
+    request_id: str = Field(description="Request identifier")
+    total_latency_ms: float = Field(description="Total end-to-end latency (ms)")
+    prefill_ms: float = Field(description="Prefill phase duration (TTFT) (ms)")
+    decode_ms: float = Field(description="Decode phase duration (output_tokens × tpot_ms) (ms)")
+    overhead_ms: float = Field(description="Overhead (total - prefill - decode), clamped to 0 (ms)")
+    prefill_fraction: float = Field(description="Fraction of total latency in prefill phase")
+    decode_fraction: float = Field(description="Fraction of total latency in decode phase")
+    overhead_fraction: float = Field(description="Fraction of total latency in overhead")
+
+
+class PhaseStats(BaseModel):
+    """Aggregate statistics for a latency phase."""
+
+    phase: str = Field(description="Phase name (prefill, decode, overhead)")
+    mean_fraction: float = Field(description="Mean fraction across all requests")
+    p50_fraction: float = Field(description="P50 fraction")
+    p95_fraction: float = Field(description="P95 fraction")
+    mean_ms: float = Field(description="Mean absolute duration (ms)")
+    p50_ms: float = Field(description="P50 absolute duration (ms)")
+    p95_ms: float = Field(description="P95 absolute duration (ms)")
+
+
+class DecompositionReport(BaseModel):
+    """Complete latency decomposition report."""
+
+    total_requests: int = Field(description="Total requests analyzed")
+    phase_stats: list[PhaseStats] = Field(description="Per-phase aggregate statistics")
+    bottleneck: BottleneckType = Field(description="Overall bottleneck classification")
+    bottleneck_threshold: float = Field(
+        description="Fraction threshold used for bottleneck classification"
+    )
+    recommendation: str = Field(description="Actionable recommendation based on bottleneck")
+    decomposed_requests: list[DecomposedRequest] = Field(
+        default_factory=list, description="Per-request decomposition (optional detail)"
+    )
+
+
+def _decompose_request(
+    request_id: str,
+    ttft_ms: float,
+    tpot_ms: float,
+    output_tokens: int,
+    total_latency_ms: float,
+) -> DecomposedRequest:
+    """Decompose a single request's latency into phases."""
+    prefill_ms = ttft_ms
+    decode_ms = output_tokens * tpot_ms
+    overhead_ms = max(0.0, total_latency_ms - prefill_ms - decode_ms)
+
+    if total_latency_ms > 0:
+        # Recalculate fractions after clamping overhead
+        actual_total = prefill_ms + decode_ms + overhead_ms
+        prefill_frac = prefill_ms / actual_total
+        decode_frac = decode_ms / actual_total
+        overhead_frac = overhead_ms / actual_total
+    else:
+        prefill_frac = 0.0
+        decode_frac = 0.0
+        overhead_frac = 0.0
+
+    return DecomposedRequest(
+        request_id=request_id,
+        total_latency_ms=total_latency_ms,
+        prefill_ms=prefill_ms,
+        decode_ms=decode_ms,
+        overhead_ms=overhead_ms,
+        prefill_fraction=prefill_frac,
+        decode_fraction=decode_frac,
+        overhead_fraction=overhead_frac,
+    )
+
+
+def _classify_bottleneck(
+    mean_prefill_frac: float,
+    mean_decode_frac: float,
+    mean_overhead_frac: float,
+    threshold: float,
+) -> BottleneckType:
+    """Classify the bottleneck based on mean phase fractions."""
+    if mean_prefill_frac >= threshold:
+        return BottleneckType.PREFILL_BOUND
+    if mean_decode_frac >= threshold:
+        return BottleneckType.DECODE_BOUND
+    if mean_overhead_frac >= threshold:
+        return BottleneckType.OVERHEAD_BOUND
+    return BottleneckType.BALANCED
+
+
+def _recommendation(bottleneck: BottleneckType) -> str:
+    """Return actionable recommendation based on bottleneck type."""
+    recommendations = {
+        BottleneckType.PREFILL_BOUND: (
+            "Prefill phase dominates latency. Consider adding more prefill instances "
+            "or optimizing prompt processing (shorter prompts, prefix caching)."
+        ),
+        BottleneckType.DECODE_BOUND: (
+            "Decode phase dominates latency. Consider adding more decode instances "
+            "or optimizing generation (speculative decoding, reduced output length)."
+        ),
+        BottleneckType.OVERHEAD_BOUND: (
+            "Overhead (scheduling, network, queuing) dominates latency. "
+            "Investigate infrastructure bottlenecks, load balancer configuration, "
+            "and request queuing behavior."
+        ),
+        BottleneckType.BALANCED: (
+            "Latency is balanced across phases. No single bottleneck dominates. "
+            "Consider overall scaling or SLA relaxation if needed."
+        ),
+    }
+    return recommendations[bottleneck]
+
+
+class LatencyDecomposer:
+    """Decompose benchmark latency into prefill, decode, and overhead phases."""
+
+    def __init__(self, data: BenchmarkData, *, bottleneck_threshold: float = 0.5) -> None:
+        self._data = data
+        self._threshold = bottleneck_threshold
+
+    def analyze(self, *, include_requests: bool = False) -> DecompositionReport:
+        """Run latency decomposition analysis."""
+        decomposed = [
+            _decompose_request(
+                request_id=r.request_id,
+                ttft_ms=r.ttft_ms,
+                tpot_ms=r.tpot_ms,
+                output_tokens=r.output_tokens,
+                total_latency_ms=r.total_latency_ms,
+            )
+            for r in self._data.requests
+        ]
+
+        prefill_fracs = np.array([d.prefill_fraction for d in decomposed])
+        decode_fracs = np.array([d.decode_fraction for d in decomposed])
+        overhead_fracs = np.array([d.overhead_fraction for d in decomposed])
+
+        prefill_ms = np.array([d.prefill_ms for d in decomposed])
+        decode_ms_arr = np.array([d.decode_ms for d in decomposed])
+        overhead_ms_arr = np.array([d.overhead_ms for d in decomposed])
+
+        def _phase_stats(name: str, fracs: np.ndarray, ms_arr: np.ndarray) -> PhaseStats:
+            return PhaseStats(
+                phase=name,
+                mean_fraction=float(np.mean(fracs)),
+                p50_fraction=float(np.percentile(fracs, 50)),
+                p95_fraction=float(np.percentile(fracs, 95)),
+                mean_ms=float(np.mean(ms_arr)),
+                p50_ms=float(np.percentile(ms_arr, 50)),
+                p95_ms=float(np.percentile(ms_arr, 95)),
+            )
+
+        phase_stats = [
+            _phase_stats("prefill", prefill_fracs, prefill_ms),
+            _phase_stats("decode", decode_fracs, decode_ms_arr),
+            _phase_stats("overhead", overhead_fracs, overhead_ms_arr),
+        ]
+
+        mean_pf = float(np.mean(prefill_fracs))
+        mean_df = float(np.mean(decode_fracs))
+        mean_of = float(np.mean(overhead_fracs))
+
+        bottleneck = _classify_bottleneck(mean_pf, mean_df, mean_of, self._threshold)
+
+        return DecompositionReport(
+            total_requests=len(decomposed),
+            phase_stats=phase_stats,
+            bottleneck=bottleneck,
+            bottleneck_threshold=self._threshold,
+            recommendation=_recommendation(bottleneck),
+            decomposed_requests=decomposed if include_requests else [],
+        )
+
+
+def decompose_latency(
+    data: BenchmarkData,
+    *,
+    bottleneck_threshold: float = 0.5,
+    include_requests: bool = False,
+) -> dict:
+    """Programmatic API: decompose benchmark latency into phases.
+
+    Returns a dict representation of DecompositionReport.
+    """
+    decomposer = LatencyDecomposer(data, bottleneck_threshold=bottleneck_threshold)
+    report = decomposer.analyze(include_requests=include_requests)
+    return report.model_dump()

--- a/tests/test_decomposer.py
+++ b/tests/test_decomposer.py
@@ -1,0 +1,327 @@
+"""Tests for latency decomposition analysis (M50)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.decomposer import (
+    BottleneckType,
+    LatencyDecomposer,
+    _classify_bottleneck,
+    _decompose_request,
+    decompose_latency,
+)
+
+
+def _make_request(
+    request_id: str = "r1",
+    prompt_tokens: int = 100,
+    output_tokens: int = 50,
+    ttft_ms: float = 100.0,
+    tpot_ms: float = 10.0,
+    total_latency_ms: float = 700.0,
+    timestamp: float = 1000.0,
+) -> BenchmarkRequest:
+    return BenchmarkRequest(
+        request_id=request_id,
+        prompt_tokens=prompt_tokens,
+        output_tokens=output_tokens,
+        ttft_ms=ttft_ms,
+        tpot_ms=tpot_ms,
+        total_latency_ms=total_latency_ms,
+        timestamp=timestamp,
+    )
+
+
+def _make_benchmark(requests: list[BenchmarkRequest]) -> BenchmarkData:
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=2,
+            total_instances=4,
+            measured_qps=10.0,
+        ),
+        requests=requests,
+    )
+
+
+class TestDecomposeRequest:
+    """Unit tests for _decompose_request."""
+
+    def test_basic_decomposition(self):
+        d = _decompose_request(
+            "r1", ttft_ms=100, tpot_ms=10, output_tokens=50, total_latency_ms=700
+        )
+        assert d.prefill_ms == 100.0
+        assert d.decode_ms == 500.0  # 50 * 10
+        assert d.overhead_ms == 100.0  # 700 - 100 - 500
+        assert abs(d.prefill_fraction + d.decode_fraction + d.overhead_fraction - 1.0) < 1e-9
+
+    def test_negative_overhead_clamped_to_zero(self):
+        # total < prefill + decode → overhead should be 0
+        d = _decompose_request(
+            "r1", ttft_ms=100, tpot_ms=10, output_tokens=50, total_latency_ms=500
+        )
+        assert d.overhead_ms == 0.0
+        assert d.overhead_fraction == 0.0
+        # Fractions should still sum to 1
+        assert abs(d.prefill_fraction + d.decode_fraction + d.overhead_fraction - 1.0) < 1e-9
+
+    def test_zero_total_latency(self):
+        d = _decompose_request("r1", ttft_ms=0, tpot_ms=0, output_tokens=1, total_latency_ms=0)
+        assert d.prefill_fraction == 0.0
+        assert d.decode_fraction == 0.0
+        assert d.overhead_fraction == 0.0
+
+    def test_all_prefill(self):
+        d = _decompose_request(
+            "r1", ttft_ms=1000, tpot_ms=0, output_tokens=1, total_latency_ms=1000
+        )
+        assert d.prefill_fraction == 1.0
+        assert d.decode_fraction == 0.0
+        assert d.overhead_fraction == 0.0
+
+
+class TestClassifyBottleneck:
+    """Tests for _classify_bottleneck."""
+
+    def test_prefill_bound(self):
+        assert _classify_bottleneck(0.6, 0.3, 0.1, 0.5) == BottleneckType.PREFILL_BOUND
+
+    def test_decode_bound(self):
+        assert _classify_bottleneck(0.2, 0.7, 0.1, 0.5) == BottleneckType.DECODE_BOUND
+
+    def test_overhead_bound(self):
+        assert _classify_bottleneck(0.1, 0.2, 0.7, 0.5) == BottleneckType.OVERHEAD_BOUND
+
+    def test_balanced(self):
+        assert _classify_bottleneck(0.35, 0.35, 0.3, 0.5) == BottleneckType.BALANCED
+
+    def test_custom_threshold(self):
+        assert _classify_bottleneck(0.45, 0.35, 0.2, 0.4) == BottleneckType.PREFILL_BOUND
+
+
+class TestLatencyDecomposer:
+    """Tests for LatencyDecomposer class."""
+
+    def test_prefill_heavy_benchmark(self):
+        """Requests where TTFT dominates → PREFILL_BOUND."""
+        requests = [
+            _make_request(
+                request_id=f"r{i}",
+                ttft_ms=800.0,
+                tpot_ms=1.0,
+                output_tokens=10,
+                total_latency_ms=820.0,
+            )
+            for i in range(20)
+        ]
+        data = _make_benchmark(requests)
+        decomposer = LatencyDecomposer(data)
+        report = decomposer.analyze()
+
+        assert report.bottleneck == BottleneckType.PREFILL_BOUND
+        assert report.total_requests == 20
+        assert len(report.phase_stats) == 3
+        assert report.phase_stats[0].phase == "prefill"
+        assert report.phase_stats[0].mean_fraction > 0.5
+
+    def test_decode_heavy_benchmark(self):
+        """Requests where decode dominates → DECODE_BOUND."""
+        requests = [
+            _make_request(
+                request_id=f"r{i}",
+                ttft_ms=10.0,
+                tpot_ms=20.0,
+                output_tokens=100,
+                total_latency_ms=2050.0,
+            )
+            for i in range(20)
+        ]
+        data = _make_benchmark(requests)
+        decomposer = LatencyDecomposer(data)
+        report = decomposer.analyze()
+
+        assert report.bottleneck == BottleneckType.DECODE_BOUND
+
+    def test_balanced_benchmark(self):
+        """Requests with balanced phases → BALANCED."""
+        requests = [
+            _make_request(
+                request_id=f"r{i}",
+                ttft_ms=300.0,
+                tpot_ms=10.0,
+                output_tokens=30,
+                total_latency_ms=700.0,
+            )
+            for i in range(20)
+        ]
+        data = _make_benchmark(requests)
+        decomposer = LatencyDecomposer(data)
+        report = decomposer.analyze()
+
+        assert report.bottleneck == BottleneckType.BALANCED
+
+    def test_overhead_bound(self):
+        """Requests with large overhead → OVERHEAD_BOUND."""
+        requests = [
+            _make_request(
+                request_id=f"r{i}",
+                ttft_ms=50.0,
+                tpot_ms=1.0,
+                output_tokens=10,
+                total_latency_ms=1000.0,
+            )
+            for i in range(20)
+        ]
+        data = _make_benchmark(requests)
+        decomposer = LatencyDecomposer(data)
+        report = decomposer.analyze()
+
+        assert report.bottleneck == BottleneckType.OVERHEAD_BOUND
+
+    def test_include_requests(self):
+        requests = [_make_request(request_id=f"r{i}") for i in range(5)]
+        data = _make_benchmark(requests)
+        decomposer = LatencyDecomposer(data)
+
+        report_without = decomposer.analyze(include_requests=False)
+        assert len(report_without.decomposed_requests) == 0
+
+        report_with = decomposer.analyze(include_requests=True)
+        assert len(report_with.decomposed_requests) == 5
+
+    def test_single_request(self):
+        data = _make_benchmark([_make_request()])
+        decomposer = LatencyDecomposer(data)
+        report = decomposer.analyze()
+        assert report.total_requests == 1
+        assert len(report.phase_stats) == 3
+
+    def test_custom_threshold(self):
+        requests = [
+            _make_request(
+                request_id=f"r{i}",
+                ttft_ms=400.0,
+                tpot_ms=5.0,
+                output_tokens=20,
+                total_latency_ms=600.0,
+            )
+            for i in range(20)
+        ]
+        data = _make_benchmark(requests)
+        # With threshold=0.6, prefill at ~66% should be classified as PREFILL_BOUND
+        decomposer = LatencyDecomposer(data, bottleneck_threshold=0.6)
+        report = decomposer.analyze()
+        assert report.bottleneck == BottleneckType.PREFILL_BOUND
+        assert report.bottleneck_threshold == 0.6
+
+    def test_recommendation_not_empty(self):
+        data = _make_benchmark([_make_request()])
+        decomposer = LatencyDecomposer(data)
+        report = decomposer.analyze()
+        assert len(report.recommendation) > 0
+
+    def test_phase_stats_structure(self):
+        data = _make_benchmark([_make_request(request_id=f"r{i}") for i in range(10)])
+        decomposer = LatencyDecomposer(data)
+        report = decomposer.analyze()
+
+        phases = {ps.phase for ps in report.phase_stats}
+        assert phases == {"prefill", "decode", "overhead"}
+
+        for ps in report.phase_stats:
+            assert ps.mean_fraction >= 0
+            assert ps.p50_fraction >= 0
+            assert ps.p95_fraction >= 0
+            assert ps.mean_ms >= 0
+            assert ps.p50_ms >= 0
+            assert ps.p95_ms >= 0
+
+
+class TestDecomposeLatencyAPI:
+    """Tests for the programmatic decompose_latency() API."""
+
+    def test_returns_dict(self):
+        data = _make_benchmark([_make_request()])
+        result = decompose_latency(data)
+        assert isinstance(result, dict)
+        assert "bottleneck" in result
+        assert "phase_stats" in result
+        assert "total_requests" in result
+        assert "recommendation" in result
+
+    def test_with_include_requests(self):
+        data = _make_benchmark([_make_request()])
+        result = decompose_latency(data, include_requests=True)
+        assert len(result["decomposed_requests"]) == 1
+
+    def test_custom_threshold(self):
+        data = _make_benchmark([_make_request()])
+        result = decompose_latency(data, bottleneck_threshold=0.3)
+        assert result["bottleneck_threshold"] == 0.3
+
+
+class TestCLIDecompose:
+    """Tests for CLI decompose subcommand output."""
+
+    def _write_benchmark(self, tmp_dir: str, requests: list[dict] | None = None) -> str:
+        import os
+
+        if requests is None:
+            requests = [
+                {
+                    "request_id": f"r{i}",
+                    "prompt_tokens": 100,
+                    "output_tokens": 50,
+                    "ttft_ms": 800.0,
+                    "tpot_ms": 1.0,
+                    "total_latency_ms": 860.0,
+                    "timestamp": 1000.0 + i,
+                }
+                for i in range(10)
+            ]
+
+        benchmark = {
+            "metadata": {
+                "num_prefill_instances": 2,
+                "num_decode_instances": 2,
+                "total_instances": 4,
+                "measured_qps": 10.0,
+            },
+            "requests": requests,
+        }
+
+        path = os.path.join(tmp_dir, "bench.json")
+        with open(path, "w") as f:
+            json.dump(benchmark, f)
+        return path
+
+    def test_json_output(self):
+        from io import StringIO
+        from unittest.mock import patch
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write_benchmark(tmp)
+
+            from xpyd_plan.cli._main import main
+
+            captured = StringIO()
+            with patch("sys.stdout", captured):
+                main(["decompose", "--benchmark", path, "--output-format", "json"])
+
+            output = json.loads(captured.getvalue())
+            assert output["bottleneck"] == "prefill_bound"
+            assert len(output["phase_stats"]) == 3
+
+    def test_table_output_runs(self):
+        """Table output should not crash."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write_benchmark(tmp)
+
+            from xpyd_plan.cli._main import main
+
+            # Just ensure it doesn't raise
+            main(["decompose", "--benchmark", path, "--output-format", "table"])


### PR DESCRIPTION
## Summary

Add latency decomposition analysis that breaks down each request's total latency into three phases: prefill (TTFT), decode (output_tokens × tpot_ms), and overhead (scheduling/network/queuing).

## Changes

- `LatencyDecomposer` class in `decomposer.py`
- `DecomposedRequest`, `DecompositionReport`, `BottleneckType`, `PhaseStats` Pydantic models
- Per-request decomposition: prefill_fraction, decode_fraction, overhead_fraction
- Aggregate statistics at P50/P95 for each phase
- Bottleneck classification: PREFILL_BOUND, DECODE_BOUND, OVERHEAD_BOUND, BALANCED (configurable threshold, default 50%)
- Actionable recommendations based on bottleneck type
- CLI `decompose` subcommand with `--benchmark`, `--bottleneck-threshold`, `--output-format table|json`
- Programmatic `decompose_latency()` API
- 23 new tests (1164 total)

Closes #117