### PR TITLE
feat: Benchmark Schema Versioning & Migration (M66)

### DIFF
--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -708,3 +708,17 @@ __all__ += [
     "SavingsEstimate",
     "calculate_roi",
 ]
+
+from xpyd_plan.schema_migrate import (  # noqa: E402
+    MigrationResult,
+    SchemaMigrator,
+    SchemaVersion,
+    migrate_schema,
+)
+
+__all__ += [
+    "MigrationResult",
+    "SchemaVersion",
+    "SchemaMigrator",
+    "migrate_schema",
+]

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -32,6 +32,7 @@ from xpyd_plan.cli._interpolate import _cmd_interpolate
 from xpyd_plan.cli._load_profile import add_load_profile_parser
 from xpyd_plan.cli._merge import _cmd_merge
 from xpyd_plan.cli._metrics import _cmd_metrics, add_metrics_parser
+from xpyd_plan.cli._migrate import add_migrate_parser
 from xpyd_plan.cli._model_compare import _cmd_model_compare
 from xpyd_plan.cli._outlier_impact import (
     add_outlier_impact_parser,
@@ -893,6 +894,7 @@ def main(argv: list[str] | None = None) -> None:
     add_queue_parser(subparsers)
     add_batch_analysis_parser(subparsers)
     add_stat_summary_parser(subparsers)
+    add_migrate_parser(subparsers)
     add_roi_parser(subparsers)
     add_token_efficiency_parser(subparsers)
     add_timeline_parser(subparsers)

--- a/src/xpyd_plan/cli/_migrate.py
+++ b/src/xpyd_plan/cli/_migrate.py
@@ -1,0 +1,119 @@
+"""CLI migrate command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.schema_migrate import (
+    LATEST_VERSION,
+    MigrationResult,
+    SchemaMigrator,
+    SchemaVersion,
+)
+
+
+def _cmd_migrate(args: argparse.Namespace) -> None:
+    """Handle the 'migrate' subcommand."""
+    console = Console()
+    migrator = SchemaMigrator()
+
+    target = SchemaVersion.parse(args.target_version) if args.target_version else None
+    dry_run = getattr(args, "dry_run", False)
+    output_path = getattr(args, "output", None)
+    output_format = getattr(args, "output_format", "table")
+
+    results: list[MigrationResult] = []
+    for bench_path in args.benchmark:
+        try:
+            result = migrator.migrate_file(
+                bench_path,
+                target_version=target,
+                dry_run=dry_run,
+                output_path=output_path,
+            )
+            results.append(result)
+        except (ValueError, FileNotFoundError) as e:
+            console.print(f"[red]Error processing {bench_path}: {e}[/red]")
+            sys.exit(1)
+
+    if output_format == "json":
+        out = [
+            {
+                "file": str(bench_path),
+                "source_version": r.source_version,
+                "target_version": r.target_version,
+                "migrated": r.migrated,
+                "changes": r.changes,
+            }
+            for bench_path, r in zip(args.benchmark, results)
+        ]
+        console.print_json(json.dumps(out))
+        return
+
+    # Table output
+    table = Table(title="Schema Migration Results")
+    table.add_column("File", style="cyan")
+    table.add_column("From", justify="center")
+    table.add_column("To", justify="center")
+    table.add_column("Status", justify="center")
+    table.add_column("Changes")
+
+    for bench_path, result in zip(args.benchmark, results):
+        if result.migrated:
+            status = "[green]migrated[/green]"
+        elif result.changes:
+            status = "[yellow]dry-run[/yellow]"
+        else:
+            status = "[dim]up-to-date[/dim]"
+
+        changes_str = "; ".join(result.changes) if result.changes else "—"
+        table.add_row(
+            str(bench_path),
+            result.source_version,
+            result.target_version,
+            status,
+            changes_str,
+        )
+
+    console.print(table)
+
+
+def add_migrate_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the 'migrate' subcommand parser."""
+    p = subparsers.add_parser(
+        "migrate",
+        help="Migrate benchmark files to a newer schema version",
+    )
+    p.add_argument(
+        "--benchmark",
+        nargs="+",
+        required=True,
+        help="Benchmark JSON file(s) to migrate",
+    )
+    p.add_argument(
+        "--target-version",
+        default=None,
+        help=f"Target schema version (default: {LATEST_VERSION})",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview changes without writing files",
+    )
+    p.add_argument(
+        "--output",
+        default=None,
+        help="Output file path (default: overwrite in place; only for single file)",
+    )
+    p.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    p.set_defaults(func=_cmd_migrate)

--- a/src/xpyd_plan/schema_migrate.py
+++ b/src/xpyd_plan/schema_migrate.py
@@ -1,0 +1,313 @@
+"""Benchmark schema versioning and migration.
+
+Detect benchmark JSON schema version and migrate between versions.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class SchemaVersion(BaseModel):
+    """Represents a schema version with comparison support."""
+
+    major: int = Field(..., ge=1, description="Major version number")
+    minor: int = Field(0, ge=0, description="Minor version number")
+
+    @classmethod
+    def parse(cls, version_str: str) -> SchemaVersion:
+        """Parse a version string like '1', '1.0', '2', '2.0'.
+
+        Args:
+            version_str: Version string to parse.
+
+        Returns:
+            Parsed SchemaVersion.
+
+        Raises:
+            ValueError: If the version string is malformed.
+        """
+        parts = str(version_str).strip().split(".")
+        if len(parts) == 1:
+            return cls(major=int(parts[0]))
+        if len(parts) == 2:
+            return cls(major=int(parts[0]), minor=int(parts[1]))
+        raise ValueError(f"Invalid schema version: {version_str!r}")
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SchemaVersion):
+            return NotImplemented
+        return self.major == other.major and self.minor == other.minor
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, SchemaVersion):
+            return NotImplemented
+        return (self.major, self.minor) < (other.major, other.minor)
+
+    def __le__(self, other: object) -> bool:
+        if not isinstance(other, SchemaVersion):
+            return NotImplemented
+        return (self.major, self.minor) <= (other.major, other.minor)
+
+    def __gt__(self, other: object) -> bool:
+        if not isinstance(other, SchemaVersion):
+            return NotImplemented
+        return (self.major, self.minor) > (other.major, other.minor)
+
+    def __ge__(self, other: object) -> bool:
+        if not isinstance(other, SchemaVersion):
+            return NotImplemented
+        return (self.major, self.minor) >= (other.major, other.minor)
+
+    def __hash__(self) -> int:
+        return hash((self.major, self.minor))
+
+
+class MigrationResult(BaseModel):
+    """Result of a schema migration operation."""
+
+    source_version: str = Field(..., description="Original schema version")
+    target_version: str = Field(..., description="Target schema version after migration")
+    migrated: bool = Field(..., description="Whether migration was performed")
+    changes: list[str] = Field(default_factory=list, description="List of changes applied")
+    data: dict[str, Any] = Field(..., description="Migrated benchmark data")
+
+
+# Current latest version
+LATEST_VERSION = SchemaVersion(major=2, minor=0)
+
+# All known versions
+KNOWN_VERSIONS = {
+    SchemaVersion(major=1, minor=0),
+    SchemaVersion(major=2, minor=0),
+}
+
+
+def detect_version(data: dict[str, Any]) -> SchemaVersion:
+    """Detect the schema version of benchmark data.
+
+    Args:
+        data: Parsed benchmark JSON data.
+
+    Returns:
+        Detected SchemaVersion.
+
+    Raises:
+        ValueError: If the data format is unrecognized.
+    """
+    if "schema_version" in data:
+        return SchemaVersion.parse(str(data["schema_version"]))
+
+    # Native format without explicit version → v1.0
+    if "metadata" in data and "requests" in data:
+        return SchemaVersion(major=1, minor=0)
+
+    # xpyd-bench format without explicit version → v1.0
+    if "bench_config" in data and "results" in data:
+        return SchemaVersion(major=1, minor=0)
+
+    raise ValueError(
+        "Cannot detect schema version. Expected 'schema_version' field, "
+        "or recognized format with 'metadata'+'requests' or 'bench_config'+'results'."
+    )
+
+
+def _migrate_v1_to_v2(data: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Migrate v1 data to v2 format.
+
+    v2 adds:
+    - schema_version field at top level
+    - metadata.run_id (UUID if not present)
+    - metadata.schema_version
+
+    Args:
+        data: v1 benchmark data.
+
+    Returns:
+        Tuple of (migrated data, list of change descriptions).
+    """
+    result = deepcopy(data)
+    changes: list[str] = []
+
+    # Add top-level schema_version
+    result["schema_version"] = "2.0"
+    changes.append("Added top-level 'schema_version': '2.0'")
+
+    # Add run_id to metadata if present
+    if "metadata" in result:
+        if "run_id" not in result["metadata"]:
+            result["metadata"]["run_id"] = str(uuid.uuid4())
+            changes.append("Added 'metadata.run_id' (generated UUID)")
+        if "schema_version" not in result["metadata"]:
+            result["metadata"]["schema_version"] = "2.0"
+            changes.append("Added 'metadata.schema_version': '2.0'")
+
+    return result, changes
+
+
+class SchemaMigrator:
+    """Detect and migrate benchmark data between schema versions."""
+
+    def __init__(self) -> None:
+        self._migrations: dict[tuple[SchemaVersion, SchemaVersion], Any] = {
+            (SchemaVersion(major=1, minor=0), SchemaVersion(major=2, minor=0)): _migrate_v1_to_v2,
+        }
+
+    def detect(self, data: dict[str, Any]) -> SchemaVersion:
+        """Detect schema version of benchmark data.
+
+        Args:
+            data: Parsed benchmark JSON.
+
+        Returns:
+            Detected SchemaVersion.
+        """
+        return detect_version(data)
+
+    def needs_migration(
+        self,
+        data: dict[str, Any],
+        target_version: SchemaVersion | None = None,
+    ) -> bool:
+        """Check if data needs migration to reach target version.
+
+        Args:
+            data: Parsed benchmark JSON.
+            target_version: Target version (default: LATEST_VERSION).
+
+        Returns:
+            True if migration is needed.
+        """
+        target = target_version or LATEST_VERSION
+        current = self.detect(data)
+        return current < target
+
+    def migrate(
+        self,
+        data: dict[str, Any],
+        target_version: SchemaVersion | None = None,
+        dry_run: bool = False,
+    ) -> MigrationResult:
+        """Migrate benchmark data to target version.
+
+        Args:
+            data: Parsed benchmark JSON.
+            target_version: Target version (default: LATEST_VERSION).
+            dry_run: If True, compute changes but return original data.
+
+        Returns:
+            MigrationResult with migrated data and change log.
+
+        Raises:
+            ValueError: If migration path is not available.
+        """
+        target = target_version or LATEST_VERSION
+        current = self.detect(data)
+
+        if current == target:
+            return MigrationResult(
+                source_version=str(current),
+                target_version=str(target),
+                migrated=False,
+                changes=[],
+                data=deepcopy(data),
+            )
+
+        if current > target:
+            raise ValueError(
+                f"Cannot downgrade from {current} to {target}. "
+                "Only forward migrations are supported."
+            )
+
+        # Find migration path
+        migration_key = (current, target)
+        if migration_key not in self._migrations:
+            raise ValueError(
+                f"No migration path from {current} to {target}. "
+                f"Known migrations: {list(self._migrations.keys())}"
+            )
+
+        migrate_fn = self._migrations[migration_key]
+        migrated_data, changes = migrate_fn(data)
+
+        if dry_run:
+            return MigrationResult(
+                source_version=str(current),
+                target_version=str(target),
+                migrated=False,
+                changes=changes,
+                data=deepcopy(data),
+            )
+
+        return MigrationResult(
+            source_version=str(current),
+            target_version=str(target),
+            migrated=True,
+            changes=changes,
+            data=migrated_data,
+        )
+
+    def migrate_file(
+        self,
+        path: str | Path,
+        target_version: SchemaVersion | None = None,
+        dry_run: bool = False,
+        output_path: str | Path | None = None,
+    ) -> MigrationResult:
+        """Migrate a benchmark JSON file.
+
+        Args:
+            path: Path to benchmark JSON file.
+            target_version: Target version (default: LATEST_VERSION).
+            dry_run: If True, preview changes without writing.
+            output_path: Where to write migrated file (default: overwrite in place).
+
+        Returns:
+            MigrationResult.
+        """
+        path = Path(path)
+        with open(path) as f:
+            data = json.load(f)
+
+        result = self.migrate(data, target_version=target_version, dry_run=dry_run)
+
+        if result.migrated and not dry_run:
+            out = Path(output_path) if output_path else path
+            with open(out, "w") as f:
+                json.dump(result.data, f, indent=2)
+                f.write("\n")
+
+        return result
+
+
+def migrate_schema(
+    path: str | Path,
+    target_version: str | None = None,
+    dry_run: bool = False,
+    output_path: str | Path | None = None,
+) -> MigrationResult:
+    """Programmatic API: migrate a benchmark file's schema.
+
+    Args:
+        path: Path to benchmark JSON file.
+        target_version: Target version string (default: latest).
+        dry_run: Preview changes without writing.
+        output_path: Output file path (default: overwrite in place).
+
+    Returns:
+        MigrationResult.
+    """
+    migrator = SchemaMigrator()
+    target = SchemaVersion.parse(target_version) if target_version else None
+    return migrator.migrate_file(
+        path, target_version=target, dry_run=dry_run, output_path=output_path
+    )

--- a/tests/test_schema_migrate.py
+++ b/tests/test_schema_migrate.py
@@ -1,0 +1,218 @@
+"""Tests for schema_migrate module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_plan.schema_migrate import (
+    SchemaMigrator,
+    SchemaVersion,
+    detect_version,
+    migrate_schema,
+)
+
+# ---------- SchemaVersion ----------
+
+
+class TestSchemaVersion:
+    def test_parse_single_digit(self) -> None:
+        v = SchemaVersion.parse("1")
+        assert v.major == 1
+        assert v.minor == 0
+
+    def test_parse_major_minor(self) -> None:
+        v = SchemaVersion.parse("2.0")
+        assert v.major == 2
+        assert v.minor == 0
+
+    def test_parse_invalid(self) -> None:
+        with pytest.raises(ValueError):
+            SchemaVersion.parse("1.2.3")
+
+    def test_str(self) -> None:
+        assert str(SchemaVersion(major=2, minor=0)) == "2.0"
+
+    def test_comparison(self) -> None:
+        v1 = SchemaVersion(major=1, minor=0)
+        v2 = SchemaVersion(major=2, minor=0)
+        assert v1 < v2
+        assert v2 > v1
+        assert v1 <= v2
+        assert v2 >= v1
+        assert v1 == SchemaVersion(major=1, minor=0)
+        assert v1 != v2
+
+    def test_hash(self) -> None:
+        v1a = SchemaVersion(major=1, minor=0)
+        v1b = SchemaVersion(major=1, minor=0)
+        assert hash(v1a) == hash(v1b)
+        assert {v1a, v1b} == {v1a}
+
+
+# ---------- detect_version ----------
+
+
+def _make_v1_data() -> dict:
+    return {
+        "metadata": {
+            "num_prefill_instances": 2,
+            "num_decode_instances": 2,
+            "total_instances": 4,
+            "measured_qps": 10.0,
+        },
+        "requests": [
+            {
+                "request_id": "r1",
+                "prompt_tokens": 100,
+                "output_tokens": 50,
+                "ttft_ms": 20.0,
+                "tpot_ms": 5.0,
+                "total_latency_ms": 270.0,
+                "timestamp": 1000.0,
+            }
+        ],
+    }
+
+
+def _make_v2_data() -> dict:
+    d = _make_v1_data()
+    d["schema_version"] = "2.0"
+    d["metadata"]["run_id"] = "abc-123"
+    d["metadata"]["schema_version"] = "2.0"
+    return d
+
+
+class TestDetectVersion:
+    def test_detect_v1_native(self) -> None:
+        v = detect_version(_make_v1_data())
+        assert v == SchemaVersion(major=1, minor=0)
+
+    def test_detect_v1_xpyd_bench(self) -> None:
+        data = {"bench_config": {}, "results": []}
+        v = detect_version(data)
+        assert v == SchemaVersion(major=1, minor=0)
+
+    def test_detect_explicit_version(self) -> None:
+        data = _make_v1_data()
+        data["schema_version"] = "2.0"
+        v = detect_version(data)
+        assert v == SchemaVersion(major=2, minor=0)
+
+    def test_detect_unknown_format(self) -> None:
+        with pytest.raises(ValueError, match="Cannot detect"):
+            detect_version({"random": "stuff"})
+
+
+# ---------- SchemaMigrator ----------
+
+
+class TestSchemaMigrator:
+    def setup_method(self) -> None:
+        self.migrator = SchemaMigrator()
+
+    def test_detect(self) -> None:
+        v = self.migrator.detect(_make_v1_data())
+        assert v == SchemaVersion(major=1, minor=0)
+
+    def test_needs_migration_v1(self) -> None:
+        assert self.migrator.needs_migration(_make_v1_data()) is True
+
+    def test_needs_migration_v2(self) -> None:
+        assert self.migrator.needs_migration(_make_v2_data()) is False
+
+    def test_migrate_v1_to_v2(self) -> None:
+        result = self.migrator.migrate(_make_v1_data())
+        assert result.migrated is True
+        assert result.source_version == "1.0"
+        assert result.target_version == "2.0"
+        assert result.data["schema_version"] == "2.0"
+        assert "run_id" in result.data["metadata"]
+        assert result.data["metadata"]["schema_version"] == "2.0"
+        assert len(result.changes) >= 2
+
+    def test_migrate_already_latest(self) -> None:
+        result = self.migrator.migrate(_make_v2_data())
+        assert result.migrated is False
+        assert result.changes == []
+
+    def test_migrate_dry_run(self) -> None:
+        data = _make_v1_data()
+        result = self.migrator.migrate(data, dry_run=True)
+        assert result.migrated is False
+        assert len(result.changes) > 0
+        # Original data should not have schema_version
+        assert "schema_version" not in result.data
+
+    def test_migrate_downgrade_error(self) -> None:
+        v2 = _make_v2_data()
+        with pytest.raises(ValueError, match="Cannot downgrade"):
+            self.migrator.migrate(v2, target_version=SchemaVersion(major=1, minor=0))
+
+    def test_migrate_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "bench.json"
+        f.write_text(json.dumps(_make_v1_data()))
+
+        result = self.migrator.migrate_file(str(f))
+        assert result.migrated is True
+
+        # File should be overwritten
+        written = json.loads(f.read_text())
+        assert written["schema_version"] == "2.0"
+
+    def test_migrate_file_dry_run(self, tmp_path: Path) -> None:
+        f = tmp_path / "bench.json"
+        original = _make_v1_data()
+        f.write_text(json.dumps(original))
+
+        result = self.migrator.migrate_file(str(f), dry_run=True)
+        assert result.migrated is False
+
+        # File should NOT be changed
+        written = json.loads(f.read_text())
+        assert "schema_version" not in written
+
+    def test_migrate_file_output_path(self, tmp_path: Path) -> None:
+        src = tmp_path / "input.json"
+        dst = tmp_path / "output.json"
+        src.write_text(json.dumps(_make_v1_data()))
+
+        result = self.migrator.migrate_file(str(src), output_path=str(dst))
+        assert result.migrated is True
+        assert dst.exists()
+        written = json.loads(dst.read_text())
+        assert written["schema_version"] == "2.0"
+
+        # Source should be unchanged
+        original = json.loads(src.read_text())
+        assert "schema_version" not in original
+
+
+# ---------- Programmatic API ----------
+
+
+class TestMigrateSchema:
+    def test_migrate_schema_api(self, tmp_path: Path) -> None:
+        f = tmp_path / "bench.json"
+        f.write_text(json.dumps(_make_v1_data()))
+
+        result = migrate_schema(str(f))
+        assert result.migrated is True
+        assert result.target_version == "2.0"
+
+    def test_migrate_schema_specific_version(self, tmp_path: Path) -> None:
+        f = tmp_path / "bench.json"
+        f.write_text(json.dumps(_make_v1_data()))
+
+        result = migrate_schema(str(f), target_version="2.0")
+        assert result.migrated is True
+
+    def test_migrate_schema_dry_run(self, tmp_path: Path) -> None:
+        f = tmp_path / "bench.json"
+        f.write_text(json.dumps(_make_v1_data()))
+
+        result = migrate_schema(str(f), dry_run=True)
+        assert result.migrated is False
+        assert len(result.changes) > 0


### PR DESCRIPTION
## Summary

Implement M66: Benchmark Schema Versioning & Migration.

Closes #151

## Changes

- `SchemaMigrator` class in `schema_migrate.py`
- `MigrationResult`, `SchemaVersion` Pydantic models
- Detect benchmark JSON schema version from file content
- Migrate older schema versions to current format (v1 → v2 transformations)
- v2 adds: top-level `schema_version`, `metadata.run_id`, `metadata.schema_version`
- Dry-run mode to preview changes without writing
- CLI `migrate` subcommand with `--benchmark`, `--target-version`, `--dry-run`, `--output`, `--output-format`
- Programmatic `migrate_schema()` API
- 23 new tests (1493 total, all passing)

## Test Results
```
1493 passed in 46.24s
```