### PR TITLE
feat(summary): add benchmark quick summary subcommand (M56)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -725,3 +725,14 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `fairness` subcommand with `--benchmark`, `--buckets`, table + JSON output
 - Programmatic `analyze_fairness()` API
 - 26 new tests (1270 total)
+
+### M56 Benchmark Quick Summary
+
+- `SummaryGenerator` class in `summary.py`
+- `SummaryReport`, `TokenStats`, `LatencyOverview` Pydantic models
+- Compact overview: request count, duration, measured QPS, P:D ratio, instance counts
+- Token distribution stats (min, mean, P50, P95, max) for prompt and output tokens
+- Latency overview (min, mean, P50, P95, P99, max) for TTFT, TPOT, total latency
+- CLI `summary` subcommand with `--benchmark`, table + JSON output
+- Programmatic `summarize_benchmark()` API
+- 19 new tests (1289 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -548,3 +548,19 @@ __all__ = [
     "get_plugin",
     "get_registry",
 ]
+
+from xpyd_plan.summary import (  # noqa: E402
+    LatencyOverview,
+    SummaryGenerator,
+    SummaryReport,
+    TokenStats,
+    summarize_benchmark,
+)
+
+__all__ += [
+    "LatencyOverview",
+    "SummaryGenerator",
+    "SummaryReport",
+    "TokenStats",
+    "summarize_benchmark",
+]

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -39,6 +39,7 @@ from xpyd_plan.cli._saturation import _cmd_saturation, add_saturation_parser
 from xpyd_plan.cli._scaling import _cmd_scaling, add_scaling_parser
 from xpyd_plan.cli._scorecard import _cmd_scorecard, add_scorecard_parser
 from xpyd_plan.cli._sla_tier import add_sla_tier_parser
+from xpyd_plan.cli._summary import _cmd_summary, add_summary_parser
 from xpyd_plan.cli._tail import _cmd_tail, add_tail_parser
 from xpyd_plan.cli._threshold_advisor import _cmd_threshold_advisor, add_threshold_advisor_parser
 from xpyd_plan.cli._timeline import _cmd_timeline, add_timeline_parser
@@ -885,6 +886,9 @@ def main(argv: list[str] | None = None) -> None:
     # --- root-cause subcommand ---
     add_root_cause_parser(subparsers)
 
+    # --- summary subcommand ---
+    add_summary_parser(subparsers)
+
     # --- tail subcommand ---
     add_tail_parser(subparsers)
 
@@ -991,6 +995,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_root_cause(args)
     elif args.command == "tail":
         _cmd_tail(args)
+    elif args.command == "summary":
+        _cmd_summary(args)
     elif args.command == "scorecard":
         _cmd_scorecard(args)
     elif args.command == "discover":

--- a/src/xpyd_plan/cli/_summary.py
+++ b/src/xpyd_plan/cli/_summary.py
@@ -1,0 +1,109 @@
+"""CLI summary command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.summary import SummaryGenerator
+
+
+def _cmd_summary(args: argparse.Namespace) -> None:
+    """Handle the 'summary' subcommand."""
+    console = Console()
+
+    data = load_benchmark_auto(args.benchmark)
+    generator = SummaryGenerator(data)
+    report = generator.generate()
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Overview table
+    overview = Table(title="Benchmark Summary")
+    overview.add_column("Property", justify="left")
+    overview.add_column("Value", justify="right")
+
+    overview.add_row("Requests", str(report.request_count))
+    overview.add_row("Duration", f"{report.duration_seconds:.1f}s")
+    overview.add_row("Measured QPS", f"{report.measured_qps:.1f}")
+    overview.add_row("P:D Ratio", report.pd_ratio)
+    overview.add_row("Prefill Instances", str(report.num_prefill_instances))
+    overview.add_row("Decode Instances", str(report.num_decode_instances))
+
+    console.print(overview)
+
+    # Token stats table
+    token_table = Table(title="Token Distribution")
+    token_table.add_column("Metric", justify="left")
+    token_table.add_column("Min", justify="right")
+    token_table.add_column("Mean", justify="right")
+    token_table.add_column("P50", justify="right")
+    token_table.add_column("P95", justify="right")
+    token_table.add_column("Max", justify="right")
+
+    for name, stats in [("Prompt Tokens", report.prompt_tokens),
+                         ("Output Tokens", report.output_tokens)]:
+        token_table.add_row(
+            name,
+            str(stats.min),
+            f"{stats.mean:.1f}",
+            f"{stats.p50:.1f}",
+            f"{stats.p95:.1f}",
+            str(stats.max),
+        )
+
+    console.print(token_table)
+
+    # Latency table
+    lat_table = Table(title="Latency Overview")
+    lat_table.add_column("Metric", justify="left")
+    lat_table.add_column("Min", justify="right")
+    lat_table.add_column("Mean", justify="right")
+    lat_table.add_column("P50", justify="right")
+    lat_table.add_column("P95", justify="right")
+    lat_table.add_column("P99", justify="right")
+    lat_table.add_column("Max", justify="right")
+
+    for name, lat in [("TTFT", report.ttft),
+                       ("TPOT", report.tpot),
+                       ("Total Latency", report.total_latency)]:
+        lat_table.add_row(
+            name,
+            f"{lat.min_ms:.1f}",
+            f"{lat.mean_ms:.1f}",
+            f"{lat.p50_ms:.1f}",
+            f"{lat.p95_ms:.1f}",
+            f"{lat.p99_ms:.1f}",
+            f"{lat.max_ms:.1f}",
+        )
+
+    console.print(lat_table)
+
+
+def add_summary_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the summary subcommand parser."""
+    parser = subparsers.add_parser(
+        "summary",
+        help="Quick overview of a benchmark file (requests, tokens, latency stats)",
+    )
+    parser.add_argument(
+        "--benchmark",
+        required=True,
+        help="Path to benchmark JSON file",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_summary)

--- a/src/xpyd_plan/summary.py
+++ b/src/xpyd_plan/summary.py
@@ -1,0 +1,106 @@
+"""Benchmark quick summary statistics."""
+
+from __future__ import annotations
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from xpyd_plan.benchmark_models import BenchmarkData
+
+
+class TokenStats(BaseModel):
+    """Token distribution statistics."""
+
+    min: int = Field(..., description="Minimum token count")
+    max: int = Field(..., description="Maximum token count")
+    mean: float = Field(..., description="Mean token count")
+    p50: float = Field(..., description="Median token count")
+    p95: float = Field(..., description="P95 token count")
+
+
+class LatencyOverview(BaseModel):
+    """Latency distribution overview for a single metric."""
+
+    min_ms: float = Field(..., description="Minimum latency (ms)")
+    max_ms: float = Field(..., description="Maximum latency (ms)")
+    mean_ms: float = Field(..., description="Mean latency (ms)")
+    p50_ms: float = Field(..., description="P50 latency (ms)")
+    p95_ms: float = Field(..., description="P95 latency (ms)")
+    p99_ms: float = Field(..., description="P99 latency (ms)")
+
+
+class SummaryReport(BaseModel):
+    """Compact benchmark summary report."""
+
+    request_count: int = Field(..., description="Total number of requests")
+    duration_seconds: float = Field(..., description="Benchmark duration in seconds")
+    measured_qps: float = Field(..., description="Measured queries per second")
+    num_prefill_instances: int = Field(..., description="Prefill instance count")
+    num_decode_instances: int = Field(..., description="Decode instance count")
+    pd_ratio: str = Field(..., description="P:D ratio string (e.g. '2:6')")
+    prompt_tokens: TokenStats = Field(..., description="Prompt token distribution")
+    output_tokens: TokenStats = Field(..., description="Output token distribution")
+    ttft: LatencyOverview = Field(..., description="TTFT latency overview")
+    tpot: LatencyOverview = Field(..., description="TPOT latency overview")
+    total_latency: LatencyOverview = Field(..., description="Total latency overview")
+
+
+class SummaryGenerator:
+    """Generate quick summary statistics from benchmark data."""
+
+    def __init__(self, data: BenchmarkData) -> None:
+        self._data = data
+
+    def generate(self) -> SummaryReport:
+        """Produce a compact summary of the benchmark dataset."""
+        requests = self._data.requests
+        meta = self._data.metadata
+
+        prompt_arr = np.array([r.prompt_tokens for r in requests])
+        output_arr = np.array([r.output_tokens for r in requests])
+        ttft_arr = np.array([r.ttft_ms for r in requests])
+        tpot_arr = np.array([r.tpot_ms for r in requests])
+        total_arr = np.array([r.total_latency_ms for r in requests])
+        timestamps = np.array([r.timestamp for r in requests])
+
+        duration = float(timestamps.max() - timestamps.min()) if len(timestamps) > 1 else 0.0
+
+        return SummaryReport(
+            request_count=len(requests),
+            duration_seconds=round(duration, 2),
+            measured_qps=meta.measured_qps,
+            num_prefill_instances=meta.num_prefill_instances,
+            num_decode_instances=meta.num_decode_instances,
+            pd_ratio=f"{meta.num_prefill_instances}:{meta.num_decode_instances}",
+            prompt_tokens=self._token_stats(prompt_arr),
+            output_tokens=self._token_stats(output_arr),
+            ttft=self._latency_overview(ttft_arr),
+            tpot=self._latency_overview(tpot_arr),
+            total_latency=self._latency_overview(total_arr),
+        )
+
+    @staticmethod
+    def _token_stats(arr: np.ndarray) -> TokenStats:
+        return TokenStats(
+            min=int(arr.min()),
+            max=int(arr.max()),
+            mean=round(float(arr.mean()), 1),
+            p50=round(float(np.percentile(arr, 50)), 1),
+            p95=round(float(np.percentile(arr, 95)), 1),
+        )
+
+    @staticmethod
+    def _latency_overview(arr: np.ndarray) -> LatencyOverview:
+        return LatencyOverview(
+            min_ms=round(float(arr.min()), 2),
+            max_ms=round(float(arr.max()), 2),
+            mean_ms=round(float(arr.mean()), 2),
+            p50_ms=round(float(np.percentile(arr, 50)), 2),
+            p95_ms=round(float(np.percentile(arr, 95)), 2),
+            p99_ms=round(float(np.percentile(arr, 99)), 2),
+        )
+
+
+def summarize_benchmark(data: BenchmarkData) -> SummaryReport:
+    """Programmatic API: generate summary report from benchmark data."""
+    return SummaryGenerator(data).generate()

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,253 @@
+"""Tests for benchmark quick summary."""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.cli import main
+from xpyd_plan.summary import (
+    LatencyOverview,
+    SummaryGenerator,
+    SummaryReport,
+    TokenStats,
+    summarize_benchmark,
+)
+
+
+def _make_requests(n: int = 50, base_ts: float = 1000.0) -> list[BenchmarkRequest]:
+    """Generate n benchmark requests with varying characteristics."""
+    requests = []
+    for i in range(n):
+        requests.append(
+            BenchmarkRequest(
+                request_id=f"req-{i:04d}",
+                prompt_tokens=100 + i * 10,
+                output_tokens=50 + i * 5,
+                ttft_ms=10.0 + i * 0.5,
+                tpot_ms=5.0 + i * 0.2,
+                total_latency_ms=100.0 + i * 2.0,
+                timestamp=base_ts + i * 0.1,
+            )
+        )
+    return requests
+
+
+def _make_data(n: int = 50) -> BenchmarkData:
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=6,
+            total_instances=8,
+            measured_qps=100.0,
+        ),
+        requests=_make_requests(n),
+    )
+
+
+class TestSummaryGenerator:
+    def test_basic_summary(self):
+        data = _make_data(50)
+        gen = SummaryGenerator(data)
+        report = gen.generate()
+
+        assert report.request_count == 50
+        assert report.measured_qps == 100.0
+        assert report.num_prefill_instances == 2
+        assert report.num_decode_instances == 6
+        assert report.pd_ratio == "2:6"
+
+    def test_duration_calculated(self):
+        data = _make_data(50)
+        report = SummaryGenerator(data).generate()
+        # 50 requests, 0.1s apart -> ~4.9s duration
+        assert report.duration_seconds > 0
+
+    def test_single_request_duration_zero(self):
+        data = _make_data(1)
+        report = SummaryGenerator(data).generate()
+        assert report.duration_seconds == 0.0
+
+    def test_prompt_token_stats(self):
+        data = _make_data(50)
+        report = SummaryGenerator(data).generate()
+        ts = report.prompt_tokens
+        # min = 100, max = 100 + 49*10 = 590
+        assert ts.min == 100
+        assert ts.max == 590
+        assert ts.mean > 0
+        assert ts.p50 > 0
+        assert ts.p95 > 0
+
+    def test_output_token_stats(self):
+        data = _make_data(50)
+        report = SummaryGenerator(data).generate()
+        ts = report.output_tokens
+        assert ts.min == 50
+        assert ts.max == 50 + 49 * 5
+
+    def test_ttft_latency_overview(self):
+        data = _make_data(50)
+        report = SummaryGenerator(data).generate()
+        lat = report.ttft
+        assert lat.min_ms == 10.0
+        assert lat.max_ms == pytest.approx(10.0 + 49 * 0.5, abs=0.01)
+        assert lat.mean_ms > 0
+        assert lat.p50_ms > 0
+        assert lat.p95_ms > 0
+        assert lat.p99_ms > 0
+        assert lat.p50_ms <= lat.p95_ms <= lat.p99_ms <= lat.max_ms
+
+    def test_tpot_latency_overview(self):
+        data = _make_data(50)
+        report = SummaryGenerator(data).generate()
+        lat = report.tpot
+        assert lat.min_ms == 5.0
+        assert lat.p95_ms >= lat.p50_ms
+
+    def test_total_latency_overview(self):
+        data = _make_data(50)
+        report = SummaryGenerator(data).generate()
+        lat = report.total_latency
+        assert lat.min_ms == 100.0
+        assert lat.max_ms == pytest.approx(100.0 + 49 * 2.0, abs=0.01)
+
+    def test_report_serializable(self):
+        data = _make_data(50)
+        report = SummaryGenerator(data).generate()
+        d = report.model_dump()
+        assert isinstance(d, dict)
+        assert "request_count" in d
+        assert "prompt_tokens" in d
+        assert "ttft" in d
+
+    def test_report_json_roundtrip(self):
+        data = _make_data(50)
+        report = SummaryGenerator(data).generate()
+        j = report.model_dump_json()
+        restored = SummaryReport.model_validate_json(j)
+        assert restored.request_count == report.request_count
+        assert restored.pd_ratio == report.pd_ratio
+
+
+class TestSummarizeBenchmarkAPI:
+    def test_api_returns_report(self):
+        data = _make_data(20)
+        report = summarize_benchmark(data)
+        assert isinstance(report, SummaryReport)
+        assert report.request_count == 20
+
+    def test_api_matches_class(self):
+        data = _make_data(30)
+        api_report = summarize_benchmark(data)
+        class_report = SummaryGenerator(data).generate()
+        assert api_report.request_count == class_report.request_count
+        assert api_report.pd_ratio == class_report.pd_ratio
+
+
+class TestTokenStats:
+    def test_token_stats_model(self):
+        ts = TokenStats(min=10, max=100, mean=55.0, p50=50.0, p95=95.0)
+        assert ts.min == 10
+        assert ts.max == 100
+
+    def test_latency_overview_model(self):
+        lo = LatencyOverview(
+            min_ms=1.0, max_ms=100.0, mean_ms=50.0,
+            p50_ms=45.0, p95_ms=90.0, p99_ms=98.0,
+        )
+        assert lo.p99_ms == 98.0
+
+
+class TestSummaryCLI:
+    def _write_benchmark(self, path: Path, data: BenchmarkData) -> None:
+        path.write_text(json.dumps(data.model_dump()))
+
+    def test_cli_table_output(self, tmp_path, capsys):
+        data = _make_data(20)
+        bench_file = tmp_path / "bench.json"
+        self._write_benchmark(bench_file, data)
+
+        main(["summary", "--benchmark", str(bench_file)])
+        captured = capsys.readouterr()
+        assert "Benchmark Summary" in captured.out
+
+    def test_cli_json_output(self, tmp_path):
+        data = _make_data(20)
+        bench_file = tmp_path / "bench.json"
+        self._write_benchmark(bench_file, data)
+
+        buf = StringIO()
+        with patch("sys.stdout", buf):
+            main(["summary", "--benchmark", str(bench_file), "--output-format", "json"])
+        parsed = json.loads(buf.getvalue())
+        assert parsed["request_count"] == 20
+        assert parsed["pd_ratio"] == "2:6"
+        assert "ttft" in parsed
+        assert "prompt_tokens" in parsed
+
+    def test_cli_json_has_all_fields(self, tmp_path):
+        data = _make_data(30)
+        bench_file = tmp_path / "bench.json"
+        self._write_benchmark(bench_file, data)
+
+        buf = StringIO()
+        with patch("sys.stdout", buf):
+            main(["summary", "--benchmark", str(bench_file), "--output-format", "json"])
+        parsed = json.loads(buf.getvalue())
+        assert "duration_seconds" in parsed
+        assert "measured_qps" in parsed
+        assert "output_tokens" in parsed
+        assert "tpot" in parsed
+        assert "total_latency" in parsed
+
+
+class TestEdgeCases:
+    def test_two_requests(self):
+        data = BenchmarkData(
+            metadata=BenchmarkMetadata(
+                num_prefill_instances=1,
+                num_decode_instances=1,
+                total_instances=2,
+                measured_qps=10.0,
+            ),
+            requests=[
+                BenchmarkRequest(
+                    request_id="r0", prompt_tokens=100, output_tokens=50,
+                    ttft_ms=10.0, tpot_ms=5.0, total_latency_ms=60.0, timestamp=1000.0,
+                ),
+                BenchmarkRequest(
+                    request_id="r1", prompt_tokens=200, output_tokens=100,
+                    ttft_ms=20.0, tpot_ms=10.0, total_latency_ms=120.0, timestamp=1001.0,
+                ),
+            ],
+        )
+        report = summarize_benchmark(data)
+        assert report.request_count == 2
+        assert report.pd_ratio == "1:1"
+        assert report.duration_seconds == 1.0
+
+    def test_uniform_data(self):
+        """All requests identical — stats should be uniform."""
+        reqs = [
+            BenchmarkRequest(
+                request_id=f"r{i}", prompt_tokens=100, output_tokens=50,
+                ttft_ms=10.0, tpot_ms=5.0, total_latency_ms=60.0, timestamp=1000.0 + i,
+            )
+            for i in range(10)
+        ]
+        data = BenchmarkData(
+            metadata=BenchmarkMetadata(
+                num_prefill_instances=3, num_decode_instances=5,
+                total_instances=8, measured_qps=50.0,
+            ),
+            requests=reqs,
+        )
+        report = summarize_benchmark(data)
+        assert report.prompt_tokens.min == report.prompt_tokens.max == 100
+        assert report.ttft.min_ms == report.ttft.max_ms == 10.0


### PR DESCRIPTION
## Summary

Add a `summary` subcommand for quick benchmark file overview — request count, duration, QPS, token distribution, and latency statistics at a glance.

## Changes

- `SummaryGenerator` class in `summary.py` with `TokenStats`, `LatencyOverview`, `SummaryReport` Pydantic models
- CLI `summary` subcommand with `--benchmark`, table + JSON output
- Programmatic `summarize_benchmark()` API
- 19 new tests (1289 total, all passing)
- Updated ROADMAP.md with M56

Closes #129