### PR TITLE
feat: M59 — Load Profile Classification

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -763,3 +763,17 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `convergence` subcommand with `--benchmark`, `--steps`, `--threshold`, table + JSON output
 - Programmatic `analyze_convergence()` API
 - 21 new tests (1331 total)
+
+### M59 – Load Profile Classification
+
+- `LoadProfileClassifier` class in `load_profile.py`
+- `LoadProfile`, `LoadProfileReport`, `ProfileType`, `RateWindow` Pydantic models
+- Time-windowed request rate computation with configurable window size
+- 6 profile types: STEADY_STATE, RAMP_UP, RAMP_DOWN, BURST, CYCLIC, UNKNOWN
+- Rate CV analysis for steady-state detection
+- Linear regression on rate for ramp classification
+- Peak-to-trough ratio for burst detection
+- Direction change counting for cyclic detection
+- CLI `load-profile` subcommand with `--benchmark`, `--window-size`, table + JSON output
+- Programmatic `classify_load_profile()` API
+- ~22 new tests

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -165,6 +165,14 @@ from xpyd_plan.interpolator import (
     PredictedPerformance,
     interpolate_performance,
 )
+from xpyd_plan.load_profile import (
+    LoadProfile,
+    LoadProfileClassifier,
+    LoadProfileReport,
+    ProfileType,
+    RateWindow,
+    classify_load_profile,
+)
 from xpyd_plan.md_report import (
     MarkdownReportConfig,
     MarkdownReporter,
@@ -350,6 +358,12 @@ __all__ = [
     "MetricConvergence",
     "StabilityStatus",
     "analyze_convergence",
+    "LoadProfileClassifier",
+    "LoadProfile",
+    "LoadProfileReport",
+    "ProfileType",
+    "RateWindow",
+    "classify_load_profile",
     "BenchmarkData",
     "BenchmarkMetadata",
     "BenchmarkRequest",

--- a/src/xpyd_plan/cli/_load_profile.py
+++ b/src/xpyd_plan/cli/_load_profile.py
@@ -1,0 +1,90 @@
+"""CLI load-profile command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.load_profile import LoadProfileClassifier, ProfileType
+
+
+def _cmd_load_profile(args: argparse.Namespace) -> None:
+    """Handle the 'load-profile' subcommand."""
+    console = Console()
+
+    data = load_benchmark_auto(args.benchmark)
+    classifier = LoadProfileClassifier(data)
+    report = classifier.classify(window_size=args.window_size)
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    profile = report.profile
+    style_map = {
+        ProfileType.STEADY_STATE: "bold green",
+        ProfileType.RAMP_UP: "bold yellow",
+        ProfileType.RAMP_DOWN: "bold yellow",
+        ProfileType.BURST: "bold red",
+        ProfileType.CYCLIC: "bold cyan",
+        ProfileType.UNKNOWN: "bold dim",
+    }
+    style = style_map.get(profile.profile_type, "bold")
+
+    console.print(f"Total requests: {report.total_requests}")
+    console.print(f"Duration: {report.duration_seconds:.1f}s")
+    console.print(f"Overall rate: {report.overall_rate_rps:.2f} rps")
+    console.print(
+        f"Profile: [{style}]{profile.profile_type.value}[/{style}] "
+        f"(confidence: {profile.confidence:.0%})"
+    )
+    console.print(f"Description: {profile.description}")
+    console.print()
+
+    # Windows table
+    table = Table(title="Rate by Time Window")
+    table.add_column("Window", justify="left")
+    table.add_column("Requests", justify="right")
+    table.add_column("Rate (rps)", justify="right")
+
+    for w in report.windows:
+        table.add_row(
+            f"{w.start_time:.1f}–{w.end_time:.1f}",
+            str(w.request_count),
+            f"{w.rate_rps:.2f}",
+        )
+
+    console.print(table)
+
+
+def add_load_profile_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the load-profile subcommand parser."""
+    parser = subparsers.add_parser(
+        "load-profile",
+        help="Classify the load pattern of a benchmark (steady-state, ramp, burst, cyclic)",
+    )
+    parser.add_argument(
+        "--benchmark",
+        required=True,
+        help="Path to benchmark JSON file",
+    )
+    parser.add_argument(
+        "--window-size",
+        type=float,
+        default=5.0,
+        help="Time window size in seconds (default: 5.0)",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_load_profile)

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -28,6 +28,7 @@ from xpyd_plan.cli._forecast import add_forecast_parser
 from xpyd_plan.cli._generate import _cmd_generate
 from xpyd_plan.cli._heatmap import _cmd_heatmap, add_heatmap_parser
 from xpyd_plan.cli._interpolate import _cmd_interpolate
+from xpyd_plan.cli._load_profile import add_load_profile_parser
 from xpyd_plan.cli._merge import _cmd_merge
 from xpyd_plan.cli._metrics import _cmd_metrics, add_metrics_parser
 from xpyd_plan.cli._model_compare import _cmd_model_compare
@@ -899,6 +900,7 @@ def main(argv: list[str] | None = None) -> None:
     # --- tail subcommand ---
     add_tail_parser(subparsers)
     add_convergence_parser(subparsers)
+    add_load_profile_parser(subparsers)
 
     # --- scorecard subcommand ---
     add_scorecard_parser(subparsers)
@@ -1006,6 +1008,9 @@ def main(argv: list[str] | None = None) -> None:
     elif args.command == "convergence":
         from xpyd_plan.cli._convergence import _cmd_convergence
         _cmd_convergence(args)
+    elif args.command == "load-profile":
+        from xpyd_plan.cli._load_profile import _cmd_load_profile
+        _cmd_load_profile(args)
     elif args.command == "summary":
         _cmd_summary(args)
     elif args.command == "outlier-impact":

--- a/src/xpyd_plan/load_profile.py
+++ b/src/xpyd_plan/load_profile.py
@@ -1,0 +1,273 @@
+"""Load profile classification for benchmark data."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from xpyd_plan.benchmark_models import BenchmarkData
+
+
+class ProfileType(str, Enum):
+    """Load profile classification."""
+
+    STEADY_STATE = "steady_state"
+    RAMP_UP = "ramp_up"
+    RAMP_DOWN = "ramp_down"
+    BURST = "burst"
+    CYCLIC = "cyclic"
+    UNKNOWN = "unknown"
+
+
+class RateWindow(BaseModel):
+    """Request rate in a time window."""
+
+    start_time: float = Field(description="Window start (epoch seconds)")
+    end_time: float = Field(description="Window end (epoch seconds)")
+    request_count: int = Field(description="Requests in this window")
+    rate_rps: float = Field(description="Requests per second in this window")
+
+
+class LoadProfile(BaseModel):
+    """Detected load profile with supporting evidence."""
+
+    profile_type: ProfileType = Field(description="Classified load profile type")
+    confidence: float = Field(description="Classification confidence (0.0–1.0)")
+    rate_cv: float = Field(description="Coefficient of variation of per-window rates")
+    rate_trend_slope: float = Field(description="Linear regression slope of rate over time")
+    peak_to_trough_ratio: float = Field(
+        description="Ratio of max rate to min rate (min clamped to avoid div-by-zero)",
+    )
+    description: str = Field(description="Human-readable description of the profile")
+
+
+class LoadProfileReport(BaseModel):
+    """Complete load profile analysis report."""
+
+    profile: LoadProfile = Field(description="Detected load profile")
+    windows: list[RateWindow] = Field(description="Per-window rate data")
+    total_requests: int = Field(description="Total requests in benchmark")
+    duration_seconds: float = Field(description="Total benchmark duration")
+    overall_rate_rps: float = Field(description="Average requests per second")
+
+
+class LoadProfileClassifier:
+    """Classify the load pattern of a benchmark."""
+
+    def __init__(self, data: BenchmarkData) -> None:
+        self._data = data
+
+    def classify(
+        self,
+        window_size: float = 5.0,
+    ) -> LoadProfileReport:
+        """Classify the load profile.
+
+        Args:
+            window_size: Time window size in seconds for rate computation.
+        """
+        requests = self._data.requests
+        n = len(requests)
+
+        if n == 0:
+            return LoadProfileReport(
+                profile=LoadProfile(
+                    profile_type=ProfileType.UNKNOWN,
+                    confidence=0.0,
+                    rate_cv=0.0,
+                    rate_trend_slope=0.0,
+                    peak_to_trough_ratio=1.0,
+                    description="No requests in benchmark data.",
+                ),
+                windows=[],
+                total_requests=0,
+                duration_seconds=0.0,
+                overall_rate_rps=0.0,
+            )
+
+        timestamps = sorted(r.timestamp for r in requests)
+        t_min = timestamps[0]
+        t_max = timestamps[-1]
+        duration = t_max - t_min
+
+        if duration <= 0:
+            return LoadProfileReport(
+                profile=LoadProfile(
+                    profile_type=ProfileType.STEADY_STATE,
+                    confidence=0.5,
+                    rate_cv=0.0,
+                    rate_trend_slope=0.0,
+                    peak_to_trough_ratio=1.0,
+                    description="All requests have the same timestamp; treating as steady state.",
+                ),
+                windows=[
+                    RateWindow(
+                        start_time=t_min,
+                        end_time=t_min + window_size,
+                        request_count=n,
+                        rate_rps=n / window_size,
+                    )
+                ],
+                total_requests=n,
+                duration_seconds=0.0,
+                overall_rate_rps=float(n),
+            )
+
+        # Build time windows
+        windows: list[RateWindow] = []
+        t = t_min
+        ts_array = np.array(timestamps)
+        while t < t_max:
+            t_end = min(t + window_size, t_max + 0.001)
+            count = int(np.sum((ts_array >= t) & (ts_array < t_end)))
+            actual_width = t_end - t
+            rate = count / actual_width if actual_width > 0 else 0.0
+            windows.append(
+                RateWindow(
+                    start_time=round(t, 3),
+                    end_time=round(t_end, 3),
+                    request_count=count,
+                    rate_rps=round(rate, 4),
+                )
+            )
+            t += window_size
+
+        if len(windows) < 2:
+            return LoadProfileReport(
+                profile=LoadProfile(
+                    profile_type=ProfileType.STEADY_STATE,
+                    confidence=0.5,
+                    rate_cv=0.0,
+                    rate_trend_slope=0.0,
+                    peak_to_trough_ratio=1.0,
+                    description="Too few windows for pattern detection; treating as steady state.",
+                ),
+                windows=windows,
+                total_requests=n,
+                duration_seconds=round(duration, 3),
+                overall_rate_rps=round(n / duration, 4),
+            )
+
+        rates = np.array([w.rate_rps for w in windows])
+        mean_rate = float(np.mean(rates))
+        std_rate = float(np.std(rates))
+        cv = std_rate / mean_rate if mean_rate > 0 else 0.0
+
+        # Linear regression for trend
+        x = np.arange(len(rates), dtype=float)
+        if len(x) > 1:
+            slope = float(np.polyfit(x, rates, 1)[0])
+        else:
+            slope = 0.0
+
+        # Normalize slope relative to mean rate
+        norm_slope = slope / mean_rate if mean_rate > 0 else 0.0
+
+        min_rate = float(np.min(rates))
+        max_rate = float(np.max(rates))
+        peak_trough = max_rate / max(min_rate, 0.001)
+
+        # Classification logic
+        profile_type, confidence, description = self._classify_pattern(
+            cv, norm_slope, peak_trough, rates
+        )
+
+        return LoadProfileReport(
+            profile=LoadProfile(
+                profile_type=profile_type,
+                confidence=round(confidence, 3),
+                rate_cv=round(cv, 4),
+                rate_trend_slope=round(slope, 4),
+                peak_to_trough_ratio=round(peak_trough, 4),
+                description=description,
+            ),
+            windows=windows,
+            total_requests=n,
+            duration_seconds=round(duration, 3),
+            overall_rate_rps=round(n / duration, 4),
+        )
+
+    @staticmethod
+    def _classify_pattern(
+        cv: float,
+        norm_slope: float,
+        peak_trough: float,
+        rates: np.ndarray,
+    ) -> tuple[ProfileType, float, str]:
+        """Classify the load pattern based on rate statistics."""
+        # Steady state: low CV
+        if cv < 0.2:
+            return (
+                ProfileType.STEADY_STATE,
+                min(1.0, 1.0 - cv / 0.2),
+                f"Request rate is stable (CV={cv:.3f}).",
+            )
+
+        # Ramp up: strong positive trend
+        if norm_slope > 0.1 and cv >= 0.2:
+            conf = min(1.0, abs(norm_slope) / 0.3)
+            return (
+                ProfileType.RAMP_UP,
+                conf,
+                f"Request rate increases over time (normalized slope={norm_slope:.3f}).",
+            )
+
+        # Ramp down: strong negative trend
+        if norm_slope < -0.1 and cv >= 0.2:
+            conf = min(1.0, abs(norm_slope) / 0.3)
+            return (
+                ProfileType.RAMP_DOWN,
+                conf,
+                f"Request rate decreases over time (normalized slope={norm_slope:.3f}).",
+            )
+
+        # Burst: very high peak-to-trough ratio
+        if peak_trough > 5.0:
+            conf = min(1.0, peak_trough / 10.0)
+            return (
+                ProfileType.BURST,
+                conf,
+                f"Burst pattern detected (peak/trough={peak_trough:.1f}x).",
+            )
+
+        # Cyclic: check for sign changes in rate derivative
+        if len(rates) >= 4:
+            diffs = np.diff(rates)
+            sign_changes = int(np.sum(np.abs(np.diff(np.sign(diffs))) > 0))
+            if sign_changes >= len(rates) // 2:
+                conf = min(1.0, sign_changes / len(rates))
+                return (
+                    ProfileType.CYCLIC,
+                    conf,
+                    f"Cyclic pattern detected ({sign_changes} direction changes).",
+                )
+
+        # Fallback: burst if high CV
+        if cv >= 0.5:
+            return (
+                ProfileType.BURST,
+                0.5,
+                f"High rate variance (CV={cv:.3f}), classified as burst.",
+            )
+
+        return (
+            ProfileType.UNKNOWN,
+            0.3,
+            f"No clear pattern detected (CV={cv:.3f}).",
+        )
+
+
+def classify_load_profile(
+    data: BenchmarkData,
+    window_size: float = 5.0,
+) -> dict:
+    """Programmatic API for load profile classification.
+
+    Returns:
+        dict representation of LoadProfileReport.
+    """
+    classifier = LoadProfileClassifier(data)
+    report = classifier.classify(window_size=window_size)
+    return report.model_dump()

--- a/tests/test_load_profile.py
+++ b/tests/test_load_profile.py
@@ -1,0 +1,263 @@
+"""Tests for load profile classification."""
+
+from __future__ import annotations
+
+import json
+import random
+import tempfile
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.load_profile import (
+    LoadProfile,
+    LoadProfileClassifier,
+    ProfileType,
+    RateWindow,
+    classify_load_profile,
+)
+
+
+def _make_requests(
+    n: int = 200,
+    *,
+    seed: int = 42,
+    pattern: str = "steady",
+    duration: float = 100.0,
+) -> list[BenchmarkRequest]:
+    """Generate requests with a specific arrival pattern."""
+    rng = random.Random(seed)
+    requests = []
+
+    for i in range(n):
+        prompt_tokens = rng.randint(50, 500)
+        output_tokens = rng.randint(20, 200)
+        ttft = 50.0 + rng.gauss(0, 5)
+        tpot = 10.0 + rng.gauss(0, 1)
+        total = max(ttft + tpot * output_tokens, 1.0)
+
+        if pattern == "steady":
+            ts = 1700000000.0 + (i / n) * duration
+        elif pattern == "ramp_up":
+            # Quadratic: more requests at the end
+            frac = (i / n) ** 0.5
+            ts = 1700000000.0 + frac * duration
+        elif pattern == "ramp_down":
+            # Inverse: more requests at the start
+            frac = 1.0 - ((n - 1 - i) / n) ** 0.5
+            ts = 1700000000.0 + frac * duration
+        elif pattern == "burst":
+            # All requests in 2 short bursts
+            if i < n // 2:
+                ts = 1700000000.0 + rng.uniform(0, 2)
+            else:
+                ts = 1700000000.0 + duration - 2 + rng.uniform(0, 2)
+        elif pattern == "cyclic":
+            # Sine-wave modulated arrival
+            import math
+            phase = (i / n) * 4 * math.pi  # 2 full cycles
+            offset = (math.sin(phase) + 1) / 2  # 0 to 1
+            ts = 1700000000.0 + (i / n) * duration + offset * 2
+        else:
+            ts = 1700000000.0 + (i / n) * duration
+
+        requests.append(
+            BenchmarkRequest(
+                request_id=f"req-{i}",
+                prompt_tokens=prompt_tokens,
+                output_tokens=output_tokens,
+                ttft_ms=round(max(ttft, 0.1), 2),
+                tpot_ms=round(max(tpot, 0.1), 2),
+                total_latency_ms=round(total, 2),
+                timestamp=ts,
+            )
+        )
+
+    return requests
+
+
+def _make_benchmark(requests: list[BenchmarkRequest]) -> BenchmarkData:
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=4,
+            total_instances=6,
+            measured_qps=10.0,
+        ),
+        requests=requests,
+    )
+
+
+class TestLoadProfileClassifier:
+    """Tests for LoadProfileClassifier."""
+
+    def test_steady_state_classification(self):
+        data = _make_benchmark(_make_requests(500, pattern="steady", duration=100))
+        classifier = LoadProfileClassifier(data)
+        report = classifier.classify(window_size=5.0)
+        assert report.profile.profile_type == ProfileType.STEADY_STATE
+
+    def test_ramp_up_classification(self):
+        data = _make_benchmark(_make_requests(500, pattern="ramp_up", duration=100))
+        classifier = LoadProfileClassifier(data)
+        report = classifier.classify(window_size=5.0)
+        assert report.profile.profile_type in (ProfileType.RAMP_UP, ProfileType.BURST)
+
+    def test_ramp_down_classification(self):
+        data = _make_benchmark(_make_requests(500, pattern="ramp_down", duration=100))
+        classifier = LoadProfileClassifier(data)
+        report = classifier.classify(window_size=5.0)
+        assert report.profile.profile_type in (ProfileType.RAMP_DOWN, ProfileType.BURST)
+
+    def test_burst_classification(self):
+        data = _make_benchmark(_make_requests(500, pattern="burst", duration=100))
+        classifier = LoadProfileClassifier(data)
+        report = classifier.classify(window_size=5.0)
+        assert report.profile.profile_type == ProfileType.BURST
+
+    def test_report_has_windows(self):
+        data = _make_benchmark(_make_requests(200, pattern="steady", duration=50))
+        classifier = LoadProfileClassifier(data)
+        report = classifier.classify(window_size=5.0)
+        assert len(report.windows) == 10
+
+    def test_report_total_requests(self):
+        data = _make_benchmark(_make_requests(200, pattern="steady"))
+        classifier = LoadProfileClassifier(data)
+        report = classifier.classify()
+        assert report.total_requests == 200
+
+    def test_report_duration(self):
+        data = _make_benchmark(_make_requests(200, pattern="steady", duration=100))
+        classifier = LoadProfileClassifier(data)
+        report = classifier.classify()
+        assert report.duration_seconds > 0
+
+    def test_overall_rate(self):
+        data = _make_benchmark(_make_requests(200, pattern="steady", duration=100))
+        classifier = LoadProfileClassifier(data)
+        report = classifier.classify()
+        assert report.overall_rate_rps > 0
+
+    def test_confidence_range(self):
+        data = _make_benchmark(_make_requests(200, pattern="steady"))
+        classifier = LoadProfileClassifier(data)
+        report = classifier.classify()
+        assert 0.0 <= report.profile.confidence <= 1.0
+
+    def test_rate_cv_nonnegative(self):
+        data = _make_benchmark(_make_requests(200, pattern="steady"))
+        classifier = LoadProfileClassifier(data)
+        report = classifier.classify()
+        assert report.profile.rate_cv >= 0
+
+    def test_peak_trough_at_least_one(self):
+        data = _make_benchmark(_make_requests(200, pattern="steady"))
+        classifier = LoadProfileClassifier(data)
+        report = classifier.classify()
+        assert report.profile.peak_to_trough_ratio >= 1.0
+
+    def test_single_request(self):
+        reqs = _make_requests(1, pattern="steady")
+        data = _make_benchmark(reqs)
+        classifier = LoadProfileClassifier(data)
+        report = classifier.classify()
+        assert report.total_requests == 1
+
+    def test_custom_window_size(self):
+        data = _make_benchmark(_make_requests(200, pattern="steady", duration=100))
+        classifier = LoadProfileClassifier(data)
+        report = classifier.classify(window_size=10.0)
+        assert len(report.windows) == 10
+
+    def test_description_not_empty(self):
+        data = _make_benchmark(_make_requests(200, pattern="steady"))
+        classifier = LoadProfileClassifier(data)
+        report = classifier.classify()
+        assert len(report.profile.description) > 0
+
+    def test_window_rates_nonnegative(self):
+        data = _make_benchmark(_make_requests(200, pattern="steady"))
+        classifier = LoadProfileClassifier(data)
+        report = classifier.classify()
+        for w in report.windows:
+            assert w.rate_rps >= 0
+            assert w.request_count >= 0
+
+    def test_profile_type_enum(self):
+        assert ProfileType.STEADY_STATE.value == "steady_state"
+        assert ProfileType.RAMP_UP.value == "ramp_up"
+        assert ProfileType.BURST.value == "burst"
+        assert ProfileType.CYCLIC.value == "cyclic"
+
+    def test_rate_window_model(self):
+        w = RateWindow(
+            start_time=1700000000.0,
+            end_time=1700000005.0,
+            request_count=50,
+            rate_rps=10.0,
+        )
+        assert w.request_count == 50
+
+    def test_load_profile_model(self):
+        p = LoadProfile(
+            profile_type=ProfileType.STEADY_STATE,
+            confidence=0.9,
+            rate_cv=0.05,
+            rate_trend_slope=0.0,
+            peak_to_trough_ratio=1.2,
+            description="Stable.",
+        )
+        assert p.profile_type == ProfileType.STEADY_STATE
+
+
+class TestClassifyLoadProfileAPI:
+    """Tests for the programmatic API."""
+
+    def test_returns_dict(self):
+        data = _make_benchmark(_make_requests(100, pattern="steady"))
+        result = classify_load_profile(data)
+        assert isinstance(result, dict)
+        assert "profile" in result
+        assert "windows" in result
+        assert "total_requests" in result
+
+    def test_custom_window_size(self):
+        data = _make_benchmark(_make_requests(100, pattern="steady", duration=50))
+        result = classify_load_profile(data, window_size=10.0)
+        assert isinstance(result, dict)
+        assert len(result["windows"]) == 5
+
+
+class TestLoadProfileCLI:
+    """Tests for CLI integration."""
+
+    def test_cli_json_output(self):
+        import subprocess
+
+        data = _make_benchmark(_make_requests(100, pattern="steady", duration=50))
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write(data.model_dump_json(indent=2))
+            f.flush()
+            result = subprocess.run(
+                ["xpyd-plan", "load-profile",
+                 "--benchmark", f.name, "--output-format", "json"],
+                capture_output=True, text=True,
+            )
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert "profile" in output
+        assert "windows" in output
+
+    def test_cli_table_output(self):
+        import subprocess
+
+        data = _make_benchmark(_make_requests(100, pattern="steady", duration=50))
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write(data.model_dump_json(indent=2))
+            f.flush()
+            result = subprocess.run(
+                ["xpyd-plan", "load-profile",
+                 "--benchmark", f.name, "--output-format", "table"],
+                capture_output=True, text=True,
+            )
+        assert result.returncode == 0
+        assert "rate" in result.stdout.lower() or "profile" in result.stdout.lower()


### PR DESCRIPTION
## Summary

Add load profile classification to determine the arrival pattern of benchmark requests.

### Changes
- `LoadProfileClassifier` class in `load_profile.py`
- `LoadProfile`, `LoadProfileReport`, `ProfileType`, `RateWindow` Pydantic models
- Time-windowed request rate computation with configurable window size
- 6 profile types: STEADY_STATE, RAMP_UP, RAMP_DOWN, BURST, CYCLIC, UNKNOWN
- Rate CV analysis for steady-state detection
- Linear regression on rate for ramp classification
- Peak-to-trough ratio for burst detection
- Direction change counting for cyclic detection
- CLI `load-profile` subcommand with `--benchmark`, `--window-size`, table + JSON output
- Programmatic `classify_load_profile()` API
- 22 new tests (1353 total, all passing)

Closes #135