### PR TITLE
feat: plugin architecture with entry-point discovery (M52)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -667,7 +667,9 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Programmatic `decompose_latency()` API
 - 23 new tests (1164 total)
 
-### M51 ⬜ Comprehensive README Rewrite
+### M51 ✅ Comprehensive README Rewrite
+
+*Completed — PR #120*
 
 - Rewrite README.md to reflect all 50 milestones of current capabilities
 - Accurate quick-start examples using current CLI subcommands

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -205,6 +205,17 @@ from xpyd_plan.plan_generator import (
     RatioPriority,
     generate_benchmark_plan,
 )
+from xpyd_plan.plugin import (
+    PluginInfo,
+    PluginListReport,
+    PluginMetadata,
+    PluginRegistry,
+    PluginSpec,
+    PluginType,
+    get_plugin,
+    get_registry,
+    list_plugins,
+)
 from xpyd_plan.recommender import (
     ActionCategory,
     Recommendation,
@@ -513,4 +524,13 @@ __all__ = [
     "LatencyDecomposer",
     "PhaseStats",
     "decompose_latency",
+    "PluginMetadata",
+    "PluginRegistry",
+    "PluginSpec",
+    "PluginType",
+    "PluginInfo",
+    "PluginListReport",
+    "list_plugins",
+    "get_plugin",
+    "get_registry",
 ]

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -902,6 +902,16 @@ def main(argv: list[str] | None = None) -> None:
     add_sla_tier_parser(subparsers)
     add_decompose_parser(subparsers)
 
+    # --- plugins subcommand ---
+    from xpyd_plan.cli._plugins import add_plugins_subcommand
+
+    add_plugins_subcommand(subparsers)
+
+    # Let plugins register their own CLI subcommands
+    from xpyd_plan.plugin import get_registry
+
+    get_registry().register_all_cli(subparsers)
+
     args = parser.parse_args(argv)
 
     if args.command == "config":
@@ -995,6 +1005,10 @@ def main(argv: list[str] | None = None) -> None:
         _run_sla_tier(args)
     elif args.command == "decompose":
         _cmd_decompose(args)
+    elif args.command == "plugins":
+        from xpyd_plan.cli._plugins import _run_plugins
+
+        _run_plugins(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/cli/_plugins.py
+++ b/src/xpyd_plan/cli/_plugins.py
@@ -1,0 +1,73 @@
+"""CLI subcommand: plugins — list installed xPyD-plan plugins."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.plugin import PluginListReport, list_plugins
+
+
+def add_plugins_subcommand(subparsers: Any) -> None:
+    """Register the ``plugins`` subcommand."""
+    parser = subparsers.add_parser(
+        "plugins",
+        help="List installed xPyD-plan plugins",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_run_plugins)
+
+
+def _run_plugins(args: argparse.Namespace) -> None:
+    report = list_plugins()
+
+    if args.output_format == "json":
+        print(json.dumps(report.model_dump(), indent=2))
+    else:
+        _print_table(report)
+
+
+def _print_table(report: PluginListReport) -> None:
+    console = Console()
+
+    if report.total == 0:
+        console.print("[dim]No plugins installed.[/dim]")
+        console.print(
+            "\n[dim]Install plugins via pip. "
+            "They register using the 'xpyd_plan.plugins' entry point group.[/dim]"
+        )
+        return
+
+    table = Table(title="Installed Plugins")
+    table.add_column("Name", style="cyan")
+    table.add_column("Version")
+    table.add_column("Type")
+    table.add_column("Description")
+    table.add_column("Author")
+    table.add_column("Status")
+
+    for p in report.plugins:
+        status = "[green]✓ loaded[/green]" if p.loaded else f"[red]✗ {p.error}[/red]"
+        table.add_row(
+            p.name,
+            p.version,
+            p.plugin_type.value,
+            p.description,
+            p.author,
+            status,
+        )
+
+    console.print(table)
+    console.print(
+        f"\n[dim]Total: {report.total} | Loaded: {report.loaded} | "
+        f"Failed: {report.failed}[/dim]"
+    )

--- a/src/xpyd_plan/plugin.py
+++ b/src/xpyd_plan/plugin.py
@@ -1,0 +1,280 @@
+"""Plugin architecture for xPyD-plan.
+
+Allows third-party packages to register custom analyzers and CLI subcommands
+via Python entry points (group: ``xpyd_plan.plugins``).
+
+Plugin authors should:
+1. Implement a class that satisfies :class:`PluginSpec`.
+2. Register it as an entry point in their ``pyproject.toml``::
+
+       [project.entry-points."xpyd_plan.plugins"]
+       my_plugin = "my_package.plugin:MyPlugin"
+
+3. Install the package — xPyD-plan will discover and load it automatically.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import logging
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+ENTRY_POINT_GROUP = "xpyd_plan.plugins"
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+class PluginType(str, Enum):
+    """Type of capability a plugin provides."""
+
+    ANALYZER = "analyzer"
+    EXPORTER = "exporter"
+    GENERAL = "general"
+
+
+class PluginMetadata(BaseModel):
+    """Metadata describing an installed plugin."""
+
+    name: str = Field(..., description="Unique plugin name")
+    version: str = Field(default="0.0.0", description="Plugin version")
+    description: str = Field(default="", description="Short description")
+    author: str = Field(default="", description="Author name or email")
+    plugin_type: PluginType = Field(
+        default=PluginType.GENERAL,
+        description="Category of plugin",
+    )
+
+
+class PluginInfo(BaseModel):
+    """Summary information about a discovered plugin (for listing)."""
+
+    name: str
+    version: str
+    description: str
+    author: str
+    plugin_type: PluginType
+    entry_point: str = Field(
+        default="", description="Entry point string (package.module:Class)"
+    )
+    loaded: bool = Field(default=False, description="Whether the plugin loaded OK")
+    error: Optional[str] = Field(
+        default=None, description="Error message if loading failed"
+    )
+
+
+class PluginListReport(BaseModel):
+    """Report returned by ``list_plugins()``."""
+
+    plugins: List[PluginInfo] = Field(default_factory=list)
+    total: int = 0
+    loaded: int = 0
+    failed: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Plugin interface
+# ---------------------------------------------------------------------------
+
+class PluginSpec(ABC):
+    """Abstract base class that every xPyD-plan plugin must implement.
+
+    Minimal example::
+
+        class MyPlugin(PluginSpec):
+            @staticmethod
+            def metadata() -> PluginMetadata:
+                return PluginMetadata(name="my-plugin", version="1.0.0",
+                                      description="Demo plugin")
+
+            def analyze(self, data: dict) -> dict:
+                return {"result": "hello"}
+    """
+
+    @staticmethod
+    @abstractmethod
+    def metadata() -> PluginMetadata:
+        """Return metadata describing this plugin."""
+        ...
+
+    def analyze(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Run the plugin's analysis on *data* and return results.
+
+        Override this in analyzer plugins.  The default implementation
+        returns an empty dict (suitable for non-analyzer plugins).
+        """
+        return {}
+
+    def register_cli(self, subparsers: Any) -> None:
+        """Register CLI subcommand(s) on the given *subparsers* object.
+
+        Override this if the plugin provides CLI commands.
+        """
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+class PluginRegistry:
+    """Discover, validate, and manage plugins."""
+
+    def __init__(self) -> None:
+        self._plugins: Dict[str, PluginSpec] = {}
+        self._errors: Dict[str, str] = {}
+        self._entry_points: Dict[str, str] = {}
+
+    # -- discovery ----------------------------------------------------------
+
+    def discover(self) -> None:
+        """Scan entry points and load all available plugins."""
+        eps = importlib.metadata.entry_points()
+        # Python 3.12+ returns a SelectableGroups; 3.10/3.11 differ
+        if hasattr(eps, "select"):
+            group = eps.select(group=ENTRY_POINT_GROUP)
+        else:
+            group = eps.get(ENTRY_POINT_GROUP, [])
+
+        for ep in group:
+            self._load_entry_point(ep)
+
+    def _load_entry_point(self, ep: importlib.metadata.EntryPoint) -> None:
+        ep_str = f"{ep.value}"
+        try:
+            cls = ep.load()
+            self._register_class(cls, ep_str)
+        except Exception as exc:  # noqa: BLE001
+            name = ep.name
+            err = f"Failed to load plugin '{name}': {exc}"
+            logger.warning(err)
+            self._errors[name] = err
+            self._entry_points[name] = ep_str
+
+    def _register_class(self, cls: type, ep_str: str) -> None:
+        """Instantiate and validate a plugin class."""
+        if not (isinstance(cls, type) and issubclass(cls, PluginSpec)):
+            raise TypeError(
+                f"{cls!r} does not subclass PluginSpec"
+            )
+        instance = cls()
+        meta = instance.metadata()
+        if not isinstance(meta, PluginMetadata):
+            raise TypeError(
+                f"metadata() must return PluginMetadata, got {type(meta)!r}"
+            )
+        name = meta.name
+        if name in self._plugins:
+            logger.warning("Duplicate plugin name '%s' — skipping", name)
+            return
+        self._plugins[name] = instance
+        self._entry_points[name] = ep_str
+
+    # -- manual registration (for testing / embedded use) -------------------
+
+    def register(self, plugin: PluginSpec) -> None:
+        """Manually register a plugin instance."""
+        meta = plugin.metadata()
+        if not isinstance(meta, PluginMetadata):
+            raise TypeError("metadata() must return PluginMetadata")
+        name = meta.name
+        if name in self._plugins:
+            logger.warning("Duplicate plugin name '%s' — skipping", name)
+            return
+        self._plugins[name] = plugin
+        self._entry_points[name] = "(manual)"
+
+    # -- queries ------------------------------------------------------------
+
+    def get_plugin(self, name: str) -> Optional[PluginSpec]:
+        """Return a loaded plugin by name, or ``None``."""
+        return self._plugins.get(name)
+
+    def list_plugins(self) -> PluginListReport:
+        """Return a report of all discovered plugins."""
+        infos: List[PluginInfo] = []
+
+        for name, instance in self._plugins.items():
+            meta = instance.metadata()
+            infos.append(
+                PluginInfo(
+                    name=meta.name,
+                    version=meta.version,
+                    description=meta.description,
+                    author=meta.author,
+                    plugin_type=meta.plugin_type,
+                    entry_point=self._entry_points.get(name, ""),
+                    loaded=True,
+                )
+            )
+
+        for name, err in self._errors.items():
+            if name not in self._plugins:
+                infos.append(
+                    PluginInfo(
+                        name=name,
+                        version="?",
+                        description="",
+                        author="",
+                        plugin_type=PluginType.GENERAL,
+                        entry_point=self._entry_points.get(name, ""),
+                        loaded=False,
+                        error=err,
+                    )
+                )
+
+        return PluginListReport(
+            plugins=infos,
+            total=len(infos),
+            loaded=len(self._plugins),
+            failed=len([i for i in infos if not i.loaded]),
+        )
+
+    def register_all_cli(self, subparsers: Any) -> None:
+        """Let every loaded plugin register its CLI subcommands."""
+        for instance in self._plugins.values():
+            try:
+                instance.register_cli(subparsers)
+            except Exception as exc:  # noqa: BLE001
+                meta = instance.metadata()
+                logger.warning(
+                    "Plugin '%s' failed to register CLI: %s", meta.name, exc
+                )
+
+    @property
+    def names(self) -> List[str]:
+        """Names of all loaded plugins."""
+        return list(self._plugins.keys())
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience
+# ---------------------------------------------------------------------------
+
+_default_registry: Optional[PluginRegistry] = None
+
+
+def get_registry() -> PluginRegistry:
+    """Return (and lazily create) the default global plugin registry."""
+    global _default_registry  # noqa: PLW0603
+    if _default_registry is None:
+        _default_registry = PluginRegistry()
+        _default_registry.discover()
+    return _default_registry
+
+
+def list_plugins() -> PluginListReport:
+    """List all discovered plugins (convenience wrapper)."""
+    return get_registry().list_plugins()
+
+
+def get_plugin(name: str) -> Optional[PluginSpec]:
+    """Get a plugin by name (convenience wrapper)."""
+    return get_registry().get_plugin(name)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,326 @@
+"""Tests for plugin architecture (M52)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from xpyd_plan.plugin import (
+    PluginInfo,
+    PluginListReport,
+    PluginMetadata,
+    PluginRegistry,
+    PluginSpec,
+    PluginType,
+    get_plugin,
+    get_registry,
+    list_plugins,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: sample plugins
+# ---------------------------------------------------------------------------
+
+class _GoodPlugin(PluginSpec):
+    @staticmethod
+    def metadata() -> PluginMetadata:
+        return PluginMetadata(
+            name="good-plugin",
+            version="1.0.0",
+            description="A well-behaved plugin",
+            author="tester",
+            plugin_type=PluginType.ANALYZER,
+        )
+
+    def analyze(self, data: dict) -> dict:
+        return {"doubled": data.get("value", 0) * 2}
+
+
+class _ExporterPlugin(PluginSpec):
+    @staticmethod
+    def metadata() -> PluginMetadata:
+        return PluginMetadata(
+            name="exporter-plugin",
+            version="0.5.0",
+            description="Exports stuff",
+            author="exporter-dev",
+            plugin_type=PluginType.EXPORTER,
+        )
+
+
+class _CLIPlugin(PluginSpec):
+    """Plugin that registers a CLI subcommand."""
+
+    registered = False
+
+    @staticmethod
+    def metadata() -> PluginMetadata:
+        return PluginMetadata(name="cli-plugin", version="2.0.0")
+
+    def register_cli(self, subparsers):
+        _CLIPlugin.registered = True
+        subparsers.add_parser("my-custom-cmd", help="custom")
+
+
+class _BadMetadataPlugin(PluginSpec):
+    @staticmethod
+    def metadata():
+        return "not-a-PluginMetadata"
+
+
+class _DuplicatePlugin(PluginSpec):
+    @staticmethod
+    def metadata() -> PluginMetadata:
+        return PluginMetadata(name="good-plugin", version="9.9.9")
+
+
+# ---------------------------------------------------------------------------
+# PluginMetadata
+# ---------------------------------------------------------------------------
+
+class TestPluginMetadata:
+    def test_defaults(self):
+        m = PluginMetadata(name="x")
+        assert m.version == "0.0.0"
+        assert m.description == ""
+        assert m.author == ""
+        assert m.plugin_type == PluginType.GENERAL
+
+    def test_full(self):
+        m = PluginMetadata(
+            name="foo",
+            version="1.2.3",
+            description="desc",
+            author="me",
+            plugin_type=PluginType.ANALYZER,
+        )
+        assert m.name == "foo"
+        assert m.plugin_type == PluginType.ANALYZER
+
+
+# ---------------------------------------------------------------------------
+# PluginSpec ABC
+# ---------------------------------------------------------------------------
+
+class TestPluginSpec:
+    def test_good_plugin_metadata(self):
+        p = _GoodPlugin()
+        m = p.metadata()
+        assert m.name == "good-plugin"
+        assert m.version == "1.0.0"
+
+    def test_analyze_default_returns_empty(self):
+        p = _ExporterPlugin()
+        assert p.analyze({}) == {}
+
+    def test_analyze_override(self):
+        p = _GoodPlugin()
+        assert p.analyze({"value": 5}) == {"doubled": 10}
+
+    def test_register_cli_default_is_noop(self):
+        p = _GoodPlugin()
+        assert p.register_cli(None) is None
+
+
+# ---------------------------------------------------------------------------
+# PluginRegistry
+# ---------------------------------------------------------------------------
+
+class TestPluginRegistry:
+    def test_register_and_get(self):
+        reg = PluginRegistry()
+        reg.register(_GoodPlugin())
+        assert reg.get_plugin("good-plugin") is not None
+        assert reg.get_plugin("nonexistent") is None
+
+    def test_names(self):
+        reg = PluginRegistry()
+        reg.register(_GoodPlugin())
+        reg.register(_ExporterPlugin())
+        assert set(reg.names) == {"good-plugin", "exporter-plugin"}
+
+    def test_duplicate_skipped(self):
+        reg = PluginRegistry()
+        reg.register(_GoodPlugin())
+        reg.register(_DuplicatePlugin())
+        p = reg.get_plugin("good-plugin")
+        assert p.metadata().version == "1.0.0"  # first one wins
+
+    def test_bad_metadata_raises(self):
+        reg = PluginRegistry()
+        with pytest.raises(TypeError, match="PluginMetadata"):
+            reg.register(_BadMetadataPlugin())
+
+    def test_list_plugins_empty(self):
+        reg = PluginRegistry()
+        report = reg.list_plugins()
+        assert report.total == 0
+        assert report.loaded == 0
+        assert report.failed == 0
+        assert report.plugins == []
+
+    def test_list_plugins_with_loaded(self):
+        reg = PluginRegistry()
+        reg.register(_GoodPlugin())
+        reg.register(_ExporterPlugin())
+        report = reg.list_plugins()
+        assert report.total == 2
+        assert report.loaded == 2
+        assert report.failed == 0
+        names = {p.name for p in report.plugins}
+        assert names == {"good-plugin", "exporter-plugin"}
+
+    def test_list_plugins_shows_errors(self):
+        reg = PluginRegistry()
+        reg._errors["broken"] = "some error"
+        reg._entry_points["broken"] = "pkg:Cls"
+        report = reg.list_plugins()
+        assert report.total == 1
+        assert report.failed == 1
+        assert report.plugins[0].loaded is False
+        assert report.plugins[0].error == "some error"
+
+    def test_register_all_cli(self):
+        reg = PluginRegistry()
+        _CLIPlugin.registered = False
+        reg.register(_CLIPlugin())
+        parser = argparse.ArgumentParser()
+        subs = parser.add_subparsers()
+        reg.register_all_cli(subs)
+        assert _CLIPlugin.registered
+
+    def test_register_non_plugin_raises(self):
+        reg = PluginRegistry()
+
+        class NotAPlugin:
+            pass
+
+        with pytest.raises(TypeError, match="PluginSpec"):
+            reg._register_class(NotAPlugin, "test:NotAPlugin")
+
+    def test_discover_with_mocked_entry_points(self):
+        """Test that discover() loads entry points from the correct group."""
+        reg = PluginRegistry()
+        mock_ep = MagicMock()
+        mock_ep.name = "good-plugin"
+        mock_ep.value = "test_module:_GoodPlugin"
+        mock_ep.load.return_value = _GoodPlugin
+
+        with patch("xpyd_plan.plugin.importlib.metadata.entry_points") as mock_eps:
+            mock_result = MagicMock()
+            mock_result.select.return_value = [mock_ep]
+            mock_eps.return_value = mock_result
+            reg.discover()
+
+        assert "good-plugin" in reg.names
+
+    def test_discover_handles_load_failure(self):
+        reg = PluginRegistry()
+        mock_ep = MagicMock()
+        mock_ep.name = "broken-plugin"
+        mock_ep.value = "bad:Plugin"
+        mock_ep.load.side_effect = ImportError("no such module")
+
+        with patch("xpyd_plan.plugin.importlib.metadata.entry_points") as mock_eps:
+            mock_result = MagicMock()
+            mock_result.select.return_value = [mock_ep]
+            mock_eps.return_value = mock_result
+            reg.discover()
+
+        assert "broken-plugin" not in reg.names
+        report = reg.list_plugins()
+        assert report.failed == 1
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience functions
+# ---------------------------------------------------------------------------
+
+class TestConvenienceFunctions:
+    def test_list_plugins_returns_report(self):
+        import xpyd_plan.plugin as mod
+
+        old = mod._default_registry
+        try:
+            mod._default_registry = None
+            with patch("xpyd_plan.plugin.importlib.metadata.entry_points") as mock_eps:
+                mock_result = MagicMock()
+                mock_result.select.return_value = []
+                mock_eps.return_value = mock_result
+                report = list_plugins()
+            assert isinstance(report, PluginListReport)
+            assert report.total == 0
+        finally:
+            mod._default_registry = old
+
+    def test_get_plugin_returns_none_for_missing(self):
+        import xpyd_plan.plugin as mod
+
+        old = mod._default_registry
+        try:
+            mod._default_registry = None
+            with patch("xpyd_plan.plugin.importlib.metadata.entry_points") as mock_eps:
+                mock_result = MagicMock()
+                mock_result.select.return_value = []
+                mock_eps.return_value = mock_result
+                assert get_plugin("nope") is None
+        finally:
+            mod._default_registry = old
+
+    def test_get_registry_caches(self):
+        import xpyd_plan.plugin as mod
+
+        old = mod._default_registry
+        try:
+            mod._default_registry = None
+            with patch("xpyd_plan.plugin.importlib.metadata.entry_points") as mock_eps:
+                mock_result = MagicMock()
+                mock_result.select.return_value = []
+                mock_eps.return_value = mock_result
+                r1 = get_registry()
+                r2 = get_registry()
+            assert r1 is r2
+        finally:
+            mod._default_registry = old
+
+
+# ---------------------------------------------------------------------------
+# PluginInfo / PluginListReport models
+# ---------------------------------------------------------------------------
+
+class TestModels:
+    def test_plugin_info_defaults(self):
+        info = PluginInfo(
+            name="x", version="1", description="", author="",
+            plugin_type=PluginType.GENERAL,
+        )
+        assert info.loaded is False
+        assert info.error is None
+
+    def test_plugin_list_report_json_roundtrip(self):
+        report = PluginListReport(
+            plugins=[
+                PluginInfo(
+                    name="a",
+                    version="1.0",
+                    description="test",
+                    author="dev",
+                    plugin_type=PluginType.ANALYZER,
+                    loaded=True,
+                )
+            ],
+            total=1,
+            loaded=1,
+            failed=0,
+        )
+        data = json.loads(report.model_dump_json())
+        assert data["total"] == 1
+        assert data["plugins"][0]["name"] == "a"
+
+    def test_plugin_type_values(self):
+        assert PluginType.ANALYZER.value == "analyzer"
+        assert PluginType.EXPORTER.value == "exporter"
+        assert PluginType.GENERAL.value == "general"


### PR DESCRIPTION
## Summary

Implement a plugin architecture for xPyD-plan using Python entry points (`xpyd_plan.plugins`), enabling third-party packages to register custom analyzers and CLI subcommands.

## Changes

- **`plugin.py`**: Core module with `PluginSpec` ABC, `PluginMetadata`/`PluginInfo`/`PluginListReport` Pydantic models, `PluginRegistry` for discovery and management
- **`cli/_plugins.py`**: `plugins` CLI subcommand (table + JSON output)
- **`cli/_main.py`**: Wire plugins subcommand + let plugins register their own CLI commands
- **`__init__.py`**: Export all plugin public API
- **`tests/test_plugin.py`**: 23 new tests

## Plugin Author Workflow

1. Subclass `PluginSpec`, implement `metadata()` and optionally `analyze()`/`register_cli()`
2. Register as entry point in `pyproject.toml`:
   ```toml
   [project.entry-points."xpyd_plan.plugins"]
   my_plugin = "my_package:MyPlugin"
   ```
3. Install the package — xPyD-plan auto-discovers it

## Test Results

- 23 new tests, 1187 total, all passing
- Lint clean (ruff + isort)

Closes #121