### PR TITLE
feat: M68 — Latency-Token Regression Analysis

### DIFF
--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -257,6 +257,13 @@ from xpyd_plan.recommender import (
     RecommendationReport,
     get_recommendations,
 )
+from xpyd_plan.regression import (
+    PredictedLatency,
+    RegressionAnalyzer,
+    RegressionFit,
+    RegressionReport,
+    analyze_regression,
+)
 from xpyd_plan.root_cause import (
     CauseFactor,
     FactorSignificance,
@@ -434,6 +441,11 @@ __all__ = [
     "RecommendationPriority",
     "RecommendationReport",
     "get_recommendations",
+    "PredictedLatency",
+    "RegressionAnalyzer",
+    "RegressionFit",
+    "RegressionReport",
+    "analyze_regression",
     "FleetAllocation",
     "FleetCalculator",
     "FleetOption",

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -42,6 +42,7 @@ from xpyd_plan.cli._pipeline import _cmd_pipeline
 from xpyd_plan.cli._plan_benchmarks import _cmd_plan_benchmarks, add_plan_benchmarks_parser
 from xpyd_plan.cli._queue import add_queue_parser
 from xpyd_plan.cli._recommend import _cmd_recommend
+from xpyd_plan.cli._regression import _cmd_regression, add_regression_parser
 from xpyd_plan.cli._replay import add_replay_parser
 from xpyd_plan.cli._roi import add_roi_parser
 from xpyd_plan.cli._root_cause import _cmd_root_cause, add_root_cause_parser
@@ -896,6 +897,7 @@ def main(argv: list[str] | None = None) -> None:
     add_batch_analysis_parser(subparsers)
     add_stat_summary_parser(subparsers)
     add_migrate_parser(subparsers)
+    add_regression_parser(subparsers)
     add_replay_parser(subparsers)
     add_roi_parser(subparsers)
     add_token_efficiency_parser(subparsers)
@@ -1061,6 +1063,8 @@ def main(argv: list[str] | None = None) -> None:
     elif args.command == "roi":
         from xpyd_plan.cli._roi import _cmd_roi
         _cmd_roi(args)
+    elif args.command == "regression":
+        _cmd_regression(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/cli/_regression.py
+++ b/src/xpyd_plan/cli/_regression.py
@@ -1,0 +1,109 @@
+"""CLI regression command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.regression import RegressionAnalyzer
+
+
+def _cmd_regression(args: argparse.Namespace) -> None:
+    """Handle the 'regression' subcommand."""
+    console = Console()
+
+    data = load_benchmark_auto(args.benchmark)
+    analyzer = RegressionAnalyzer(data)
+
+    predict_prompt = getattr(args, "predict_prompt", None)
+    predict_output = getattr(args, "predict_output", None)
+
+    report = analyzer.analyze(
+        predict_prompt=predict_prompt,
+        predict_output=predict_output,
+    )
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Regression fits table
+    fit_table = Table(title="Latency-Token Regression Fits")
+    fit_table.add_column("Predictor", justify="left")
+    fit_table.add_column("Target", justify="left")
+    fit_table.add_column("Slope (ms/tok)", justify="right")
+    fit_table.add_column("Intercept (ms)", justify="right")
+    fit_table.add_column("R²", justify="right")
+    fit_table.add_column("Slope SE", justify="right")
+    fit_table.add_column("Samples", justify="right")
+
+    for fit in report.fits:
+        fit_table.add_row(
+            fit.predictor,
+            fit.target,
+            f"{fit.slope:.4f}",
+            f"{fit.intercept:.2f}",
+            f"{fit.r_squared:.4f}",
+            f"{fit.slope_std_err:.4f}",
+            str(fit.n_samples),
+        )
+
+    console.print(fit_table)
+
+    if report.predictions:
+        pred_table = Table(title="Latency Predictions (95% CI)")
+        pred_table.add_column("Metric", justify="left")
+        pred_table.add_column("Token Count", justify="right")
+        pred_table.add_column("Predicted (ms)", justify="right")
+        pred_table.add_column("CI Lower (ms)", justify="right")
+        pred_table.add_column("CI Upper (ms)", justify="right")
+
+        for pred in report.predictions:
+            pred_table.add_row(
+                pred.metric,
+                str(pred.token_count),
+                f"{pred.predicted_ms:.2f}",
+                f"{pred.ci_lower_ms:.2f}",
+                f"{pred.ci_upper_ms:.2f}",
+            )
+
+        console.print(pred_table)
+
+
+def add_regression_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the regression subcommand parser."""
+    parser = subparsers.add_parser(
+        "regression",
+        help="Latency-token regression analysis (fit linear models, predict latency)",
+    )
+    parser.add_argument(
+        "--benchmark",
+        required=True,
+        help="Path to benchmark JSON file",
+    )
+    parser.add_argument(
+        "--predict-prompt",
+        type=int,
+        default=None,
+        help="Predict TTFT for this prompt token count",
+    )
+    parser.add_argument(
+        "--predict-output",
+        type=int,
+        default=None,
+        help="Predict TPOT for this output token count",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_regression)

--- a/src/xpyd_plan/regression.py
+++ b/src/xpyd_plan/regression.py
@@ -1,0 +1,240 @@
+"""Latency-token regression analysis.
+
+Fit linear regression models to understand how latency scales with token counts
+and predict expected latency for given token counts.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from xpyd_plan.benchmark_models import BenchmarkData
+
+
+class RegressionFit(BaseModel):
+    """Result of a single linear regression fit."""
+
+    predictor: str = Field(..., description="Predictor variable name")
+    target: str = Field(..., description="Target latency metric name")
+    slope: float = Field(..., description="Regression slope (ms per token)")
+    intercept: float = Field(..., description="Regression intercept (ms)")
+    r_squared: float = Field(..., ge=0, le=1, description="Coefficient of determination")
+    n_samples: int = Field(..., ge=1, description="Number of data points")
+    slope_std_err: float = Field(..., ge=0, description="Standard error of slope")
+
+
+class PredictedLatency(BaseModel):
+    """Predicted latency for given token counts."""
+
+    metric: str = Field(..., description="Latency metric name")
+    predicted_ms: float = Field(..., description="Predicted latency (ms)")
+    ci_lower_ms: float = Field(..., description="95% CI lower bound (ms)")
+    ci_upper_ms: float = Field(..., description="95% CI upper bound (ms)")
+    token_count: int = Field(..., description="Input token count used for prediction")
+
+
+class RegressionReport(BaseModel):
+    """Complete regression analysis report."""
+
+    fits: list[RegressionFit] = Field(..., description="Regression fits for each metric pair")
+    predictions: list[PredictedLatency] = Field(
+        default_factory=list, description="Predicted latencies (if requested)"
+    )
+
+
+def _linear_regression(
+    x: np.ndarray, y: np.ndarray
+) -> tuple[float, float, float, float, float]:
+    """Compute linear regression: y = slope*x + intercept.
+
+    Returns (slope, intercept, r_squared, slope_std_err, residual_std).
+    """
+    n = len(x)
+    x_mean = np.mean(x)
+    y_mean = np.mean(y)
+    ss_xx = np.sum((x - x_mean) ** 2)
+    ss_xy = np.sum((x - x_mean) * (y - y_mean))
+    ss_yy = np.sum((y - y_mean) ** 2)
+
+    if ss_xx == 0:
+        return 0.0, float(y_mean), 0.0, 0.0, 0.0
+
+    slope = float(ss_xy / ss_xx)
+    intercept = float(y_mean - slope * x_mean)
+
+    ss_res = float(np.sum((y - (slope * x + intercept)) ** 2))
+    r_squared = 1 - ss_res / ss_yy if ss_yy > 0 else 0.0
+    r_squared = max(0.0, min(1.0, r_squared))
+
+    if n > 2:
+        mse = ss_res / (n - 2)
+        slope_std_err = math.sqrt(mse / ss_xx) if ss_xx > 0 else 0.0
+        residual_std = math.sqrt(mse)
+    else:
+        slope_std_err = 0.0
+        residual_std = 0.0
+
+    return slope, intercept, r_squared, slope_std_err, residual_std
+
+
+def _predict_with_ci(
+    x_pred: float,
+    slope: float,
+    intercept: float,
+    residual_std: float,
+    x_arr: np.ndarray,
+    n: int,
+) -> tuple[float, float, float]:
+    """Predict y at x_pred with 95% confidence interval."""
+    y_pred = slope * x_pred + intercept
+
+    if n <= 2 or residual_std == 0:
+        return y_pred, y_pred, y_pred
+
+    x_mean = float(np.mean(x_arr))
+    ss_xx = float(np.sum((x_arr - x_mean) ** 2))
+
+    # Use ~1.96 for 95% CI (normal approximation for large n)
+    t_val = 1.96
+    if ss_xx > 0:
+        se_pred = residual_std * math.sqrt(1 + 1 / n + (x_pred - x_mean) ** 2 / ss_xx)
+    else:
+        se_pred = residual_std
+
+    ci_lower = y_pred - t_val * se_pred
+    ci_upper = y_pred + t_val * se_pred
+    return y_pred, ci_lower, ci_upper
+
+
+class RegressionAnalyzer:
+    """Analyze latency-token regression relationships."""
+
+    def __init__(self, data: BenchmarkData) -> None:
+        self._data = data
+
+    def analyze(
+        self,
+        predict_prompt: int | None = None,
+        predict_output: int | None = None,
+    ) -> RegressionReport:
+        """Run regression analysis and optional predictions."""
+        requests = self._data.requests
+        prompt_arr = np.array([r.prompt_tokens for r in requests], dtype=float)
+        output_arr = np.array([r.output_tokens for r in requests], dtype=float)
+        ttft_arr = np.array([r.ttft_ms for r in requests], dtype=float)
+        tpot_arr = np.array([r.tpot_ms for r in requests], dtype=float)
+        total_arr = np.array([r.total_latency_ms for r in requests], dtype=float)
+        total_tokens = prompt_arr + output_arr
+
+        n = len(requests)
+
+        # Define regression pairs: (predictor_name, predictor_arr, target_name, target_arr)
+        pairs = [
+            ("prompt_tokens", prompt_arr, "ttft_ms", ttft_arr),
+            ("output_tokens", output_arr, "tpot_ms", tpot_arr),
+            ("total_tokens", total_tokens, "total_latency_ms", total_arr),
+        ]
+
+        fits: list[RegressionFit] = []
+        residual_stds: dict[str, tuple[float, np.ndarray]] = {}
+
+        for pred_name, x, target_name, y in pairs:
+            slope, intercept, r_sq, slope_se, res_std = _linear_regression(x, y)
+            fits.append(
+                RegressionFit(
+                    predictor=pred_name,
+                    target=target_name,
+                    slope=slope,
+                    intercept=intercept,
+                    r_squared=r_sq,
+                    n_samples=n,
+                    slope_std_err=slope_se,
+                )
+            )
+            residual_stds[target_name] = (res_std, x)
+
+        predictions: list[PredictedLatency] = []
+
+        if predict_prompt is not None:
+            # TTFT prediction
+            fit_ttft = fits[0]
+            res_std, x_arr = residual_stds["ttft_ms"]
+            y_pred, ci_lo, ci_hi = _predict_with_ci(
+                float(predict_prompt),
+                fit_ttft.slope,
+                fit_ttft.intercept,
+                res_std,
+                x_arr,
+                n,
+            )
+            predictions.append(
+                PredictedLatency(
+                    metric="ttft_ms",
+                    predicted_ms=y_pred,
+                    ci_lower_ms=ci_lo,
+                    ci_upper_ms=ci_hi,
+                    token_count=predict_prompt,
+                )
+            )
+
+        if predict_output is not None:
+            # TPOT prediction
+            fit_tpot = fits[1]
+            res_std, x_arr = residual_stds["tpot_ms"]
+            y_pred, ci_lo, ci_hi = _predict_with_ci(
+                float(predict_output),
+                fit_tpot.slope,
+                fit_tpot.intercept,
+                res_std,
+                x_arr,
+                n,
+            )
+            predictions.append(
+                PredictedLatency(
+                    metric="tpot_ms",
+                    predicted_ms=y_pred,
+                    ci_lower_ms=ci_lo,
+                    ci_upper_ms=ci_hi,
+                    token_count=predict_output,
+                )
+            )
+
+        if predict_prompt is not None and predict_output is not None:
+            # Total latency prediction
+            fit_total = fits[2]
+            total_tok = predict_prompt + predict_output
+            res_std, x_arr = residual_stds["total_latency_ms"]
+            y_pred, ci_lo, ci_hi = _predict_with_ci(
+                float(total_tok),
+                fit_total.slope,
+                fit_total.intercept,
+                res_std,
+                x_arr,
+                n,
+            )
+            predictions.append(
+                PredictedLatency(
+                    metric="total_latency_ms",
+                    predicted_ms=y_pred,
+                    ci_lower_ms=ci_lo,
+                    ci_upper_ms=ci_hi,
+                    token_count=total_tok,
+                )
+            )
+
+        return RegressionReport(fits=fits, predictions=predictions)
+
+
+def analyze_regression(
+    data: BenchmarkData,
+    predict_prompt: int | None = None,
+    predict_output: int | None = None,
+) -> RegressionReport:
+    """Programmatic API for regression analysis."""
+    analyzer = RegressionAnalyzer(data)
+    return analyzer.analyze(
+        predict_prompt=predict_prompt, predict_output=predict_output
+    )

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,0 +1,261 @@
+"""Tests for latency-token regression analysis."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.regression import (
+    RegressionAnalyzer,
+    RegressionReport,
+    analyze_regression,
+)
+
+
+def _make_benchmark(
+    num_requests: int = 100,
+    linear: bool = True,
+) -> BenchmarkData:
+    """Create benchmark data. If linear=True, latency scales linearly with tokens."""
+    requests = []
+    for i in range(num_requests):
+        prompt = 50 + i * 10
+        output = 20 + i * 5
+        if linear:
+            ttft = 10.0 + 0.05 * prompt + (i % 3) * 0.5  # small noise
+            tpot = 5.0 + 0.1 * output + (i % 4) * 0.3
+            total = ttft + tpot * output
+        else:
+            # Random-ish, weak correlation
+            ttft = 50.0 + (i % 7) * 10.0
+            tpot = 20.0 + (i % 5) * 8.0
+            total = 300.0 + (i % 11) * 50.0
+
+        requests.append(
+            BenchmarkRequest(
+                request_id=f"req-{i}",
+                prompt_tokens=prompt,
+                output_tokens=output,
+                ttft_ms=ttft,
+                tpot_ms=tpot,
+                total_latency_ms=total,
+                timestamp=1000.0 + i * 0.1,
+            )
+        )
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=6,
+            total_instances=8,
+            measured_qps=10.0,
+        ),
+        requests=requests,
+    )
+
+
+class TestRegressionAnalyzer:
+    """Tests for RegressionAnalyzer."""
+
+    def test_basic_fits(self) -> None:
+        data = _make_benchmark(linear=True)
+        analyzer = RegressionAnalyzer(data)
+        report = analyzer.analyze()
+
+        assert len(report.fits) == 3
+        assert report.fits[0].predictor == "prompt_tokens"
+        assert report.fits[0].target == "ttft_ms"
+        assert report.fits[1].predictor == "output_tokens"
+        assert report.fits[1].target == "tpot_ms"
+        assert report.fits[2].predictor == "total_tokens"
+        assert report.fits[2].target == "total_latency_ms"
+
+    def test_linear_data_high_r_squared(self) -> None:
+        data = _make_benchmark(linear=True)
+        report = analyze_regression(data)
+        # With strong linear relationship, R² should be high
+        for fit in report.fits:
+            assert fit.r_squared > 0.8, f"{fit.predictor}->{fit.target} R²={fit.r_squared}"
+
+    def test_weak_correlation_low_r_squared(self) -> None:
+        data = _make_benchmark(linear=False)
+        report = analyze_regression(data)
+        # TTFT with weak pattern should have lower R²
+        ttft_fit = report.fits[0]
+        # Not necessarily very low but shouldn't be near 1.0
+        assert ttft_fit.r_squared < 0.95
+
+    def test_slope_positive_for_linear(self) -> None:
+        data = _make_benchmark(linear=True)
+        report = analyze_regression(data)
+        for fit in report.fits:
+            assert fit.slope > 0, f"{fit.predictor} slope should be positive"
+
+    def test_n_samples(self) -> None:
+        data = _make_benchmark(num_requests=50, linear=True)
+        report = analyze_regression(data)
+        for fit in report.fits:
+            assert fit.n_samples == 50
+
+    def test_no_predictions_by_default(self) -> None:
+        data = _make_benchmark(linear=True)
+        report = analyze_regression(data)
+        assert report.predictions == []
+
+    def test_predict_prompt(self) -> None:
+        data = _make_benchmark(linear=True)
+        report = analyze_regression(data, predict_prompt=500)
+        assert len(report.predictions) == 1
+        pred = report.predictions[0]
+        assert pred.metric == "ttft_ms"
+        assert pred.token_count == 500
+        assert pred.ci_lower_ms <= pred.predicted_ms <= pred.ci_upper_ms
+
+    def test_predict_output(self) -> None:
+        data = _make_benchmark(linear=True)
+        report = analyze_regression(data, predict_output=200)
+        assert len(report.predictions) == 1
+        pred = report.predictions[0]
+        assert pred.metric == "tpot_ms"
+        assert pred.token_count == 200
+
+    def test_predict_both(self) -> None:
+        data = _make_benchmark(linear=True)
+        report = analyze_regression(data, predict_prompt=500, predict_output=200)
+        assert len(report.predictions) == 3
+        metrics = [p.metric for p in report.predictions]
+        assert "ttft_ms" in metrics
+        assert "tpot_ms" in metrics
+        assert "total_latency_ms" in metrics
+
+    def test_total_prediction_token_count(self) -> None:
+        data = _make_benchmark(linear=True)
+        report = analyze_regression(data, predict_prompt=500, predict_output=200)
+        total_pred = [p for p in report.predictions if p.metric == "total_latency_ms"][0]
+        assert total_pred.token_count == 700
+
+    def test_ci_width(self) -> None:
+        data = _make_benchmark(linear=True, num_requests=100)
+        report = analyze_regression(data, predict_prompt=500)
+        pred = report.predictions[0]
+        ci_width = pred.ci_upper_ms - pred.ci_lower_ms
+        assert ci_width > 0
+
+    def test_small_dataset(self) -> None:
+        """Should work with minimum viable data (2 points)."""
+        requests = [
+            BenchmarkRequest(
+                request_id="r0", prompt_tokens=100, output_tokens=50,
+                ttft_ms=20.0, tpot_ms=10.0, total_latency_ms=100.0, timestamp=1000.0,
+            ),
+            BenchmarkRequest(
+                request_id="r1", prompt_tokens=200, output_tokens=100,
+                ttft_ms=30.0, tpot_ms=15.0, total_latency_ms=200.0, timestamp=1001.0,
+            ),
+        ]
+        data = BenchmarkData(
+            metadata=BenchmarkMetadata(
+                num_prefill_instances=1, num_decode_instances=1,
+                total_instances=2, measured_qps=2.0,
+            ),
+            requests=requests,
+        )
+        report = analyze_regression(data)
+        assert len(report.fits) == 3
+        # Perfect fit with 2 points
+        for fit in report.fits:
+            assert fit.r_squared == pytest.approx(1.0, abs=0.01)
+
+    def test_constant_predictor(self) -> None:
+        """All same token count -> slope 0, R²=0."""
+        requests = [
+            BenchmarkRequest(
+                request_id=f"r{i}", prompt_tokens=100, output_tokens=50,
+                ttft_ms=20.0 + i, tpot_ms=10.0 + i, total_latency_ms=100.0 + i,
+                timestamp=1000.0 + i,
+            )
+            for i in range(10)
+        ]
+        data = BenchmarkData(
+            metadata=BenchmarkMetadata(
+                num_prefill_instances=1, num_decode_instances=1,
+                total_instances=2, measured_qps=10.0,
+            ),
+            requests=requests,
+        )
+        report = analyze_regression(data)
+        ttft_fit = report.fits[0]
+        assert ttft_fit.slope == 0.0
+        assert ttft_fit.r_squared == 0.0
+
+    def test_report_serialization(self) -> None:
+        data = _make_benchmark(linear=True)
+        report = analyze_regression(data, predict_prompt=500)
+        d = report.model_dump()
+        assert "fits" in d
+        assert "predictions" in d
+        # Round-trip
+        report2 = RegressionReport.model_validate(d)
+        assert len(report2.fits) == len(report.fits)
+
+    def test_slope_std_err_positive(self) -> None:
+        data = _make_benchmark(linear=True, num_requests=50)
+        report = analyze_regression(data)
+        for fit in report.fits:
+            assert fit.slope_std_err >= 0
+
+
+class TestCLIRegression:
+    """Test CLI integration."""
+
+    def test_cli_json_output(self) -> None:
+
+        data = _make_benchmark(linear=True, num_requests=20)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write(data.model_dump_json())
+            f.flush()
+
+            result = subprocess.run(
+                ["xpyd-plan", "regression",
+                 "--benchmark", f.name, "--output-format", "json"],
+                capture_output=True, text=True,
+            )
+            assert result.returncode == 0, result.stderr
+            out = json.loads(result.stdout)
+            assert "fits" in out
+            assert len(out["fits"]) == 3
+
+    def test_cli_with_prediction(self) -> None:
+
+        data = _make_benchmark(linear=True, num_requests=20)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write(data.model_dump_json())
+            f.flush()
+
+            result = subprocess.run(
+                ["xpyd-plan", "regression",
+                 "--benchmark", f.name, "--predict-prompt", "500",
+                 "--predict-output", "200", "--output-format", "json"],
+                capture_output=True, text=True,
+            )
+            assert result.returncode == 0, result.stderr
+            out = json.loads(result.stdout)
+            assert len(out["predictions"]) == 3
+
+    def test_cli_table_output(self) -> None:
+
+        data = _make_benchmark(linear=True, num_requests=20)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write(data.model_dump_json())
+            f.flush()
+
+            result = subprocess.run(
+                ["xpyd-plan", "regression",
+                 "--benchmark", f.name],
+                capture_output=True, text=True,
+            )
+            assert result.returncode == 0, result.stderr
+            assert "Regression" in result.stdout


### PR DESCRIPTION
## Summary

Implement latency-token regression analysis to understand how latency scales with token counts.

### Changes
- `RegressionAnalyzer` class in `regression.py`
- `RegressionFit`, `PredictedLatency`, `RegressionReport` Pydantic models
- Linear regression fits: TTFT~prompt_tokens, TPOT~output_tokens, total_latency~total_tokens
- R², slope, intercept, slope standard error for each fit
- Optional prediction with 95% confidence interval
- CLI `regression` subcommand with table and JSON output
- Programmatic `analyze_regression()` API
- 18 new tests (1536 total)

Closes #155