### PR TITLE
feat: Request Replay Schedule Generator (M67)

### DIFF
--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -722,3 +722,19 @@ __all__ += [
     "SchemaMigrator",
     "migrate_schema",
 ]
+
+from xpyd_plan.replay import (  # noqa: E402
+    ReplayConfig,
+    ReplayEntry,
+    ReplayGenerator,
+    ReplaySchedule,
+    generate_replay,
+)
+
+__all__ += [
+    "ReplayConfig",
+    "ReplayEntry",
+    "ReplayGenerator",
+    "ReplaySchedule",
+    "generate_replay",
+]

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -42,6 +42,7 @@ from xpyd_plan.cli._pipeline import _cmd_pipeline
 from xpyd_plan.cli._plan_benchmarks import _cmd_plan_benchmarks, add_plan_benchmarks_parser
 from xpyd_plan.cli._queue import add_queue_parser
 from xpyd_plan.cli._recommend import _cmd_recommend
+from xpyd_plan.cli._replay import add_replay_parser
 from xpyd_plan.cli._roi import add_roi_parser
 from xpyd_plan.cli._root_cause import _cmd_root_cause, add_root_cause_parser
 from xpyd_plan.cli._saturation import _cmd_saturation, add_saturation_parser
@@ -895,6 +896,7 @@ def main(argv: list[str] | None = None) -> None:
     add_batch_analysis_parser(subparsers)
     add_stat_summary_parser(subparsers)
     add_migrate_parser(subparsers)
+    add_replay_parser(subparsers)
     add_roi_parser(subparsers)
     add_token_efficiency_parser(subparsers)
     add_timeline_parser(subparsers)

--- a/src/xpyd_plan/cli/_replay.py
+++ b/src/xpyd_plan/cli/_replay.py
@@ -1,0 +1,130 @@
+"""CLI replay command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.replay import ReplayConfig, ReplayGenerator
+
+
+def _cmd_replay(args: argparse.Namespace) -> None:
+    """Handle the 'replay' subcommand."""
+    console = Console()
+    output_format = getattr(args, "output_format", "table")
+    output_path = getattr(args, "output", None)
+
+    config = ReplayConfig(
+        time_scale=args.time_scale,
+        target_qps=args.target_qps,
+    )
+    generator = ReplayGenerator(config)
+
+    try:
+        schedule = generator.generate_from_file(args.benchmark)
+    except (ValueError, FileNotFoundError) as e:
+        console.print(f"[red]Error: {e}[/red]")
+        sys.exit(1)
+
+    if output_format == "json":
+        out = {
+            "request_count": schedule.request_count,
+            "total_duration_ms": schedule.total_duration_ms,
+            "effective_qps": schedule.effective_qps,
+            "config": {
+                "time_scale": schedule.config.time_scale,
+                "target_qps": schedule.config.target_qps,
+            },
+            "entries": [e.model_dump() for e in schedule.entries],
+        }
+        if output_path:
+            with open(output_path, "w") as f:
+                json.dump(out, f, indent=2)
+                f.write("\n")
+            console.print(f"[green]Replay schedule written to {output_path}[/green]")
+        else:
+            console.print_json(json.dumps(out))
+        return
+
+    # Table output — summary + first/last entries
+    summary = Table(title="Replay Schedule Summary")
+    summary.add_column("Metric", style="cyan")
+    summary.add_column("Value", justify="right")
+    summary.add_row("Request count", str(schedule.request_count))
+    summary.add_row("Total duration (ms)", f"{schedule.total_duration_ms:.1f}")
+    summary.add_row("Effective QPS", f"{schedule.effective_qps:.2f}")
+    summary.add_row("Time scale", f"{schedule.config.time_scale:.2f}")
+    if schedule.config.target_qps:
+        summary.add_row("Target QPS", f"{schedule.config.target_qps:.2f}")
+    console.print(summary)
+
+    if schedule.entries:
+        detail = Table(title="Replay Entries (first 20)")
+        detail.add_column("#", justify="right")
+        detail.add_column("Offset (ms)", justify="right")
+        detail.add_column("Prompt Tokens", justify="right")
+        detail.add_column("Output Tokens", justify="right")
+
+        for i, entry in enumerate(schedule.entries[:20]):
+            detail.add_row(
+                str(i + 1),
+                f"{entry.offset_ms:.1f}",
+                str(entry.prompt_tokens),
+                str(entry.output_tokens),
+            )
+        if len(schedule.entries) > 20:
+            detail.add_row("...", "...", "...", "...")
+        console.print(detail)
+
+    if output_path:
+        out = {
+            "request_count": schedule.request_count,
+            "total_duration_ms": schedule.total_duration_ms,
+            "effective_qps": schedule.effective_qps,
+            "entries": [e.model_dump() for e in schedule.entries],
+        }
+        with open(output_path, "w") as f:
+            json.dump(out, f, indent=2)
+            f.write("\n")
+        console.print(f"[green]Replay schedule written to {output_path}[/green]")
+
+
+def add_replay_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the 'replay' subcommand parser."""
+    p = subparsers.add_parser(
+        "replay",
+        help="Generate a replay schedule from benchmark data",
+    )
+    p.add_argument(
+        "--benchmark",
+        required=True,
+        help="Benchmark JSON file",
+    )
+    p.add_argument(
+        "--time-scale",
+        type=float,
+        default=1.0,
+        help="Time scaling factor (2.0 = 2x faster, 0.5 = 2x slower; default: 1.0)",
+    )
+    p.add_argument(
+        "--target-qps",
+        type=float,
+        default=None,
+        help="Override QPS with uniform distribution",
+    )
+    p.add_argument(
+        "--output",
+        default=None,
+        help="Output file path for the replay schedule JSON",
+    )
+    p.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    p.set_defaults(func=_cmd_replay)

--- a/src/xpyd_plan/replay.py
+++ b/src/xpyd_plan/replay.py
@@ -1,0 +1,193 @@
+"""Request replay schedule generator.
+
+Extract request arrival patterns from benchmark data and generate
+reproducible replay schedules for benchmark reproduction.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ReplayEntry(BaseModel):
+    """A single entry in a replay schedule."""
+
+    offset_ms: float = Field(..., ge=0, description="Time offset from start in milliseconds")
+    prompt_tokens: int = Field(..., ge=0, description="Number of prompt tokens")
+    output_tokens: int = Field(..., ge=0, description="Number of output tokens")
+
+
+class ReplayConfig(BaseModel):
+    """Configuration for replay schedule generation."""
+
+    time_scale: float = Field(1.0, gt=0, description="Time scaling factor (2.0 = 2x faster)")
+    target_qps: float | None = Field(None, gt=0, description="Override QPS (uniform distribution)")
+
+
+class ReplaySchedule(BaseModel):
+    """Generated replay schedule."""
+
+    entries: list[ReplayEntry] = Field(default_factory=list, description="Ordered replay entries")
+    total_duration_ms: float = Field(..., ge=0, description="Total schedule duration in ms")
+    request_count: int = Field(..., ge=0, description="Number of requests in the schedule")
+    effective_qps: float = Field(..., ge=0, description="Effective QPS of the schedule")
+    config: ReplayConfig = Field(..., description="Configuration used to generate this schedule")
+
+
+class ReplayGenerator:
+    """Generate replay schedules from benchmark data."""
+
+    def __init__(self, config: ReplayConfig | None = None) -> None:
+        self._config = config or ReplayConfig()
+
+    def generate(self, data: dict[str, Any]) -> ReplaySchedule:
+        """Generate a replay schedule from benchmark data.
+
+        Args:
+            data: Parsed benchmark JSON data.
+
+        Returns:
+            ReplaySchedule with ordered entries.
+
+        Raises:
+            ValueError: If data is missing required fields.
+        """
+        requests = self._extract_requests(data)
+        if not requests:
+            return ReplaySchedule(
+                entries=[],
+                total_duration_ms=0.0,
+                request_count=0,
+                effective_qps=0.0,
+                config=self._config,
+            )
+
+        # Sort by timestamp
+        requests.sort(key=lambda r: r["timestamp"])
+
+        base_timestamp = requests[0]["timestamp"]
+
+        if self._config.target_qps is not None:
+            entries = self._generate_uniform(requests, self._config.target_qps)
+        else:
+            entries = self._generate_from_timestamps(requests, base_timestamp)
+
+        # Apply time scaling
+        if self._config.time_scale != 1.0:
+            scale = self._config.time_scale
+            entries = [
+                ReplayEntry(
+                    offset_ms=e.offset_ms / scale,
+                    prompt_tokens=e.prompt_tokens,
+                    output_tokens=e.output_tokens,
+                )
+                for e in entries
+            ]
+
+        total_duration_ms = entries[-1].offset_ms if entries else 0.0
+        effective_qps = (
+            (len(entries) / (total_duration_ms / 1000.0)) if total_duration_ms > 0 else 0.0
+        )
+
+        return ReplaySchedule(
+            entries=entries,
+            total_duration_ms=total_duration_ms,
+            request_count=len(entries),
+            effective_qps=round(effective_qps, 2),
+            config=self._config,
+        )
+
+    def _extract_requests(self, data: dict[str, Any]) -> list[dict[str, Any]]:
+        """Extract request list from benchmark data (native or xpyd-bench format)."""
+        if "requests" in data:
+            reqs = data["requests"]
+        elif "results" in data:
+            reqs = data["results"]
+        else:
+            raise ValueError(
+                "Benchmark data must have 'requests' or 'results' field."
+            )
+
+        validated = []
+        for r in reqs:
+            if "timestamp" not in r:
+                raise ValueError(
+                    "Each request must have a 'timestamp' field for replay generation."
+                )
+            validated.append(
+                {
+                    "timestamp": float(r["timestamp"]),
+                    "prompt_tokens": int(r.get("prompt_tokens", 0)),
+                    "output_tokens": int(r.get("output_tokens", 0)),
+                }
+            )
+        return validated
+
+    def _generate_from_timestamps(
+        self,
+        requests: list[dict[str, Any]],
+        base_timestamp: float,
+    ) -> list[ReplayEntry]:
+        """Generate entries preserving original inter-arrival times."""
+        return [
+            ReplayEntry(
+                offset_ms=(r["timestamp"] - base_timestamp) * 1000.0,
+                prompt_tokens=r["prompt_tokens"],
+                output_tokens=r["output_tokens"],
+            )
+            for r in requests
+        ]
+
+    def _generate_uniform(
+        self,
+        requests: list[dict[str, Any]],
+        target_qps: float,
+    ) -> list[ReplayEntry]:
+        """Redistribute arrivals uniformly at target QPS."""
+        interval_ms = 1000.0 / target_qps
+        return [
+            ReplayEntry(
+                offset_ms=i * interval_ms,
+                prompt_tokens=r["prompt_tokens"],
+                output_tokens=r["output_tokens"],
+            )
+            for i, r in enumerate(requests)
+        ]
+
+    def generate_from_file(self, path: str | Path) -> ReplaySchedule:
+        """Generate replay schedule from a benchmark JSON file.
+
+        Args:
+            path: Path to benchmark JSON file.
+
+        Returns:
+            ReplaySchedule.
+        """
+        import json
+
+        with open(path) as f:
+            data = json.load(f)
+        return self.generate(data)
+
+
+def generate_replay(
+    path: str | Path,
+    time_scale: float = 1.0,
+    target_qps: float | None = None,
+) -> ReplaySchedule:
+    """Programmatic API: generate a replay schedule from a benchmark file.
+
+    Args:
+        path: Path to benchmark JSON file.
+        time_scale: Time scaling factor (default 1.0).
+        target_qps: Override QPS with uniform distribution (optional).
+
+    Returns:
+        ReplaySchedule.
+    """
+    config = ReplayConfig(time_scale=time_scale, target_qps=target_qps)
+    generator = ReplayGenerator(config)
+    return generator.generate_from_file(path)

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,0 +1,274 @@
+"""Tests for replay module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_plan.replay import (
+    ReplayConfig,
+    ReplayEntry,
+    ReplayGenerator,
+    generate_replay,
+)
+
+
+def _make_benchmark_data(n: int = 10, base_ts: float = 1000.0, interval: float = 0.1) -> dict:
+    """Create benchmark data with n requests spaced by interval seconds."""
+    return {
+        "metadata": {
+            "num_prefill_instances": 2,
+            "num_decode_instances": 2,
+            "total_instances": 4,
+            "measured_qps": n / (n * interval) if n > 0 else 0,
+        },
+        "requests": [
+            {
+                "request_id": f"r{i}",
+                "prompt_tokens": 100 + i * 10,
+                "output_tokens": 50 + i * 5,
+                "ttft_ms": 20.0,
+                "tpot_ms": 5.0,
+                "total_latency_ms": 270.0,
+                "timestamp": base_ts + i * interval,
+            }
+            for i in range(n)
+        ],
+    }
+
+
+# ---------- ReplayEntry ----------
+
+
+class TestReplayEntry:
+    def test_create(self) -> None:
+        e = ReplayEntry(offset_ms=100.0, prompt_tokens=128, output_tokens=64)
+        assert e.offset_ms == 100.0
+        assert e.prompt_tokens == 128
+        assert e.output_tokens == 64
+
+    def test_offset_non_negative(self) -> None:
+        with pytest.raises(Exception):
+            ReplayEntry(offset_ms=-1.0, prompt_tokens=0, output_tokens=0)
+
+
+# ---------- ReplayConfig ----------
+
+
+class TestReplayConfig:
+    def test_defaults(self) -> None:
+        c = ReplayConfig()
+        assert c.time_scale == 1.0
+        assert c.target_qps is None
+
+    def test_time_scale_positive(self) -> None:
+        with pytest.raises(Exception):
+            ReplayConfig(time_scale=0)
+
+    def test_target_qps_positive(self) -> None:
+        with pytest.raises(Exception):
+            ReplayConfig(target_qps=0)
+
+
+# ---------- ReplayGenerator basic ----------
+
+
+class TestReplayGeneratorBasic:
+    def test_generate_preserves_order(self) -> None:
+        data = _make_benchmark_data(5)
+        gen = ReplayGenerator()
+        schedule = gen.generate(data)
+        assert schedule.request_count == 5
+        offsets = [e.offset_ms for e in schedule.entries]
+        assert offsets == sorted(offsets)
+
+    def test_first_offset_is_zero(self) -> None:
+        data = _make_benchmark_data(3)
+        gen = ReplayGenerator()
+        schedule = gen.generate(data)
+        assert schedule.entries[0].offset_ms == 0.0
+
+    def test_relative_timestamps(self) -> None:
+        data = _make_benchmark_data(3, base_ts=5000.0, interval=0.5)
+        gen = ReplayGenerator()
+        schedule = gen.generate(data)
+        assert schedule.entries[0].offset_ms == pytest.approx(0.0)
+        assert schedule.entries[1].offset_ms == pytest.approx(500.0)
+        assert schedule.entries[2].offset_ms == pytest.approx(1000.0)
+
+    def test_token_counts_preserved(self) -> None:
+        data = _make_benchmark_data(3)
+        gen = ReplayGenerator()
+        schedule = gen.generate(data)
+        assert schedule.entries[0].prompt_tokens == 100
+        assert schedule.entries[0].output_tokens == 50
+        assert schedule.entries[2].prompt_tokens == 120
+        assert schedule.entries[2].output_tokens == 60
+
+    def test_empty_requests(self) -> None:
+        data = {"metadata": {}, "requests": []}
+        gen = ReplayGenerator()
+        schedule = gen.generate(data)
+        assert schedule.request_count == 0
+        assert schedule.total_duration_ms == 0.0
+        assert schedule.effective_qps == 0.0
+
+    def test_single_request(self) -> None:
+        data = _make_benchmark_data(1)
+        gen = ReplayGenerator()
+        schedule = gen.generate(data)
+        assert schedule.request_count == 1
+        assert schedule.entries[0].offset_ms == 0.0
+        assert schedule.total_duration_ms == 0.0
+
+
+# ---------- Time scaling ----------
+
+
+class TestTimeScaling:
+    def test_scale_2x_faster(self) -> None:
+        data = _make_benchmark_data(5, interval=1.0)
+        config = ReplayConfig(time_scale=2.0)
+        gen = ReplayGenerator(config)
+        schedule = gen.generate(data)
+        # Original: 0, 1000, 2000, 3000, 4000 ms
+        # Scaled 2x: 0, 500, 1000, 1500, 2000 ms
+        assert schedule.entries[1].offset_ms == pytest.approx(500.0)
+        assert schedule.entries[4].offset_ms == pytest.approx(2000.0)
+
+    def test_scale_half_speed(self) -> None:
+        data = _make_benchmark_data(3, interval=0.1)
+        config = ReplayConfig(time_scale=0.5)
+        gen = ReplayGenerator(config)
+        schedule = gen.generate(data)
+        # Original: 0, 100, 200 ms → Scaled 0.5x: 0, 200, 400 ms
+        assert schedule.entries[1].offset_ms == pytest.approx(200.0)
+        assert schedule.entries[2].offset_ms == pytest.approx(400.0)
+
+
+# ---------- Target QPS ----------
+
+
+class TestTargetQPS:
+    def test_uniform_distribution(self) -> None:
+        data = _make_benchmark_data(5)
+        config = ReplayConfig(target_qps=10.0)
+        gen = ReplayGenerator(config)
+        schedule = gen.generate(data)
+        # 10 QPS → 100ms interval
+        assert schedule.entries[0].offset_ms == pytest.approx(0.0)
+        assert schedule.entries[1].offset_ms == pytest.approx(100.0)
+        assert schedule.entries[4].offset_ms == pytest.approx(400.0)
+
+    def test_target_qps_preserves_tokens(self) -> None:
+        data = _make_benchmark_data(3)
+        config = ReplayConfig(target_qps=5.0)
+        gen = ReplayGenerator(config)
+        schedule = gen.generate(data)
+        assert schedule.entries[0].prompt_tokens == 100
+        assert schedule.entries[2].prompt_tokens == 120
+
+    def test_target_qps_with_time_scale(self) -> None:
+        data = _make_benchmark_data(4)
+        config = ReplayConfig(target_qps=10.0, time_scale=2.0)
+        gen = ReplayGenerator(config)
+        schedule = gen.generate(data)
+        # target_qps=10 → 100ms intervals, then scale 2x → 50ms intervals
+        assert schedule.entries[1].offset_ms == pytest.approx(50.0)
+
+
+# ---------- ReplaySchedule fields ----------
+
+
+class TestReplaySchedule:
+    def test_effective_qps(self) -> None:
+        data = _make_benchmark_data(10, interval=0.1)
+        gen = ReplayGenerator()
+        schedule = gen.generate(data)
+        # 10 requests over 900ms = ~11.1 QPS
+        assert schedule.effective_qps > 0
+        assert schedule.total_duration_ms == pytest.approx(900.0)
+
+    def test_config_stored(self) -> None:
+        config = ReplayConfig(time_scale=3.0, target_qps=20.0)
+        gen = ReplayGenerator(config)
+        schedule = gen.generate(_make_benchmark_data(5))
+        assert schedule.config.time_scale == 3.0
+        assert schedule.config.target_qps == 20.0
+
+
+# ---------- Error handling ----------
+
+
+class TestErrors:
+    def test_missing_requests_field(self) -> None:
+        with pytest.raises(ValueError, match="requests"):
+            ReplayGenerator().generate({"foo": "bar"})
+
+    def test_missing_timestamp(self) -> None:
+        data = {"requests": [{"prompt_tokens": 100, "output_tokens": 50}]}
+        with pytest.raises(ValueError, match="timestamp"):
+            ReplayGenerator().generate(data)
+
+
+# ---------- File-based ----------
+
+
+class TestFileGeneration:
+    def test_generate_from_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "bench.json"
+        f.write_text(json.dumps(_make_benchmark_data(5)))
+        gen = ReplayGenerator()
+        schedule = gen.generate_from_file(f)
+        assert schedule.request_count == 5
+
+    def test_generate_from_file_not_found(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            ReplayGenerator().generate_from_file("/nonexistent/file.json")
+
+
+# ---------- Programmatic API ----------
+
+
+class TestGenerateReplay:
+    def test_api_basic(self, tmp_path: Path) -> None:
+        f = tmp_path / "bench.json"
+        f.write_text(json.dumps(_make_benchmark_data(5)))
+        schedule = generate_replay(str(f))
+        assert schedule.request_count == 5
+
+    def test_api_with_options(self, tmp_path: Path) -> None:
+        f = tmp_path / "bench.json"
+        f.write_text(json.dumps(_make_benchmark_data(5)))
+        schedule = generate_replay(str(f), time_scale=2.0, target_qps=10.0)
+        assert schedule.config.time_scale == 2.0
+        assert schedule.config.target_qps == 10.0
+
+
+# ---------- xpyd-bench format ----------
+
+
+class TestXpydBenchFormat:
+    def test_results_field(self) -> None:
+        data = {
+            "bench_config": {},
+            "results": [
+                {
+                    "prompt_tokens": 100,
+                    "output_tokens": 50,
+                    "timestamp": 1000.0,
+                },
+                {
+                    "prompt_tokens": 200,
+                    "output_tokens": 100,
+                    "timestamp": 1001.0,
+                },
+            ],
+        }
+        gen = ReplayGenerator()
+        schedule = gen.generate(data)
+        assert schedule.request_count == 2
+        assert schedule.entries[0].prompt_tokens == 100
+        assert schedule.entries[1].offset_ms == pytest.approx(1000.0)


### PR DESCRIPTION
## Summary

Implement M67: Request Replay Schedule Generator.

Closes #153

## Changes

- `ReplayGenerator` class in `replay.py`
- `ReplaySchedule`, `ReplayEntry`, `ReplayConfig` Pydantic models
- Extract request arrival times and token counts from benchmark data
- Generate reproducible replay schedule (JSON) with relative timestamps
- Time scaling: speed up or slow down schedule (`--time-scale` factor)
- QPS override: redistribute arrivals uniformly (`--target-qps`)
- Support both native and xpyd-bench benchmark formats
- CLI `replay` subcommand with `--benchmark`, `--time-scale`, `--target-qps`, `--output`, `--output-format`
- Programmatic `generate_replay()` API
- 25 new tests (1518 total, all passing)

## Test Results
```
1518 passed in 49.12s
```