### PR TITLE
feat: M65 Cost Projection & ROI Calculator

### DIFF
--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -692,3 +692,19 @@ __all__ += [
     "BatchReport",
     "analyze_batch_impact",
 ]
+
+from xpyd_plan.roi import (  # noqa: E402
+    CostProjection,
+    ROICalculator,
+    ROIReport,
+    SavingsEstimate,
+    calculate_roi,
+)
+
+__all__ += [
+    "CostProjection",
+    "ROICalculator",
+    "ROIReport",
+    "SavingsEstimate",
+    "calculate_roi",
+]

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -41,6 +41,7 @@ from xpyd_plan.cli._pipeline import _cmd_pipeline
 from xpyd_plan.cli._plan_benchmarks import _cmd_plan_benchmarks, add_plan_benchmarks_parser
 from xpyd_plan.cli._queue import add_queue_parser
 from xpyd_plan.cli._recommend import _cmd_recommend
+from xpyd_plan.cli._roi import add_roi_parser
 from xpyd_plan.cli._root_cause import _cmd_root_cause, add_root_cause_parser
 from xpyd_plan.cli._saturation import _cmd_saturation, add_saturation_parser
 from xpyd_plan.cli._scaling import _cmd_scaling, add_scaling_parser
@@ -892,6 +893,7 @@ def main(argv: list[str] | None = None) -> None:
     add_queue_parser(subparsers)
     add_batch_analysis_parser(subparsers)
     add_stat_summary_parser(subparsers)
+    add_roi_parser(subparsers)
     add_token_efficiency_parser(subparsers)
     add_timeline_parser(subparsers)
 
@@ -1052,6 +1054,9 @@ def main(argv: list[str] | None = None) -> None:
         _run_plugins(args)
     elif args.command == "token-efficiency":
         handle_token_efficiency(args)
+    elif args.command == "roi":
+        from xpyd_plan.cli._roi import _cmd_roi
+        _cmd_roi(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/cli/_roi.py
+++ b/src/xpyd_plan/cli/_roi.py
@@ -1,0 +1,124 @@
+"""CLI roi command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.cost import CostConfig
+from xpyd_plan.models import SLAConfig
+from xpyd_plan.roi import ROICalculator
+
+
+def _cmd_roi(args: argparse.Namespace) -> None:
+    """Handle the 'roi' subcommand."""
+    console = Console()
+
+    data = load_benchmark_auto(args.benchmark)
+    cost_config = CostConfig.from_yaml(args.cost_model)
+    sla = SLAConfig(
+        ttft_ms=getattr(args, "sla_ttft", None),
+        tpot_ms=getattr(args, "sla_tpot", None),
+        max_latency_ms=getattr(args, "sla_total", None),
+    )
+    migration_cost = getattr(args, "migration_cost", 0.0)
+
+    calculator = ROICalculator(cost_config, sla, migration_cost=migration_cost)
+    report = calculator.calculate(data)
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Current vs Optimal projections
+    proj_table = Table(title="Cost Projections")
+    proj_table.add_column("", justify="left")
+    proj_table.add_column("Current", justify="right")
+    proj_table.add_column("Optimal", justify="right")
+
+    cur = report.current_projection
+    opt = report.optimal_projection
+    proj_table.add_row("P:D Ratio", cur.ratio_str, opt.ratio_str)
+    proj_table.add_row("Instances", str(cur.total_instances), str(opt.total_instances))
+    proj_table.add_row("Meets SLA", str(cur.meets_sla), str(opt.meets_sla))
+    proj_table.add_row(
+        "Hourly",
+        f"{cur.currency} {cur.hourly_cost:.2f}",
+        f"{opt.currency} {opt.hourly_cost:.2f}",
+    )
+    proj_table.add_row(
+        "Daily",
+        f"{cur.currency} {cur.daily_cost:.2f}",
+        f"{opt.currency} {opt.daily_cost:.2f}",
+    )
+    proj_table.add_row(
+        "Monthly (30d)",
+        f"{cur.currency} {cur.monthly_cost:.2f}",
+        f"{opt.currency} {opt.monthly_cost:.2f}",
+    )
+    proj_table.add_row(
+        "Yearly",
+        f"{cur.currency} {cur.yearly_cost:.2f}",
+        f"{opt.currency} {opt.yearly_cost:.2f}",
+    )
+    console.print(proj_table)
+    console.print()
+
+    # Savings table
+    s = report.savings
+    sav_table = Table(title="Savings Estimate")
+    sav_table.add_column("Metric", justify="left")
+    sav_table.add_column("Value", justify="right")
+    sav_table.add_row("Migration", f"{s.current_ratio} → {s.optimal_ratio}")
+    sav_table.add_row("Hourly Savings", f"{s.currency} {s.hourly_savings:.2f}")
+    sav_table.add_row("Monthly Savings", f"{s.currency} {s.monthly_savings:.2f}")
+    sav_table.add_row("Yearly Savings", f"{s.currency} {s.yearly_savings:.2f}")
+    sav_table.add_row("Savings %", f"{s.savings_percent:.1f}%")
+    if s.migration_cost > 0:
+        sav_table.add_row("Migration Cost", f"{s.currency} {s.migration_cost:.2f}")
+        if s.break_even_hours is not None:
+            sav_table.add_row("Break-Even", f"{s.break_even_hours:.1f} hours")
+        else:
+            sav_table.add_row("Break-Even", "N/A (no savings)")
+    console.print(sav_table)
+
+
+def add_roi_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the roi subcommand parser."""
+    parser = subparsers.add_parser(
+        "roi",
+        help="Cost projection and ROI calculator",
+    )
+    parser.add_argument(
+        "--benchmark",
+        required=True,
+        help="Benchmark JSON file",
+    )
+    parser.add_argument(
+        "--cost-model",
+        required=True,
+        help="YAML file with GPU cost configuration",
+    )
+    parser.add_argument(
+        "--migration-cost",
+        type=float,
+        default=0.0,
+        help="One-time migration cost (default: 0)",
+    )
+    parser.add_argument("--sla-ttft", type=float, default=None, help="SLA TTFT (ms)")
+    parser.add_argument("--sla-tpot", type=float, default=None, help="SLA TPOT (ms)")
+    parser.add_argument("--sla-total", type=float, default=None, help="SLA total latency (ms)")
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_roi)

--- a/src/xpyd_plan/roi.py
+++ b/src/xpyd_plan/roi.py
@@ -1,0 +1,222 @@
+"""Cost projection and ROI calculator.
+
+Given current and optimal P:D ratio costs, project savings over time
+and calculate break-even points for migration investments.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from xpyd_plan.analyzer import BenchmarkAnalyzer
+from xpyd_plan.benchmark_models import BenchmarkData
+from xpyd_plan.cost import CostAnalyzer, CostConfig, CostResult
+from xpyd_plan.models import SLAConfig
+
+
+class CostProjection(BaseModel):
+    """Cost projection for a specific P:D configuration over time."""
+
+    num_prefill: int = Field(..., ge=1)
+    num_decode: int = Field(..., ge=1)
+    total_instances: int
+    hourly_cost: float = Field(..., ge=0)
+    daily_cost: float = Field(..., ge=0)
+    monthly_cost: float = Field(..., ge=0, description="30-day cost")
+    yearly_cost: float = Field(..., ge=0, description="365-day cost")
+    cost_per_request: float | None = None
+    currency: str = "USD"
+    meets_sla: bool = True
+
+    @property
+    def ratio_str(self) -> str:
+        return f"{self.num_prefill}P:{self.num_decode}D"
+
+
+class SavingsEstimate(BaseModel):
+    """Estimated savings from migrating to a cheaper configuration."""
+
+    current_ratio: str = Field(..., description="Current P:D ratio string")
+    optimal_ratio: str = Field(..., description="Optimal P:D ratio string")
+    hourly_savings: float = Field(..., description="Hourly cost savings")
+    daily_savings: float = Field(..., description="Daily cost savings")
+    monthly_savings: float = Field(..., description="Monthly (30-day) savings")
+    yearly_savings: float = Field(..., description="Yearly (365-day) savings")
+    savings_percent: float = Field(
+        ..., description="Savings as percentage of current cost"
+    )
+    migration_cost: float = Field(0.0, ge=0, description="One-time migration cost")
+    break_even_hours: float | None = Field(
+        None,
+        description="Hours until migration cost is recovered (None if no savings)",
+    )
+    currency: str = "USD"
+
+
+class ROIReport(BaseModel):
+    """Complete ROI analysis report."""
+
+    current_projection: CostProjection
+    optimal_projection: CostProjection
+    savings: SavingsEstimate
+    all_projections: list[CostProjection] = Field(default_factory=list)
+    currency: str = "USD"
+
+
+class ROICalculator:
+    """Calculate cost projections and ROI for P:D ratio configurations."""
+
+    def __init__(
+        self,
+        cost_config: CostConfig,
+        sla: SLAConfig,
+        *,
+        migration_cost: float = 0.0,
+    ) -> None:
+        self._cost_config = cost_config
+        self._sla = sla
+        self._migration_cost = migration_cost
+        self._cost_analyzer = CostAnalyzer(cost_config)
+
+    def _project(self, cost_result: CostResult) -> CostProjection:
+        """Create a time-based cost projection from a CostResult."""
+        hourly = cost_result.hourly_cost
+        return CostProjection(
+            num_prefill=cost_result.num_prefill,
+            num_decode=cost_result.num_decode,
+            total_instances=cost_result.total_instances,
+            hourly_cost=hourly,
+            daily_cost=hourly * 24,
+            monthly_cost=hourly * 24 * 30,
+            yearly_cost=hourly * 24 * 365,
+            cost_per_request=cost_result.cost_per_request,
+            currency=cost_result.currency,
+            meets_sla=cost_result.meets_sla,
+        )
+
+    def _estimate_savings(
+        self,
+        current: CostProjection,
+        optimal: CostProjection,
+    ) -> SavingsEstimate:
+        """Compute savings and break-even from current to optimal."""
+        hourly_savings = current.hourly_cost - optimal.hourly_cost
+        savings_pct = (
+            (hourly_savings / current.hourly_cost * 100)
+            if current.hourly_cost > 0
+            else 0.0
+        )
+
+        break_even = None
+        if hourly_savings > 0 and self._migration_cost > 0:
+            break_even = self._migration_cost / hourly_savings
+        elif hourly_savings <= 0 and self._migration_cost > 0:
+            break_even = None  # Never recovers
+
+        return SavingsEstimate(
+            current_ratio=current.ratio_str,
+            optimal_ratio=optimal.ratio_str,
+            hourly_savings=hourly_savings,
+            daily_savings=hourly_savings * 24,
+            monthly_savings=hourly_savings * 24 * 30,
+            yearly_savings=hourly_savings * 24 * 365,
+            savings_percent=savings_pct,
+            migration_cost=self._migration_cost,
+            break_even_hours=break_even,
+            currency=current.currency,
+        )
+
+    def calculate(
+        self,
+        data: BenchmarkData,
+    ) -> ROIReport:
+        """Run full ROI analysis on benchmark data.
+
+        Finds the current configuration's cost and the cost-optimal
+        SLA-meeting configuration, then computes savings projections.
+
+        Args:
+            data: Benchmark data with measured results.
+
+        Returns:
+            ROIReport with projections, savings, and break-even analysis.
+        """
+        analyzer = BenchmarkAnalyzer()
+        analyzer._data = data
+        analysis = analyzer.find_optimal_ratio(
+            data.metadata.total_instances, self._sla
+        )
+        measured_qps = data.metadata.measured_qps
+
+        # Current config cost
+        from xpyd_plan.benchmark_models import RatioCandidate
+
+        current_candidate = None
+        for c in analysis.candidates:
+            if (
+                c.num_prefill == data.metadata.num_prefill_instances
+                and c.num_decode == data.metadata.num_decode_instances
+            ):
+                current_candidate = c
+                break
+
+        if current_candidate is None:
+            # Fallback: create from metadata
+            current_candidate = RatioCandidate(
+                num_prefill=data.metadata.num_prefill_instances,
+                num_decode=data.metadata.num_decode_instances,
+                prefill_utilization=0.0,
+                decode_utilization=0.0,
+                waste_rate=1.0,
+                meets_sla=False,
+            )
+
+        current_cost = self._cost_analyzer.compute_cost(current_candidate, measured_qps)
+        current_proj = self._project(current_cost)
+
+        # Cost-optimal config
+        comparison = self._cost_analyzer.compare(analysis, measured_qps)
+
+        if comparison.cost_optimal is not None:
+            optimal_cost = comparison.cost_optimal
+        else:
+            # No SLA-meeting config; use current as "optimal"
+            optimal_cost = current_cost
+
+        optimal_proj = self._project(optimal_cost)
+
+        # All projections
+        all_costs = self._cost_analyzer.compute_all_costs(analysis, measured_qps)
+        all_projections = [self._project(c) for c in all_costs]
+
+        savings = self._estimate_savings(current_proj, optimal_proj)
+
+        return ROIReport(
+            current_projection=current_proj,
+            optimal_projection=optimal_proj,
+            savings=savings,
+            all_projections=all_projections,
+            currency=self._cost_config.currency,
+        )
+
+
+def calculate_roi(
+    data: BenchmarkData,
+    cost_config: CostConfig,
+    sla: SLAConfig,
+    *,
+    migration_cost: float = 0.0,
+) -> ROIReport:
+    """Programmatic API for ROI calculation.
+
+    Args:
+        data: Benchmark data with measured results.
+        cost_config: GPU cost configuration.
+        sla: SLA configuration for compliance checks.
+        migration_cost: One-time cost of migrating configurations.
+
+    Returns:
+        ROIReport with projections, savings, and break-even analysis.
+    """
+    calculator = ROICalculator(cost_config, sla, migration_cost=migration_cost)
+    return calculator.calculate(data)

--- a/tests/test_roi.py
+++ b/tests/test_roi.py
@@ -1,0 +1,388 @@
+"""Tests for the ROI calculator module."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from xpyd_plan.benchmark_models import (
+    BenchmarkData,
+    BenchmarkMetadata,
+    BenchmarkRequest,
+)
+from xpyd_plan.cost import CostConfig
+from xpyd_plan.models import SLAConfig
+from xpyd_plan.roi import (
+    CostProjection,
+    ROICalculator,
+    ROIReport,
+    SavingsEstimate,
+    calculate_roi,
+)
+
+
+def _make_requests(n: int = 100, base_ts: float = 1000.0) -> list[BenchmarkRequest]:
+    """Generate n benchmark requests."""
+    return [
+        BenchmarkRequest(
+            request_id=f"req-{i}",
+            prompt_tokens=50 + (i % 50),
+            output_tokens=20 + (i % 30),
+            ttft_ms=10.0 + (i % 20) * 0.5,
+            tpot_ms=5.0 + (i % 10) * 0.3,
+            total_latency_ms=50.0 + (i % 30) * 1.0,
+            timestamp=base_ts + i * 0.1,
+        )
+        for i in range(n)
+    ]
+
+
+def _make_benchmark(
+    num_prefill: int = 2,
+    num_decode: int = 2,
+    qps: float = 10.0,
+    n_requests: int = 100,
+) -> BenchmarkData:
+    total = num_prefill + num_decode
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=num_prefill,
+            num_decode_instances=num_decode,
+            total_instances=total,
+            measured_qps=qps,
+        ),
+        requests=_make_requests(n_requests),
+    )
+
+
+def _make_cost_config(rate: float = 3.0) -> CostConfig:
+    return CostConfig(gpu_hourly_rate=rate, currency="USD")
+
+
+def _make_sla() -> SLAConfig:
+    return SLAConfig(ttft_ms=50.0, tpot_ms=20.0, max_latency_ms=200.0)
+
+
+class TestCostProjection:
+    """Tests for CostProjection model."""
+
+    def test_ratio_str(self) -> None:
+        proj = CostProjection(
+            num_prefill=3,
+            num_decode=5,
+            total_instances=8,
+            hourly_cost=24.0,
+            daily_cost=576.0,
+            monthly_cost=17280.0,
+            yearly_cost=210240.0,
+        )
+        assert proj.ratio_str == "3P:5D"
+
+    def test_time_projections_consistent(self) -> None:
+        proj = CostProjection(
+            num_prefill=2,
+            num_decode=2,
+            total_instances=4,
+            hourly_cost=12.0,
+            daily_cost=288.0,
+            monthly_cost=8640.0,
+            yearly_cost=105120.0,
+        )
+        assert proj.daily_cost == proj.hourly_cost * 24
+        assert proj.monthly_cost == proj.hourly_cost * 24 * 30
+        assert proj.yearly_cost == proj.hourly_cost * 24 * 365
+
+
+class TestSavingsEstimate:
+    """Tests for SavingsEstimate model."""
+
+    def test_positive_savings(self) -> None:
+        s = SavingsEstimate(
+            current_ratio="3P:5D",
+            optimal_ratio="2P:2D",
+            hourly_savings=6.0,
+            daily_savings=144.0,
+            monthly_savings=4320.0,
+            yearly_savings=52560.0,
+            savings_percent=25.0,
+            migration_cost=100.0,
+            break_even_hours=16.67,
+        )
+        assert s.hourly_savings > 0
+        assert s.break_even_hours is not None
+
+    def test_no_savings(self) -> None:
+        s = SavingsEstimate(
+            current_ratio="2P:2D",
+            optimal_ratio="2P:2D",
+            hourly_savings=0.0,
+            daily_savings=0.0,
+            monthly_savings=0.0,
+            yearly_savings=0.0,
+            savings_percent=0.0,
+        )
+        assert s.break_even_hours is None
+
+
+class TestROICalculator:
+    """Tests for ROICalculator."""
+
+    def test_basic_calculation(self) -> None:
+        data = _make_benchmark(num_prefill=2, num_decode=2)
+        cost_config = _make_cost_config(3.0)
+        sla = _make_sla()
+
+        calc = ROICalculator(cost_config, sla)
+        report = calc.calculate(data)
+
+        assert isinstance(report, ROIReport)
+        assert report.current_projection is not None
+        assert report.optimal_projection is not None
+        assert report.savings is not None
+
+    def test_projections_are_consistent(self) -> None:
+        data = _make_benchmark()
+        cost_config = _make_cost_config(5.0)
+        sla = _make_sla()
+
+        report = ROICalculator(cost_config, sla).calculate(data)
+
+        cur = report.current_projection
+        assert cur.daily_cost == pytest.approx(cur.hourly_cost * 24)
+        assert cur.monthly_cost == pytest.approx(cur.hourly_cost * 24 * 30)
+        assert cur.yearly_cost == pytest.approx(cur.hourly_cost * 24 * 365)
+
+    def test_savings_consistent_with_projections(self) -> None:
+        data = _make_benchmark()
+        cost_config = _make_cost_config(3.0)
+        sla = _make_sla()
+
+        report = ROICalculator(cost_config, sla).calculate(data)
+        s = report.savings
+        cur = report.current_projection
+        opt = report.optimal_projection
+
+        assert s.hourly_savings == pytest.approx(cur.hourly_cost - opt.hourly_cost)
+        assert s.daily_savings == pytest.approx(s.hourly_savings * 24)
+        assert s.monthly_savings == pytest.approx(s.hourly_savings * 24 * 30)
+
+    def test_migration_cost_break_even(self) -> None:
+        data = _make_benchmark(num_prefill=3, num_decode=3)
+        cost_config = _make_cost_config(10.0)
+        sla = SLAConfig(ttft_ms=500.0, tpot_ms=500.0, max_latency_ms=5000.0)
+
+        report = ROICalculator(
+            cost_config, sla, migration_cost=1000.0
+        ).calculate(data)
+
+        s = report.savings
+        if s.hourly_savings > 0:
+            assert s.break_even_hours is not None
+            assert s.break_even_hours == pytest.approx(
+                1000.0 / s.hourly_savings
+            )
+
+    def test_no_migration_cost_no_break_even(self) -> None:
+        data = _make_benchmark()
+        cost_config = _make_cost_config(3.0)
+        sla = _make_sla()
+
+        report = ROICalculator(cost_config, sla, migration_cost=0.0).calculate(data)
+        # break_even_hours should be None when migration_cost = 0
+        assert report.savings.break_even_hours is None
+
+    def test_all_projections_populated(self) -> None:
+        data = _make_benchmark(num_prefill=2, num_decode=3)
+        cost_config = _make_cost_config(2.0)
+        sla = SLAConfig(ttft_ms=500.0, tpot_ms=500.0, max_latency_ms=5000.0)
+
+        report = ROICalculator(cost_config, sla).calculate(data)
+        assert len(report.all_projections) >= 1
+
+    def test_currency_propagated(self) -> None:
+        data = _make_benchmark()
+        cost_config = CostConfig(gpu_hourly_rate=3.0, currency="EUR")
+        sla = _make_sla()
+
+        report = ROICalculator(cost_config, sla).calculate(data)
+        assert report.currency == "EUR"
+        assert report.current_projection.currency == "EUR"
+        assert report.savings.currency == "EUR"
+
+    def test_same_config_zero_savings(self) -> None:
+        """When current == optimal, savings should be zero."""
+        data = _make_benchmark(num_prefill=1, num_decode=1)
+        cost_config = _make_cost_config(5.0)
+        # Very relaxed SLA so all configs pass
+        sla = SLAConfig(ttft_ms=9999.0, tpot_ms=9999.0, max_latency_ms=99999.0)
+
+        report = ROICalculator(cost_config, sla).calculate(data)
+        # With only total_instances=2, there's only one split (1P:1D)
+        assert report.savings.hourly_savings == pytest.approx(0.0)
+
+    def test_report_model_dump(self) -> None:
+        data = _make_benchmark()
+        cost_config = _make_cost_config(3.0)
+        sla = _make_sla()
+
+        report = ROICalculator(cost_config, sla).calculate(data)
+        d = report.model_dump()
+        assert "current_projection" in d
+        assert "optimal_projection" in d
+        assert "savings" in d
+        assert "all_projections" in d
+
+    def test_savings_percent_computed(self) -> None:
+        data = _make_benchmark(num_prefill=3, num_decode=3)
+        cost_config = _make_cost_config(10.0)
+        sla = SLAConfig(ttft_ms=500.0, tpot_ms=500.0, max_latency_ms=5000.0)
+
+        report = ROICalculator(cost_config, sla).calculate(data)
+        s = report.savings
+        cur = report.current_projection
+        if cur.hourly_cost > 0:
+            expected_pct = s.hourly_savings / cur.hourly_cost * 100
+            assert s.savings_percent == pytest.approx(expected_pct)
+
+
+class TestCalculateROIAPI:
+    """Tests for the programmatic calculate_roi() API."""
+
+    def test_returns_roi_report(self) -> None:
+        data = _make_benchmark()
+        cost_config = _make_cost_config(3.0)
+        sla = _make_sla()
+
+        report = calculate_roi(data, cost_config, sla)
+        assert isinstance(report, ROIReport)
+
+    def test_with_migration_cost(self) -> None:
+        data = _make_benchmark()
+        cost_config = _make_cost_config(3.0)
+        sla = _make_sla()
+
+        report = calculate_roi(data, cost_config, sla, migration_cost=500.0)
+        assert report.savings.migration_cost == 500.0
+
+    def test_json_serializable(self) -> None:
+        data = _make_benchmark()
+        cost_config = _make_cost_config(3.0)
+        sla = _make_sla()
+
+        report = calculate_roi(data, cost_config, sla)
+        dumped = json.dumps(report.model_dump())
+        assert isinstance(dumped, str)
+
+
+class TestROICLI:
+    """Tests for the ROI CLI subcommand."""
+
+    def _write_benchmark(self, path: Path, data: BenchmarkData) -> None:
+        path.write_text(json.dumps(data.model_dump()))
+
+    def _write_cost_config(self, path: Path, rate: float = 3.0) -> None:
+        path.write_text(f"gpu_hourly_rate: {rate}\ncurrency: USD\n")
+
+    def test_cli_table_output(self) -> None:
+        from unittest.mock import patch
+
+        data = _make_benchmark()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bench_path = Path(tmpdir) / "bench.json"
+            cost_path = Path(tmpdir) / "cost.yaml"
+            self._write_benchmark(bench_path, data)
+            self._write_cost_config(cost_path)
+
+            with patch(
+                "sys.argv",
+                [
+                    "xpyd-plan",
+                    "roi",
+                    "--benchmark",
+                    str(bench_path),
+                    "--cost-model",
+                    str(cost_path),
+                    "--sla-ttft",
+                    "50",
+                    "--sla-tpot",
+                    "20",
+                    "--sla-total",
+                    "200",
+                ],
+            ):
+                from xpyd_plan.cli import main
+
+                main()
+
+    def test_cli_json_output(self) -> None:
+        import io
+        from unittest.mock import patch
+
+        data = _make_benchmark()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bench_path = Path(tmpdir) / "bench.json"
+            cost_path = Path(tmpdir) / "cost.yaml"
+            self._write_benchmark(bench_path, data)
+            self._write_cost_config(cost_path)
+
+            captured = io.StringIO()
+            with (
+                patch(
+                    "sys.argv",
+                    [
+                        "xpyd-plan",
+                        "roi",
+                        "--benchmark",
+                        str(bench_path),
+                        "--cost-model",
+                        str(cost_path),
+                        "--sla-ttft",
+                        "50",
+                        "--output-format",
+                        "json",
+                    ],
+                ),
+                patch("sys.stdout", captured),
+            ):
+                from xpyd_plan.cli import main
+
+                main()
+
+            output = json.loads(captured.getvalue())
+            assert "current_projection" in output
+            assert "savings" in output
+
+    def test_cli_with_migration_cost(self) -> None:
+        from unittest.mock import patch
+
+        data = _make_benchmark()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bench_path = Path(tmpdir) / "bench.json"
+            cost_path = Path(tmpdir) / "cost.yaml"
+            self._write_benchmark(bench_path, data)
+            self._write_cost_config(cost_path)
+
+            with patch(
+                "sys.argv",
+                [
+                    "xpyd-plan",
+                    "roi",
+                    "--benchmark",
+                    str(bench_path),
+                    "--cost-model",
+                    str(cost_path),
+                    "--migration-cost",
+                    "500",
+                    "--sla-ttft",
+                    "50",
+                ],
+            ):
+                from xpyd_plan.cli import main
+
+                main()


### PR DESCRIPTION
## Summary

Add cost projection and ROI calculator for comparing P:D ratio configurations over time.

## Changes

- `ROICalculator` class in `roi.py` with `calculate()` method
- `CostProjection` model: hourly/daily/monthly/yearly cost fields
- `SavingsEstimate` model: savings amounts, percentages, break-even hours
- `ROIReport` model combining current/optimal projections and savings
- CLI `roi` subcommand with `--benchmark`, `--cost-model`, `--migration-cost`, table + JSON output
- Programmatic `calculate_roi()` API
- 20 new tests (1470 total, all passing)

Closes #149