### PR TITLE
fix: M54 — Fix Pre-Existing CLI Bugs (scorecard, pareto, threshold-advisor)

### DIFF
--- a/src/xpyd_plan/cli/_pareto.py
+++ b/src/xpyd_plan/cli/_pareto.py
@@ -31,7 +31,8 @@ def _cmd_pareto(args: argparse.Namespace) -> None:
     )
     total = args.total_instances or data.metadata.total_instances
 
-    analyzer = BenchmarkAnalyzer(data)
+    analyzer = BenchmarkAnalyzer()
+    analyzer._data = data
     analysis = analyzer.find_optimal_ratio(total, sla)
     measured_qps = data.metadata.measured_qps
 

--- a/src/xpyd_plan/cli/_scorecard.py
+++ b/src/xpyd_plan/cli/_scorecard.py
@@ -28,7 +28,8 @@ def _cmd_scorecard(args: argparse.Namespace) -> None:
 
     analyzer = BenchmarkAnalyzer()
     analyzer._data = data
-    analysis = analyzer.find_optimal_ratio(sla)
+    total_instances = data.metadata.total_instances
+    analysis = analyzer.find_optimal_ratio(total_instances, sla)
 
     calc = ScorecardCalculator(
         sla_weight=args.sla_weight,

--- a/src/xpyd_plan/cli/_threshold_advisor.py
+++ b/src/xpyd_plan/cli/_threshold_advisor.py
@@ -17,7 +17,11 @@ def _cmd_threshold_advisor(args: argparse.Namespace) -> None:
     """Handle the 'threshold-advisor' subcommand."""
     console = Console()
 
-    analyzer = BenchmarkAnalyzer(args.benchmark)
+    from xpyd_plan.bench_adapter import load_benchmark_auto
+
+    data = load_benchmark_auto(args.benchmark)
+    analyzer = BenchmarkAnalyzer()
+    analyzer._data = data
     data = analyzer.data
 
     pass_rates = [float(x) for x in args.pass_rates.split(",")]

--- a/tests/test_e2e_integration.py
+++ b/tests/test_e2e_integration.py
@@ -304,7 +304,6 @@ class TestTailE2E:
 
 
 class TestScorecardE2E:
-    @pytest.mark.xfail(reason="Pre-existing bug: scorecard CLI missing total_instances arg")
     def test_scorecard(self, single_benchmark: Path):
         _run(["scorecard", "--benchmark", str(single_benchmark),
               "--sla-ttft", "5000", "--sla-tpot", "500"])
@@ -348,7 +347,6 @@ class TestPlanBenchmarksE2E:
 
 
 class TestThresholdAdvisorE2E:
-    @pytest.mark.xfail(reason="Pre-existing bug: threshold-advisor CLI")
     def test_threshold_advisor(self, single_benchmark: Path):
         _run(["threshold-advisor", "--benchmark", str(single_benchmark)])
 
@@ -382,7 +380,6 @@ class TestInterpolateE2E:
 
 
 class TestParetoE2E:
-    @pytest.mark.xfail(reason="Pre-existing bug: pareto CLI passes data to BenchmarkAnalyzer")
     def test_pareto(self, single_benchmark: Path):
         _run(["pareto", "--benchmark", str(single_benchmark),
               "--sla-ttft", "5000", "--sla-tpot", "500"])


### PR DESCRIPTION
## Summary

Fix 3 pre-existing CLI bugs discovered by M53 E2E integration tests.

## Changes

- **scorecard**: Add missing `total_instances` argument to `find_optimal_ratio()` call
- **pareto**: Use `analyzer._data = data` instead of passing `data` to `BenchmarkAnalyzer()` constructor
- **threshold-advisor**: Load data via `load_benchmark_auto()` before creating `BenchmarkAnalyzer()`
- Remove 3 `xfail` markers from integration tests

## Test Results

```
1244 passed in 29.59s
```

All tests pass with 0 xfail.

Closes #125