### PR TITLE
feat: M55 Request Fairness Analysis

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -711,3 +711,15 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Fix `threshold-advisor` subcommand: load data via `load_benchmark_auto()` first
 - Convert 3 xfail integration tests to passing
 - 1244 passed, 0 xfail
+
+### M55 Request Fairness Analysis
+
+- `FairnessAnalyzer` class in `fairness.py`
+- `FairnessReport`, `BucketStats`, `FairnessIndex`, `FairnessClassification` Pydantic models
+- Bucket requests by prompt_tokens into configurable quantile-based bins (default 4)
+- Per-bucket P50/P95 latency stats for TTFT, TPOT, total_latency
+- Jain's fairness index (J = (Σxi)² / (n·Σxi²)) computed on per-bucket P95 latencies
+- Fairness classification: FAIR (J≥0.9), MODERATE (0.7-0.9), UNFAIR (<0.7)
+- CLI `fairness` subcommand with `--benchmark`, `--buckets`, table + JSON output
+- Programmatic `analyze_fairness()` API
+- 26 new tests (1270 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -98,6 +98,14 @@ from xpyd_plan.drift import (
     DriftSeverity,
     detect_drift,
 )
+from xpyd_plan.fairness import (
+    BucketStats,
+    FairnessAnalyzer,
+    FairnessClassification,
+    FairnessIndex,
+    FairnessReport,
+    analyze_fairness,
+)
 from xpyd_plan.filter import (
     BenchmarkFilter,
     BenchmarkFilterResult,
@@ -458,6 +466,12 @@ __all__ = [
     "CorrelationReport",
     "CorrelationStrength",
     "analyze_correlation",
+    "BucketStats",
+    "FairnessAnalyzer",
+    "FairnessClassification",
+    "FairnessIndex",
+    "FairnessReport",
+    "analyze_fairness",
     "DriftDetector",
     "DriftReport",
     "DriftResult",

--- a/src/xpyd_plan/cli/_fairness.py
+++ b/src/xpyd_plan/cli/_fairness.py
@@ -1,0 +1,108 @@
+"""CLI fairness command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.fairness import FairnessAnalyzer, FairnessClassification
+
+
+def _cmd_fairness(args: argparse.Namespace) -> None:
+    """Handle the 'fairness' subcommand."""
+    console = Console()
+
+    data = load_benchmark_auto(args.benchmark)
+    analyzer = FairnessAnalyzer()
+    report = analyzer.analyze(data, num_buckets=args.buckets)
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Bucket stats table
+    table = Table(title="Request Fairness Analysis — Bucket Stats")
+    table.add_column("Bucket", justify="center")
+    table.add_column("Token Range", justify="center")
+    table.add_column("Requests", justify="right")
+    table.add_column("TTFT P95", justify="right")
+    table.add_column("TPOT P95", justify="right")
+    table.add_column("Total P95", justify="right")
+
+    for b in report.buckets:
+        table.add_row(
+            str(b.bucket_index),
+            f"{b.min_tokens}–{b.max_tokens}",
+            str(b.request_count),
+            f"{b.ttft_p95_ms:.1f}",
+            f"{b.tpot_p95_ms:.1f}",
+            f"{b.total_latency_p95_ms:.1f}",
+        )
+
+    console.print(table)
+    console.print()
+
+    # Fairness indices table
+    fi_table = Table(title="Jain's Fairness Index")
+    fi_table.add_column("Metric", justify="left")
+    fi_table.add_column("Jain's Index", justify="right")
+    fi_table.add_column("Classification", justify="center")
+
+    for fi in report.fairness_indices:
+        style = {
+            FairnessClassification.FAIR: "green",
+            FairnessClassification.MODERATE: "yellow",
+            FairnessClassification.UNFAIR: "bold red",
+        }[fi.classification]
+        fi_table.add_row(
+            fi.metric,
+            f"[{style}]{fi.jain_index:.4f}[/{style}]",
+            f"[{style}]{fi.classification.value}[/{style}]",
+        )
+
+    console.print(fi_table)
+    console.print()
+    style_map = {
+        FairnessClassification.FAIR: "green",
+        FairnessClassification.MODERATE: "yellow",
+        FairnessClassification.UNFAIR: "bold red",
+    }
+    overall_style = style_map[report.overall_classification]
+    console.print(
+        f"Overall: [{overall_style}]"
+        f"{report.overall_classification.value}[/]"
+    )
+    console.print(f"[bold]{report.recommendation}[/bold]")
+
+
+def add_fairness_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the fairness subcommand parser."""
+    parser = subparsers.add_parser(
+        "fairness",
+        help="Analyze latency fairness across request token-count buckets",
+    )
+    parser.add_argument(
+        "--benchmark",
+        required=True,
+        help="Path to benchmark JSON file",
+    )
+    parser.add_argument(
+        "--buckets",
+        type=int,
+        default=4,
+        help="Number of quantile-based buckets (default: 4)",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_fairness)

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -20,6 +20,7 @@ from xpyd_plan.cli._decompose import _cmd_decompose, add_decompose_parser
 from xpyd_plan.cli._discover import _cmd_discover, add_discover_parser
 from xpyd_plan.cli._drift import _cmd_drift, add_drift_parser
 from xpyd_plan.cli._export import _cmd_export
+from xpyd_plan.cli._fairness import _cmd_fairness, add_fairness_parser
 from xpyd_plan.cli._filter import _cmd_filter
 from xpyd_plan.cli._fleet import _cmd_fleet
 from xpyd_plan.cli._forecast import add_forecast_parser
@@ -872,6 +873,9 @@ def main(argv: list[str] | None = None) -> None:
     # --- correlation subcommand ---
     add_correlation_parser(subparsers)
 
+    # --- fairness subcommand ---
+    add_fairness_parser(subparsers)
+
     # --- timeline subcommand ---
     add_timeline_parser(subparsers)
 
@@ -977,6 +981,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_metrics(args)
     elif args.command == "correlation":
         _cmd_correlation(args)
+    elif args.command == "fairness":
+        _cmd_fairness(args)
     elif args.command == "timeline":
         _cmd_timeline(args)
     elif args.command == "drift":

--- a/src/xpyd_plan/fairness.py
+++ b/src/xpyd_plan/fairness.py
@@ -1,0 +1,253 @@
+"""Request fairness analysis across token-count buckets."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData
+
+
+class FairnessClassification(str, Enum):
+    """Classification of fairness based on Jain's index."""
+
+    FAIR = "fair"          # J >= 0.9
+    MODERATE = "moderate"  # 0.7 <= J < 0.9
+    UNFAIR = "unfair"      # J < 0.7
+
+
+class BucketStats(BaseModel):
+    """Latency statistics for a single token-count bucket."""
+
+    bucket_index: int = Field(..., ge=0, description="Bucket index (0-based)")
+    min_tokens: int = Field(..., ge=0, description="Lower bound of token range (inclusive)")
+    max_tokens: int = Field(..., description="Upper bound of token range (inclusive)")
+    request_count: int = Field(..., ge=0, description="Number of requests in this bucket")
+    ttft_p50_ms: float = Field(..., ge=0)
+    ttft_p95_ms: float = Field(..., ge=0)
+    tpot_p50_ms: float = Field(..., ge=0)
+    tpot_p95_ms: float = Field(..., ge=0)
+    total_latency_p50_ms: float = Field(..., ge=0)
+    total_latency_p95_ms: float = Field(..., ge=0)
+
+
+class FairnessIndex(BaseModel):
+    """Jain's fairness index for a specific latency metric."""
+
+    metric: str = Field(..., description="Latency metric name")
+    jain_index: float = Field(..., ge=0, le=1, description="Jain's fairness index")
+    classification: FairnessClassification = Field(
+        ..., description="Fairness classification"
+    )
+
+
+class FairnessReport(BaseModel):
+    """Complete fairness analysis report."""
+
+    buckets: list[BucketStats] = Field(..., description="Per-bucket latency stats")
+    num_buckets: int = Field(..., ge=1, description="Number of buckets used")
+    fairness_indices: list[FairnessIndex] = Field(
+        ..., description="Jain's index per latency metric"
+    )
+    overall_classification: FairnessClassification = Field(
+        ..., description="Worst-case classification across all metrics"
+    )
+    recommendation: str = Field(..., description="Human-readable summary")
+
+
+def _classify_fairness(j: float) -> FairnessClassification:
+    """Classify fairness from Jain's index value."""
+    if j >= 0.9:
+        return FairnessClassification.FAIR
+    if j >= 0.7:
+        return FairnessClassification.MODERATE
+    return FairnessClassification.UNFAIR
+
+
+def _jain_index(values: list[float]) -> float:
+    """Compute Jain's fairness index: J = (sum(x))^2 / (n * sum(x^2)).
+
+    Returns 1.0 for empty or single-element lists.
+    Returns 1.0 if all values are zero.
+    """
+    n = len(values)
+    if n <= 1:
+        return 1.0
+    s = sum(values)
+    s2 = sum(x * x for x in values)
+    if s2 == 0:
+        return 1.0
+    return (s * s) / (n * s2)
+
+
+class FairnessAnalyzer:
+    """Analyze latency fairness across request token-count buckets."""
+
+    def analyze(
+        self,
+        data: BenchmarkData,
+        num_buckets: int = 4,
+    ) -> FairnessReport:
+        """Bucket requests by prompt_tokens and compute fairness indices.
+
+        Args:
+            data: Benchmark data to analyze.
+            num_buckets: Number of quantile-based buckets (default 4).
+
+        Returns:
+            FairnessReport with per-bucket stats and Jain's indices.
+
+        Raises:
+            ValueError: If fewer than num_buckets requests or num_buckets < 2.
+        """
+        if num_buckets < 2:
+            raise ValueError("num_buckets must be at least 2")
+        if len(data.requests) < num_buckets:
+            raise ValueError(
+                f"Need at least {num_buckets} requests, got {len(data.requests)}"
+            )
+
+        # Compute quantile boundaries for prompt_tokens
+        prompt_tokens = np.array([r.prompt_tokens for r in data.requests])
+        quantiles = np.quantile(
+            prompt_tokens,
+            np.linspace(0, 1, num_buckets + 1),
+        )
+        # Ensure unique boundaries
+        boundaries = sorted(set(quantiles))
+        if len(boundaries) < 2:
+            # All same token count — one bucket
+            boundaries = [float(prompt_tokens.min()), float(prompt_tokens.max())]
+
+        # Assign requests to buckets
+        actual_num_buckets = len(boundaries) - 1
+        bucket_requests: list[list[int]] = [[] for _ in range(actual_num_buckets)]
+        for i, r in enumerate(data.requests):
+            for b in range(actual_num_buckets):
+                lo = boundaries[b]
+                hi = boundaries[b + 1]
+                if b == actual_num_buckets - 1:
+                    # Last bucket: inclusive on both ends
+                    if lo <= r.prompt_tokens <= hi:
+                        bucket_requests[b].append(i)
+                        break
+                else:
+                    if lo <= r.prompt_tokens < hi:
+                        bucket_requests[b].append(i)
+                        break
+
+        # Compute per-bucket stats
+        buckets: list[BucketStats] = []
+        for b in range(actual_num_buckets):
+            indices = bucket_requests[b]
+            if not indices:
+                buckets.append(
+                    BucketStats(
+                        bucket_index=b,
+                        min_tokens=int(boundaries[b]),
+                        max_tokens=int(boundaries[b + 1]),
+                        request_count=0,
+                        ttft_p50_ms=0.0,
+                        ttft_p95_ms=0.0,
+                        tpot_p50_ms=0.0,
+                        tpot_p95_ms=0.0,
+                        total_latency_p50_ms=0.0,
+                        total_latency_p95_ms=0.0,
+                    )
+                )
+                continue
+
+            reqs = [data.requests[i] for i in indices]
+            ttft = np.array([r.ttft_ms for r in reqs])
+            tpot = np.array([r.tpot_ms for r in reqs])
+            total = np.array([r.total_latency_ms for r in reqs])
+
+            buckets.append(
+                BucketStats(
+                    bucket_index=b,
+                    min_tokens=int(boundaries[b]),
+                    max_tokens=int(boundaries[b + 1]),
+                    request_count=len(indices),
+                    ttft_p50_ms=round(float(np.percentile(ttft, 50)), 3),
+                    ttft_p95_ms=round(float(np.percentile(ttft, 95)), 3),
+                    tpot_p50_ms=round(float(np.percentile(tpot, 50)), 3),
+                    tpot_p95_ms=round(float(np.percentile(tpot, 95)), 3),
+                    total_latency_p50_ms=round(float(np.percentile(total, 50)), 3),
+                    total_latency_p95_ms=round(float(np.percentile(total, 95)), 3),
+                )
+            )
+
+        # Compute Jain's fairness index on P95 latencies per bucket (non-empty only)
+        non_empty = [b for b in buckets if b.request_count > 0]
+
+        metrics = [
+            ("ttft_p95", [b.ttft_p95_ms for b in non_empty]),
+            ("tpot_p95", [b.tpot_p95_ms for b in non_empty]),
+            ("total_latency_p95", [b.total_latency_p95_ms for b in non_empty]),
+        ]
+
+        fairness_indices: list[FairnessIndex] = []
+        for name, values in metrics:
+            j = round(_jain_index(values), 6)
+            fairness_indices.append(
+                FairnessIndex(
+                    metric=name,
+                    jain_index=j,
+                    classification=_classify_fairness(j),
+                )
+            )
+
+        # Overall = worst case
+        worst_j = min(fi.jain_index for fi in fairness_indices)
+        overall = _classify_fairness(worst_j)
+
+        # Recommendation
+        if overall == FairnessClassification.FAIR:
+            recommendation = (
+                "Latency is fairly distributed across request token-count buckets. "
+                "No action needed."
+            )
+        elif overall == FairnessClassification.MODERATE:
+            unfair_metrics = [
+                fi.metric for fi in fairness_indices
+                if fi.classification != FairnessClassification.FAIR
+            ]
+            recommendation = (
+                f"Moderate fairness gap detected in: {', '.join(unfair_metrics)}. "
+                f"Some request sizes may experience disproportionately higher latency."
+            )
+        else:
+            unfair_metrics = [
+                fi.metric for fi in fairness_indices
+                if fi.classification == FairnessClassification.UNFAIR
+            ]
+            recommendation = (
+                f"Significant unfairness in: {', '.join(unfair_metrics)}. "
+                f"Consider rebalancing P:D ratio or investigating token-size-dependent "
+                f"performance degradation."
+            )
+
+        return FairnessReport(
+            buckets=buckets,
+            num_buckets=actual_num_buckets,
+            fairness_indices=fairness_indices,
+            overall_classification=overall,
+            recommendation=recommendation,
+        )
+
+
+def analyze_fairness(data: BenchmarkData, num_buckets: int = 4) -> dict:
+    """Programmatic API for fairness analysis.
+
+    Args:
+        data: Benchmark data to analyze.
+        num_buckets: Number of quantile-based buckets.
+
+    Returns:
+        Dictionary representation of the FairnessReport.
+    """
+    analyzer = FairnessAnalyzer()
+    report = analyzer.analyze(data, num_buckets=num_buckets)
+    return report.model_dump()

--- a/tests/test_fairness.py
+++ b/tests/test_fairness.py
@@ -1,0 +1,315 @@
+"""Tests for fairness analysis."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.fairness import (
+    FairnessAnalyzer,
+    FairnessClassification,
+    FairnessReport,
+    _jain_index,
+    analyze_fairness,
+)
+
+
+def _make_data(
+    requests: list[dict] | None = None,
+    n: int = 100,
+) -> BenchmarkData:
+    """Build a BenchmarkData with custom or generated requests."""
+    if requests is not None:
+        reqs = [BenchmarkRequest(**r) for r in requests]
+    else:
+        # Generate requests with varying prompt_tokens and latency correlated to tokens
+        reqs = []
+        for i in range(n):
+            pt = 50 + i * 10  # 50..1040
+            reqs.append(
+                BenchmarkRequest(
+                    request_id=f"r{i}",
+                    prompt_tokens=pt,
+                    output_tokens=50,
+                    ttft_ms=10.0 + pt * 0.05,
+                    tpot_ms=5.0 + pt * 0.01,
+                    total_latency_ms=100.0 + pt * 0.1,
+                    timestamp=1000.0 + i,
+                )
+            )
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=2,
+            total_instances=4,
+            measured_qps=10.0,
+        ),
+        requests=reqs,
+    )
+
+
+def _make_uniform_data(n: int = 100) -> BenchmarkData:
+    """All requests have same latency — perfectly fair."""
+    reqs = [
+        BenchmarkRequest(
+            request_id=f"r{i}",
+            prompt_tokens=50 + i * 10,
+            output_tokens=50,
+            ttft_ms=10.0,
+            tpot_ms=5.0,
+            total_latency_ms=100.0,
+            timestamp=1000.0 + i,
+        )
+        for i in range(n)
+    ]
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=2,
+            total_instances=4,
+            measured_qps=10.0,
+        ),
+        requests=reqs,
+    )
+
+
+def _make_unfair_data(n: int = 100) -> BenchmarkData:
+    """Long prompts have drastically worse latency."""
+    reqs = []
+    for i in range(n):
+        pt = 50 + i * 10
+        factor = 1.0 if pt < 500 else 10.0  # step change
+        reqs.append(
+            BenchmarkRequest(
+                request_id=f"r{i}",
+                prompt_tokens=pt,
+                output_tokens=50,
+                ttft_ms=10.0 * factor,
+                tpot_ms=5.0 * factor,
+                total_latency_ms=100.0 * factor,
+                timestamp=1000.0 + i,
+            )
+        )
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=2,
+            total_instances=4,
+            measured_qps=10.0,
+        ),
+        requests=reqs,
+    )
+
+
+class TestJainIndex:
+    def test_equal_values(self):
+        assert _jain_index([5.0, 5.0, 5.0]) == 1.0
+
+    def test_single_value(self):
+        assert _jain_index([42.0]) == 1.0
+
+    def test_empty(self):
+        assert _jain_index([]) == 1.0
+
+    def test_all_zero(self):
+        assert _jain_index([0.0, 0.0]) == 1.0
+
+    def test_two_values(self):
+        # J = (1+2)^2 / (2*(1+4)) = 9/10 = 0.9
+        assert abs(_jain_index([1.0, 2.0]) - 0.9) < 1e-6
+
+    def test_very_unfair(self):
+        # [1, 100] -> J = 101^2 / (2*10001) = 10201/20002 ≈ 0.51
+        j = _jain_index([1.0, 100.0])
+        assert j < 0.7
+
+
+class TestFairnessAnalyzer:
+    def test_basic_analysis(self):
+        data = _make_data()
+        analyzer = FairnessAnalyzer()
+        report = analyzer.analyze(data, num_buckets=4)
+        assert isinstance(report, FairnessReport)
+        assert len(report.fairness_indices) == 3
+        assert all(0 <= fi.jain_index <= 1 for fi in report.fairness_indices)
+
+    def test_uniform_is_fair(self):
+        data = _make_uniform_data()
+        analyzer = FairnessAnalyzer()
+        report = analyzer.analyze(data, num_buckets=4)
+        assert report.overall_classification == FairnessClassification.FAIR
+
+    def test_unfair_data(self):
+        data = _make_unfair_data()
+        analyzer = FairnessAnalyzer()
+        report = analyzer.analyze(data, num_buckets=4)
+        assert report.overall_classification in (
+            FairnessClassification.MODERATE,
+            FairnessClassification.UNFAIR,
+        )
+
+    def test_bucket_count(self):
+        data = _make_data()
+        analyzer = FairnessAnalyzer()
+        report = analyzer.analyze(data, num_buckets=5)
+        # May have fewer buckets if quantiles collapse
+        assert report.num_buckets >= 1
+
+    def test_total_requests_match(self):
+        data = _make_data(n=80)
+        analyzer = FairnessAnalyzer()
+        report = analyzer.analyze(data, num_buckets=4)
+        total = sum(b.request_count for b in report.buckets)
+        assert total == 80
+
+    def test_too_few_requests(self):
+        data = _make_data(n=2)
+        analyzer = FairnessAnalyzer()
+        with pytest.raises(ValueError, match="Need at least"):
+            analyzer.analyze(data, num_buckets=4)
+
+    def test_num_buckets_too_small(self):
+        data = _make_data()
+        analyzer = FairnessAnalyzer()
+        with pytest.raises(ValueError, match="num_buckets must be at least 2"):
+            analyzer.analyze(data, num_buckets=1)
+
+    def test_same_prompt_tokens(self):
+        """All requests have same prompt_tokens — should still work."""
+        reqs = [
+            dict(
+                request_id=f"r{i}",
+                prompt_tokens=100,
+                output_tokens=50,
+                ttft_ms=10.0 + i,
+                tpot_ms=5.0,
+                total_latency_ms=100.0 + i,
+                timestamp=1000.0 + i,
+            )
+            for i in range(20)
+        ]
+        data = _make_data(requests=reqs)
+        analyzer = FairnessAnalyzer()
+        report = analyzer.analyze(data, num_buckets=4)
+        # Should collapse to 1 bucket
+        assert report.num_buckets == 1
+
+    def test_recommendation_text(self):
+        data = _make_uniform_data()
+        analyzer = FairnessAnalyzer()
+        report = analyzer.analyze(data, num_buckets=4)
+        assert "No action needed" in report.recommendation
+
+    def test_two_buckets(self):
+        data = _make_data()
+        analyzer = FairnessAnalyzer()
+        report = analyzer.analyze(data, num_buckets=2)
+        assert report.num_buckets >= 1
+
+
+class TestAnalyzeFairnessAPI:
+    def test_returns_dict(self):
+        data = _make_data()
+        result = analyze_fairness(data, num_buckets=4)
+        assert isinstance(result, dict)
+        assert "fairness_indices" in result
+        assert "buckets" in result
+        assert "overall_classification" in result
+
+    def test_default_buckets(self):
+        data = _make_data()
+        result = analyze_fairness(data)
+        assert isinstance(result, dict)
+
+
+class TestFairnessCLI:
+    def test_json_output(self):
+        data = _make_data()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write(data.model_dump_json())
+            f.flush()
+
+            result = subprocess.run(
+                [
+                    "xpyd-plan", "fairness",
+                    "--benchmark", f.name, "--output-format", "json",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0
+            output = json.loads(result.stdout)
+            assert "fairness_indices" in output
+
+    def test_table_output(self):
+        data = _make_data()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write(data.model_dump_json())
+            f.flush()
+
+            result = subprocess.run(
+                ["xpyd-plan", "fairness", "--benchmark", f.name],
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0
+            assert "Fairness" in result.stdout or "fairness" in result.stdout.lower()
+
+    def test_custom_buckets(self):
+        data = _make_data()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write(data.model_dump_json())
+            f.flush()
+
+            result = subprocess.run(
+                [
+                    "xpyd-plan", "fairness",
+                    "--benchmark", f.name,
+                    "--buckets", "3", "--output-format", "json",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0
+
+
+class TestFairnessClassifications:
+    def test_fair_threshold(self):
+        assert FairnessClassification.FAIR.value == "fair"
+
+    def test_moderate_threshold(self):
+        assert FairnessClassification.MODERATE.value == "moderate"
+
+    def test_unfair_threshold(self):
+        assert FairnessClassification.UNFAIR.value == "unfair"
+
+
+class TestEdgeCases:
+    def test_minimum_requests(self):
+        """Exactly num_buckets requests should work."""
+        reqs = [
+            dict(
+                request_id=f"r{i}",
+                prompt_tokens=50 + i * 100,
+                output_tokens=50,
+                ttft_ms=10.0,
+                tpot_ms=5.0,
+                total_latency_ms=100.0,
+                timestamp=1000.0 + i,
+            )
+            for i in range(4)
+        ]
+        data = _make_data(requests=reqs)
+        analyzer = FairnessAnalyzer()
+        report = analyzer.analyze(data, num_buckets=4)
+        assert report.num_buckets >= 1
+
+    def test_large_bucket_count(self):
+        data = _make_data(n=100)
+        analyzer = FairnessAnalyzer()
+        report = analyzer.analyze(data, num_buckets=10)
+        assert report.num_buckets >= 1


### PR DESCRIPTION
## Summary

Add request fairness analysis to quantify whether different request sizes (by prompt token count) experience equitable latency treatment.

## Changes

- `FairnessAnalyzer` class in `fairness.py` with Jain's fairness index computation
- `BucketStats`, `FairnessIndex`, `FairnessReport`, `FairnessClassification` Pydantic models
- Bucket requests by prompt_tokens into configurable quantile-based bins (default 4)
- Per-bucket P50/P95 latency stats for TTFT, TPOT, total_latency
- Jain's fairness index: J = (Σxi)² / (n·Σxi²) on per-bucket P95 latencies
- Fairness classification: FAIR (J≥0.9), MODERATE (0.7-0.9), UNFAIR (<0.7)
- CLI `fairness` subcommand with `--benchmark`, `--buckets`, table + JSON output
- Programmatic `analyze_fairness()` API
- 26 new tests (1270 total)

Closes #127