### PR TITLE
feat: M58 — Percentile Convergence Analysis

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -751,4 +751,15 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Recommendation logic: FILTER if SLA flips or >5% P95 shift, KEEP otherwise
 - CLI `outlier-impact` subcommand with `--benchmark`, `--sla-*`, `--iqr-multiplier`, table + JSON output
 - Programmatic `analyze_outlier_impact()` API
-- 21 new tests (1310 total)
+- 21 new tests (1331 total)
+
+### M58 – Percentile Convergence Analysis
+
+- `ConvergenceAnalyzer` class in `convergence.py`
+- `ConvergencePoint`, `ConvergenceReport`, `MetricConvergence`, `StabilityStatus` Pydantic models
+- Running P50/P95/P99 computation at cumulative sample windows (configurable steps)
+- CV-based stability classification: STABLE (≤threshold), MARGINAL (≤2×threshold), UNSTABLE
+- Minimum stable sample size detection per metric
+- CLI `convergence` subcommand with `--benchmark`, `--steps`, `--threshold`, table + JSON output
+- Programmatic `analyze_convergence()` API
+- 21 new tests (1331 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -62,6 +62,14 @@ from xpyd_plan.confidence import (
     analyze_confidence,
 )
 from xpyd_plan.config import ConfigProfile, load_config
+from xpyd_plan.convergence import (
+    ConvergenceAnalyzer,
+    ConvergencePoint,
+    ConvergenceReport,
+    MetricConvergence,
+    StabilityStatus,
+    analyze_convergence,
+)
 from xpyd_plan.correlation import (
     CorrelationAnalyzer,
     CorrelationPair,
@@ -336,6 +344,12 @@ __all__ = [
     "ConfidenceReport",
     "MetricConfidence",
     "analyze_confidence",
+    "ConvergenceAnalyzer",
+    "ConvergencePoint",
+    "ConvergenceReport",
+    "MetricConvergence",
+    "StabilityStatus",
+    "analyze_convergence",
     "BenchmarkData",
     "BenchmarkMetadata",
     "BenchmarkRequest",

--- a/src/xpyd_plan/cli/_convergence.py
+++ b/src/xpyd_plan/cli/_convergence.py
@@ -1,0 +1,97 @@
+"""CLI convergence command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.convergence import ConvergenceAnalyzer, StabilityStatus
+
+
+def _cmd_convergence(args: argparse.Namespace) -> None:
+    """Handle the 'convergence' subcommand."""
+    console = Console()
+
+    data = load_benchmark_auto(args.benchmark)
+    analyzer = ConvergenceAnalyzer(data)
+    report = analyzer.analyze(
+        steps=args.steps,
+        threshold=args.threshold,
+    )
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Summary
+    status_style = {
+        StabilityStatus.STABLE: "bold green",
+        StabilityStatus.MARGINAL: "bold yellow",
+        StabilityStatus.UNSTABLE: "bold red",
+    }
+
+    console.print(f"Total requests: {report.total_requests}")
+    style = status_style[report.overall_status]
+    console.print(f"Overall stability: [{style}]{report.overall_status.value}[/{style}]")
+    if report.recommended_min_requests is not None:
+        console.print(f"Recommended min requests: {report.recommended_min_requests}")
+    console.print()
+
+    # Per-metric table
+    table = Table(title="Percentile Convergence Analysis")
+    table.add_column("Field", justify="left")
+    table.add_column("CV(P95)", justify="right")
+    table.add_column("CV(P99)", justify="right")
+    table.add_column("Status", justify="center")
+    table.add_column("Min Stable Size", justify="right")
+
+    for m in report.metrics:
+        style = status_style[m.status]
+        table.add_row(
+            m.field,
+            f"{m.cv_p95:.4f}",
+            f"{m.cv_p99:.4f}",
+            f"[{style}]{m.status.value}[/{style}]",
+            str(m.min_stable_sample_size) if m.min_stable_sample_size else "N/A",
+        )
+
+    console.print(table)
+
+
+def add_convergence_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the convergence subcommand parser."""
+    parser = subparsers.add_parser(
+        "convergence",
+        help="Analyze percentile convergence (are metrics stable with enough samples?)",
+    )
+    parser.add_argument(
+        "--benchmark",
+        required=True,
+        help="Path to benchmark JSON file",
+    )
+    parser.add_argument(
+        "--steps",
+        type=int,
+        default=10,
+        help="Number of cumulative windows (default: 10)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.05,
+        help="CV threshold for STABLE classification (default: 0.05)",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_convergence)

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -14,6 +14,7 @@ from xpyd_plan.cli._capacity import _cmd_plan_capacity
 from xpyd_plan.cli._compare import _cmd_compare
 from xpyd_plan.cli._confidence import _cmd_confidence
 from xpyd_plan.cli._config import _add_config_flag, _apply_config_defaults, _cmd_config
+from xpyd_plan.cli._convergence import add_convergence_parser
 from xpyd_plan.cli._correlation import _cmd_correlation, add_correlation_parser
 from xpyd_plan.cli._dashboard import _cmd_dashboard
 from xpyd_plan.cli._decompose import _cmd_decompose, add_decompose_parser
@@ -897,6 +898,7 @@ def main(argv: list[str] | None = None) -> None:
 
     # --- tail subcommand ---
     add_tail_parser(subparsers)
+    add_convergence_parser(subparsers)
 
     # --- scorecard subcommand ---
     add_scorecard_parser(subparsers)
@@ -1001,6 +1003,9 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_root_cause(args)
     elif args.command == "tail":
         _cmd_tail(args)
+    elif args.command == "convergence":
+        from xpyd_plan.cli._convergence import _cmd_convergence
+        _cmd_convergence(args)
     elif args.command == "summary":
         _cmd_summary(args)
     elif args.command == "outlier-impact":

--- a/src/xpyd_plan/convergence.py
+++ b/src/xpyd_plan/convergence.py
@@ -1,0 +1,205 @@
+"""Percentile convergence analysis for benchmark data."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from xpyd_plan.benchmark_models import BenchmarkData
+
+
+class StabilityStatus(str, Enum):
+    """Stability classification based on coefficient of variation."""
+
+    STABLE = "stable"
+    MARGINAL = "marginal"
+    UNSTABLE = "unstable"
+
+
+class ConvergencePoint(BaseModel):
+    """Running percentile value at a specific sample size."""
+
+    sample_size: int = Field(description="Number of requests in this window")
+    sample_fraction: float = Field(description="Fraction of total requests (0.0–1.0)")
+    p50: float = Field(description="P50 at this sample size")
+    p95: float = Field(description="P95 at this sample size")
+    p99: float = Field(description="P99 at this sample size")
+
+
+class MetricConvergence(BaseModel):
+    """Convergence analysis for a single latency metric."""
+
+    field: str = Field(description="Latency field name")
+    points: list[ConvergencePoint] = Field(description="Running percentile values")
+    cv_p95: float = Field(description="Coefficient of variation of P95 across windows")
+    cv_p99: float = Field(description="Coefficient of variation of P99 across windows")
+    status: StabilityStatus = Field(description="Overall stability classification")
+    min_stable_sample_size: Optional[int] = Field(
+        default=None,
+        description="Minimum sample size at which metric stabilizes (None if unstable)",
+    )
+
+
+class ConvergenceReport(BaseModel):
+    """Complete convergence analysis report."""
+
+    metrics: list[MetricConvergence] = Field(description="Per-metric convergence analysis")
+    overall_status: StabilityStatus = Field(description="Worst status across all metrics")
+    total_requests: int = Field(description="Total requests in benchmark")
+    recommended_min_requests: Optional[int] = Field(
+        default=None,
+        description="Recommended minimum requests for stable percentiles",
+    )
+
+
+def _classify_stability(cv: float, threshold: float) -> StabilityStatus:
+    """Classify stability based on coefficient of variation."""
+    if cv <= threshold:
+        return StabilityStatus.STABLE
+    elif cv <= threshold * 2:
+        return StabilityStatus.MARGINAL
+    else:
+        return StabilityStatus.UNSTABLE
+
+
+def _worst_status(a: StabilityStatus, b: StabilityStatus) -> StabilityStatus:
+    order = [StabilityStatus.STABLE, StabilityStatus.MARGINAL, StabilityStatus.UNSTABLE]
+    return max(a, b, key=lambda s: order.index(s))
+
+
+class ConvergenceAnalyzer:
+    """Analyze whether benchmark percentile metrics have converged."""
+
+    FIELDS = ["ttft_ms", "tpot_ms", "total_latency_ms"]
+
+    def __init__(self, data: BenchmarkData) -> None:
+        self._data = data
+
+    def analyze(
+        self,
+        steps: int = 10,
+        threshold: float = 0.05,
+    ) -> ConvergenceReport:
+        """Run convergence analysis.
+
+        Args:
+            steps: Number of cumulative windows (e.g. 10 → 10%, 20%, ..., 100%).
+            threshold: CV threshold for STABLE classification (default 5%).
+        """
+        requests = self._data.requests
+        n = len(requests)
+        if n == 0:
+            return ConvergenceReport(
+                metrics=[],
+                overall_status=StabilityStatus.UNSTABLE,
+                total_requests=0,
+                recommended_min_requests=None,
+            )
+
+        # Build arrays
+        arrays: dict[str, np.ndarray] = {}
+        for field in self.FIELDS:
+            arrays[field] = np.array([getattr(r, field) for r in requests])
+
+        # Window sizes
+        window_sizes = [max(1, int(n * (i + 1) / steps)) for i in range(steps)]
+        # Deduplicate while preserving order
+        seen: set[int] = set()
+        unique_sizes: list[int] = []
+        for s in window_sizes:
+            if s not in seen:
+                seen.add(s)
+                unique_sizes.append(s)
+        window_sizes = unique_sizes
+
+        metrics: list[MetricConvergence] = []
+        overall = StabilityStatus.STABLE
+
+        for field in self.FIELDS:
+            arr = arrays[field]
+            points: list[ConvergencePoint] = []
+
+            for ws in window_sizes:
+                subset = arr[:ws]
+                points.append(
+                    ConvergencePoint(
+                        sample_size=ws,
+                        sample_fraction=ws / n,
+                        p50=float(np.percentile(subset, 50)),
+                        p95=float(np.percentile(subset, 95)),
+                        p99=float(np.percentile(subset, 99)),
+                    )
+                )
+
+            # Compute CV over the last half of windows for stability
+            tail_points = points[len(points) // 2 :]
+            p95_values = [p.p95 for p in tail_points]
+            p99_values = [p.p99 for p in tail_points]
+
+            mean_p95 = np.mean(p95_values)
+            mean_p99 = np.mean(p99_values)
+            cv_p95 = float(np.std(p95_values) / mean_p95) if mean_p95 > 0 else 0.0
+            cv_p99 = float(np.std(p99_values) / mean_p99) if mean_p99 > 0 else 0.0
+
+            worst_cv = max(cv_p95, cv_p99)
+            status = _classify_stability(worst_cv, threshold)
+
+            # Find minimum stable sample size
+            min_stable: Optional[int] = None
+            if status != StabilityStatus.UNSTABLE and len(points) >= 3:
+                # Walk forward: find the first point from which all subsequent CVs are stable
+                for start_idx in range(len(points) - 2):
+                    remaining = points[start_idx:]
+                    r_p95 = [p.p95 for p in remaining]
+                    r_p99 = [p.p99 for p in remaining]
+                    m95 = np.mean(r_p95)
+                    m99 = np.mean(r_p99)
+                    c95 = float(np.std(r_p95) / m95) if m95 > 0 else 0.0
+                    c99 = float(np.std(r_p99) / m99) if m99 > 0 else 0.0
+                    if max(c95, c99) <= threshold:
+                        min_stable = points[start_idx].sample_size
+                        break
+
+            mc = MetricConvergence(
+                field=field,
+                points=points,
+                cv_p95=cv_p95,
+                cv_p99=cv_p99,
+                status=status,
+                min_stable_sample_size=min_stable,
+            )
+            metrics.append(mc)
+            overall = _worst_status(overall, status)
+
+        # Recommended min requests: max of all min_stable values, or None
+        min_stables = [
+            m.min_stable_sample_size
+            for m in metrics
+            if m.min_stable_sample_size is not None
+        ]
+        recommended = max(min_stables) if min_stables else None
+
+        return ConvergenceReport(
+            metrics=metrics,
+            overall_status=overall,
+            total_requests=n,
+            recommended_min_requests=recommended,
+        )
+
+
+def analyze_convergence(
+    data: BenchmarkData,
+    steps: int = 10,
+    threshold: float = 0.05,
+) -> dict:
+    """Programmatic API for convergence analysis.
+
+    Returns:
+        dict representation of ConvergenceReport.
+    """
+    analyzer = ConvergenceAnalyzer(data)
+    report = analyzer.analyze(steps=steps, threshold=threshold)
+    return report.model_dump()

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -1,0 +1,273 @@
+"""Tests for percentile convergence analysis."""
+
+from __future__ import annotations
+
+import json
+import random
+import tempfile
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.convergence import (
+    ConvergenceAnalyzer,
+    ConvergencePoint,
+    ConvergenceReport,
+    MetricConvergence,
+    StabilityStatus,
+    analyze_convergence,
+)
+
+
+def _make_requests(
+    n: int = 200,
+    *,
+    seed: int = 42,
+    stable: bool = True,
+) -> list[BenchmarkRequest]:
+    """Generate synthetic requests.
+
+    If stable=True, latencies are drawn from a tight distribution.
+    If stable=False, latencies shift significantly across the sequence.
+    """
+    rng = random.Random(seed)
+    requests = []
+    for i in range(n):
+        prompt_tokens = rng.randint(50, 500)
+        output_tokens = rng.randint(20, 200)
+        if stable:
+            ttft = 50.0 + rng.gauss(0, 5)
+            tpot = 10.0 + rng.gauss(0, 1)
+        else:
+            # Latency drifts significantly — early requests are fast, late are slow
+            drift = (i / n) * 200  # 0 to 200ms drift
+            ttft = 50.0 + drift + rng.gauss(0, 5)
+            tpot = 10.0 + drift / 20 + rng.gauss(0, 1)
+        total = max(ttft + tpot * output_tokens, 1.0)
+        requests.append(
+            BenchmarkRequest(
+                request_id=f"req-{i}",
+                prompt_tokens=prompt_tokens,
+                output_tokens=output_tokens,
+                ttft_ms=round(max(ttft, 0.1), 2),
+                tpot_ms=round(max(tpot, 0.1), 2),
+                total_latency_ms=round(total, 2),
+                timestamp=1700000000.0 + i,
+            )
+        )
+    return requests
+
+
+def _make_benchmark(requests: list[BenchmarkRequest]) -> BenchmarkData:
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=4,
+            total_instances=6,
+            measured_qps=10.0,
+        ),
+        requests=requests,
+    )
+
+
+class TestConvergenceAnalyzer:
+    """Tests for ConvergenceAnalyzer."""
+
+    def test_stable_data_reports_stable(self):
+        data = _make_benchmark(_make_requests(500, stable=True))
+        analyzer = ConvergenceAnalyzer(data)
+        report = analyzer.analyze()
+        assert report.overall_status == StabilityStatus.STABLE
+        assert report.total_requests == 500
+
+    def test_unstable_data_reports_not_stable(self):
+        data = _make_benchmark(_make_requests(500, stable=False))
+        analyzer = ConvergenceAnalyzer(data)
+        report = analyzer.analyze()
+        assert report.overall_status in (StabilityStatus.MARGINAL, StabilityStatus.UNSTABLE)
+
+    def test_report_has_three_metrics(self):
+        data = _make_benchmark(_make_requests(100, stable=True))
+        analyzer = ConvergenceAnalyzer(data)
+        report = analyzer.analyze()
+        assert len(report.metrics) == 3
+        fields = {m.field for m in report.metrics}
+        assert fields == {"ttft_ms", "tpot_ms", "total_latency_ms"}
+
+    def test_convergence_points_count(self):
+        data = _make_benchmark(_make_requests(100, stable=True))
+        analyzer = ConvergenceAnalyzer(data)
+        report = analyzer.analyze(steps=10)
+        for m in report.metrics:
+            assert len(m.points) == 10
+            # Last point should cover all requests
+            assert m.points[-1].sample_size == 100
+            assert m.points[-1].sample_fraction == 1.0
+
+    def test_custom_steps(self):
+        data = _make_benchmark(_make_requests(100, stable=True))
+        analyzer = ConvergenceAnalyzer(data)
+        report = analyzer.analyze(steps=5)
+        for m in report.metrics:
+            assert len(m.points) == 5
+
+    def test_custom_threshold(self):
+        data = _make_benchmark(_make_requests(500, stable=True))
+        analyzer = ConvergenceAnalyzer(data)
+        # Very tight threshold
+        report_tight = analyzer.analyze(threshold=0.001)
+        # Very loose threshold
+        report_loose = analyzer.analyze(threshold=0.5)
+        # Loose should be at least as stable as tight
+        order = [StabilityStatus.STABLE, StabilityStatus.MARGINAL, StabilityStatus.UNSTABLE]
+        assert order.index(report_loose.overall_status) <= order.index(report_tight.overall_status)
+
+    def test_cv_values_are_nonnegative(self):
+        data = _make_benchmark(_make_requests(200, stable=True))
+        analyzer = ConvergenceAnalyzer(data)
+        report = analyzer.analyze()
+        for m in report.metrics:
+            assert m.cv_p95 >= 0
+            assert m.cv_p99 >= 0
+
+    def test_sample_fractions_monotonic(self):
+        data = _make_benchmark(_make_requests(200, stable=True))
+        analyzer = ConvergenceAnalyzer(data)
+        report = analyzer.analyze(steps=10)
+        for m in report.metrics:
+            fractions = [p.sample_fraction for p in m.points]
+            assert fractions == sorted(fractions)
+
+    def test_sample_sizes_monotonic(self):
+        data = _make_benchmark(_make_requests(200, stable=True))
+        analyzer = ConvergenceAnalyzer(data)
+        report = analyzer.analyze(steps=10)
+        for m in report.metrics:
+            sizes = [p.sample_size for p in m.points]
+            assert sizes == sorted(sizes)
+
+    def test_min_stable_sample_size_for_stable_data(self):
+        data = _make_benchmark(_make_requests(500, stable=True))
+        analyzer = ConvergenceAnalyzer(data)
+        report = analyzer.analyze()
+        for m in report.metrics:
+            if m.status == StabilityStatus.STABLE:
+                # Should have a min stable size
+                assert m.min_stable_sample_size is not None
+                assert m.min_stable_sample_size > 0
+                assert m.min_stable_sample_size <= 500
+
+    def test_recommended_min_requests_for_stable(self):
+        data = _make_benchmark(_make_requests(500, stable=True))
+        analyzer = ConvergenceAnalyzer(data)
+        report = analyzer.analyze()
+        if report.overall_status == StabilityStatus.STABLE:
+            assert report.recommended_min_requests is not None
+
+    def test_small_dataset(self):
+        data = _make_benchmark(_make_requests(5, stable=True))
+        analyzer = ConvergenceAnalyzer(data)
+        report = analyzer.analyze(steps=5)
+        assert report.total_requests == 5
+        # Should still produce results without crashing
+
+    def test_single_request(self):
+        data = _make_benchmark(_make_requests(1, stable=True))
+        analyzer = ConvergenceAnalyzer(data)
+        report = analyzer.analyze(steps=5)
+        assert report.total_requests == 1
+
+    def test_convergence_point_model(self):
+        p = ConvergencePoint(
+            sample_size=100,
+            sample_fraction=0.5,
+            p50=50.0,
+            p95=95.0,
+            p99=99.0,
+        )
+        assert p.sample_size == 100
+        assert p.p50 == 50.0
+
+    def test_metric_convergence_model(self):
+        mc = MetricConvergence(
+            field="ttft_ms",
+            points=[],
+            cv_p95=0.03,
+            cv_p99=0.04,
+            status=StabilityStatus.STABLE,
+            min_stable_sample_size=50,
+        )
+        assert mc.field == "ttft_ms"
+        assert mc.status == StabilityStatus.STABLE
+
+    def test_report_model(self):
+        report = ConvergenceReport(
+            metrics=[],
+            overall_status=StabilityStatus.STABLE,
+            total_requests=100,
+            recommended_min_requests=50,
+        )
+        assert report.total_requests == 100
+
+    def test_stability_status_enum(self):
+        assert StabilityStatus.STABLE.value == "stable"
+        assert StabilityStatus.MARGINAL.value == "marginal"
+        assert StabilityStatus.UNSTABLE.value == "unstable"
+
+
+class TestAnalyzeConvergenceAPI:
+    """Tests for the programmatic API."""
+
+    def test_returns_dict(self):
+        data = _make_benchmark(_make_requests(100, stable=True))
+        result = analyze_convergence(data)
+        assert isinstance(result, dict)
+        assert "metrics" in result
+        assert "overall_status" in result
+        assert "total_requests" in result
+
+    def test_custom_params(self):
+        data = _make_benchmark(_make_requests(100, stable=True))
+        result = analyze_convergence(data, steps=5, threshold=0.1)
+        assert isinstance(result, dict)
+        for m in result["metrics"]:
+            assert len(m["points"]) == 5
+
+
+class TestConvergenceCLI:
+    """Tests for CLI integration."""
+
+    def test_cli_json_output(self):
+        import subprocess
+
+        requests = _make_requests(100, stable=True)
+        data = _make_benchmark(requests)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write(data.model_dump_json(indent=2))
+            f.flush()
+            result = subprocess.run(
+                ["xpyd-plan", "convergence",
+                 "--benchmark", f.name, "--output-format", "json"],
+                capture_output=True, text=True,
+            )
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert "metrics" in output
+        assert "overall_status" in output
+
+    def test_cli_table_output(self):
+        import subprocess
+
+        requests = _make_requests(100, stable=True)
+        data = _make_benchmark(requests)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write(data.model_dump_json(indent=2))
+            f.flush()
+            result = subprocess.run(
+                ["xpyd-plan", "convergence",
+                 "--benchmark", f.name, "--output-format", "table"],
+                capture_output=True, text=True,
+            )
+        assert result.returncode == 0
+        out = result.stdout.lower()
+        assert "convergence" in out or "stability" in out or "stable" in out


### PR DESCRIPTION
## Summary

Add percentile convergence analysis to determine whether a benchmark ran long enough for reliable metrics.

### Changes
- `ConvergenceAnalyzer` class in `convergence.py`
- `ConvergencePoint`, `ConvergenceReport`, `MetricConvergence`, `StabilityStatus` Pydantic models
- Running P50/P95/P99 at cumulative sample windows with configurable step count
- CV-based stability: STABLE (CV ≤ threshold), MARGINAL (≤ 2×), UNSTABLE (> 2×)
- Minimum stable sample size detection per metric
- CLI `convergence` subcommand with `--benchmark`, `--steps`, `--threshold`, table + JSON
- Programmatic `analyze_convergence()` API
- 21 new tests (1331 total, all passing)

Closes #133