### PR TITLE
feat: M69 — Latency CDF Export

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -894,3 +894,16 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `replay` subcommand with `--benchmark`, `--time-scale`, `--target-qps`, `--output`, `--output-format`
 - Programmatic `generate_replay()` API
 - 25 new tests (1518 total)
+
+### M68 ✅ Latency-Token Regression Analysis
+
+*Completed — PR #156*
+
+- `RegressionAnalyzer` class in `regression.py`
+- `RegressionFit`, `PredictedLatency`, `RegressionReport` Pydantic models
+- Linear regression fits: TTFT~prompt_tokens, TPOT~output_tokens, total_latency~total_tokens
+- R², slope, intercept, slope standard error for each fit
+- Optional prediction with 95% confidence interval
+- CLI `regression` subcommand with table and JSON output
+- Programmatic `analyze_regression()` API
+- 18 new tests (1536 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -47,6 +47,14 @@ from xpyd_plan.budget import (
     StageBudget,
     allocate_budget,
 )
+from xpyd_plan.cdf import (
+    CDFCurve,
+    CDFGenerator,
+    CDFPoint,
+    CDFReport,
+    SLAMarker,
+    generate_cdf,
+)
 from xpyd_plan.comparator import (
     BenchmarkComparator,
     ComparisonResult,
@@ -446,6 +454,12 @@ __all__ = [
     "RegressionFit",
     "RegressionReport",
     "analyze_regression",
+    "CDFCurve",
+    "CDFGenerator",
+    "CDFPoint",
+    "CDFReport",
+    "SLAMarker",
+    "generate_cdf",
     "FleetAllocation",
     "FleetCalculator",
     "FleetOption",

--- a/src/xpyd_plan/cdf.py
+++ b/src/xpyd_plan/cdf.py
@@ -1,0 +1,160 @@
+"""Latency CDF (Cumulative Distribution Function) export.
+
+Generate CDF data points for latency metrics, enabling distribution
+visualization and multi-benchmark CDF overlay comparisons.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.benchmark_models import BenchmarkData
+
+
+class CDFPoint(BaseModel):
+    """Single CDF data point."""
+
+    latency_ms: float = Field(..., description="Latency value (ms)")
+    cumulative_probability: float = Field(
+        ..., ge=0.0, le=1.0, description="Cumulative probability [0, 1]"
+    )
+
+
+class SLAMarker(BaseModel):
+    """SLA threshold marker on a CDF curve."""
+
+    threshold_ms: float = Field(..., description="SLA threshold (ms)")
+    percentile_at_threshold: float = Field(
+        ..., ge=0.0, le=100.0, description="Percentile of requests meeting threshold"
+    )
+
+
+class CDFCurve(BaseModel):
+    """CDF curve for a single metric from a single source."""
+
+    source: str = Field(..., description="Source benchmark file or label")
+    metric: str = Field(..., description="Latency metric name")
+    points: list[CDFPoint] = Field(..., description="CDF data points")
+    sla_marker: SLAMarker | None = Field(
+        None, description="SLA threshold marker (if configured)"
+    )
+
+
+class CDFReport(BaseModel):
+    """Complete CDF export report."""
+
+    curves: list[CDFCurve] = Field(..., description="CDF curves")
+
+
+_METRIC_FIELDS = {
+    "ttft": "ttft_ms",
+    "tpot": "tpot_ms",
+    "total_latency": "total_latency_ms",
+}
+
+
+def _extract_values(data: BenchmarkData, metric: str) -> np.ndarray:
+    """Extract latency values for the given metric."""
+    field = _METRIC_FIELDS.get(metric, metric)
+    return np.array([getattr(r, field) for r in data.requests], dtype=float)
+
+
+def _build_cdf_points(values: np.ndarray, n_points: int) -> list[CDFPoint]:
+    """Build CDF data points via uniform quantile sampling."""
+    sorted_vals = np.sort(values)
+    n = len(sorted_vals)
+    if n == 0:
+        return []
+
+    # Generate n_points evenly spaced quantiles from 0 to 1
+    quantiles = np.linspace(0.0, 1.0, n_points)
+    points: list[CDFPoint] = []
+    for q in quantiles:
+        idx = min(int(q * n), n - 1)
+        points.append(
+            CDFPoint(
+                latency_ms=float(sorted_vals[idx]),
+                cumulative_probability=float(q),
+            )
+        )
+    return points
+
+
+def _build_sla_marker(
+    sorted_vals: np.ndarray, threshold_ms: float
+) -> SLAMarker:
+    """Compute the percentile at which the SLA threshold is crossed."""
+    n = len(sorted_vals)
+    if n == 0:
+        return SLAMarker(threshold_ms=threshold_ms, percentile_at_threshold=0.0)
+    count_below = int(np.searchsorted(sorted_vals, threshold_ms, side="right"))
+    pct = (count_below / n) * 100.0
+    return SLAMarker(threshold_ms=threshold_ms, percentile_at_threshold=pct)
+
+
+class CDFGenerator:
+    """Generate CDF data from benchmark data."""
+
+    def __init__(self, data: BenchmarkData, source: str = "benchmark") -> None:
+        self._data = data
+        self._source = source
+
+    def generate(
+        self,
+        metric: str = "total_latency",
+        n_points: int = 100,
+        sla_threshold_ms: float | None = None,
+    ) -> CDFCurve:
+        """Generate a CDF curve for a single metric."""
+        values = _extract_values(self._data, metric)
+        points = _build_cdf_points(values, n_points)
+
+        sla_marker = None
+        if sla_threshold_ms is not None:
+            sorted_vals = np.sort(values)
+            sla_marker = _build_sla_marker(sorted_vals, sla_threshold_ms)
+
+        return CDFCurve(
+            source=self._source,
+            metric=metric,
+            points=points,
+            sla_marker=sla_marker,
+        )
+
+
+def generate_cdf(
+    benchmarks: list[str | Path],
+    metric: str = "total_latency",
+    n_points: int = 100,
+    sla_threshold_ms: float | None = None,
+    labels: list[str] | None = None,
+) -> CDFReport:
+    """Programmatic API: generate CDF curves from one or more benchmark files.
+
+    Args:
+        benchmarks: Paths to benchmark JSON files.
+        metric: Latency metric (ttft, tpot, total_latency).
+        n_points: Number of CDF data points per curve.
+        sla_threshold_ms: Optional SLA threshold for marker.
+        labels: Optional per-file labels (defaults to filenames).
+
+    Returns:
+        CDFReport with one curve per benchmark file.
+    """
+    curves: list[CDFCurve] = []
+    for i, path in enumerate(benchmarks):
+        path = Path(path)
+        label = labels[i] if labels and i < len(labels) else path.name
+        data = load_benchmark_auto(str(path))
+        gen = CDFGenerator(data, source=label)
+        curve = gen.generate(
+            metric=metric,
+            n_points=n_points,
+            sla_threshold_ms=sla_threshold_ms,
+        )
+        curves.append(curve)
+    return CDFReport(curves=curves)

--- a/src/xpyd_plan/cli/_cdf.py
+++ b/src/xpyd_plan/cli/_cdf.py
@@ -1,0 +1,106 @@
+"""CLI cdf command."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.cdf import generate_cdf
+
+
+def _cmd_cdf(args: argparse.Namespace) -> None:
+    """Handle the 'cdf' subcommand."""
+    console = Console()
+
+    sla = getattr(args, "sla_threshold", None)
+    labels_raw = getattr(args, "labels", None)
+    labels = labels_raw.split(",") if labels_raw else None
+    output_format = getattr(args, "output_format", "table")
+
+    report = generate_cdf(
+        benchmarks=args.benchmark,
+        metric=args.metric,
+        n_points=args.points,
+        sla_threshold_ms=sla,
+        labels=labels,
+    )
+
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    if output_format == "csv":
+        writer = csv.writer(sys.stdout)
+        writer.writerow(["source", "metric", "latency_ms", "cumulative_probability"])
+        for curve in report.curves:
+            for pt in curve.points:
+                writer.writerow(
+                    [curve.source, curve.metric, pt.latency_ms, pt.cumulative_probability]
+                )
+        return
+
+    # Table output
+    for curve in report.curves:
+        table = Table(title=f"CDF: {curve.source} — {curve.metric}")
+        table.add_column("Latency (ms)", justify="right")
+        table.add_column("Cumulative Probability", justify="right")
+        for pt in curve.points:
+            table.add_row(f"{pt.latency_ms:.2f}", f"{pt.cumulative_probability:.4f}")
+        console.print(table)
+
+        if curve.sla_marker:
+            console.print(
+                f"  SLA threshold {curve.sla_marker.threshold_ms:.1f} ms → "
+                f"{curve.sla_marker.percentile_at_threshold:.1f}% of requests pass"
+            )
+        console.print()
+
+
+def add_cdf_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the cdf subcommand parser."""
+    parser = subparsers.add_parser(
+        "cdf",
+        help="Export latency CDF data for visualization",
+    )
+    parser.add_argument(
+        "--benchmark",
+        nargs="+",
+        required=True,
+        help="Benchmark JSON file(s)",
+    )
+    parser.add_argument(
+        "--metric",
+        default="total_latency",
+        choices=["ttft", "tpot", "total_latency"],
+        help="Latency metric (default: total_latency)",
+    )
+    parser.add_argument(
+        "--points",
+        type=int,
+        default=100,
+        help="Number of CDF data points per curve (default: 100)",
+    )
+    parser.add_argument(
+        "--sla-threshold",
+        type=float,
+        default=None,
+        help="SLA threshold (ms) to mark on CDF",
+    )
+    parser.add_argument(
+        "--labels",
+        type=str,
+        default=None,
+        help="Comma-separated labels for each benchmark file",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json", "csv"],
+        default="table",
+        help="Output format (default: table)",
+    )

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -12,6 +12,7 @@ from xpyd_plan.cli._annotate import _cmd_annotate
 from xpyd_plan.cli._batch_analysis import add_batch_analysis_parser
 from xpyd_plan.cli._budget import _cmd_budget
 from xpyd_plan.cli._capacity import _cmd_plan_capacity
+from xpyd_plan.cli._cdf import _cmd_cdf, add_cdf_parser
 from xpyd_plan.cli._compare import _cmd_compare
 from xpyd_plan.cli._confidence import _cmd_confidence
 from xpyd_plan.cli._config import _add_config_flag, _apply_config_defaults, _cmd_config
@@ -897,6 +898,7 @@ def main(argv: list[str] | None = None) -> None:
     add_batch_analysis_parser(subparsers)
     add_stat_summary_parser(subparsers)
     add_migrate_parser(subparsers)
+    add_cdf_parser(subparsers)
     add_regression_parser(subparsers)
     add_replay_parser(subparsers)
     add_roi_parser(subparsers)
@@ -1065,6 +1067,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_roi(args)
     elif args.command == "regression":
         _cmd_regression(args)
+    elif args.command == "cdf":
+        _cmd_cdf(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/tests/test_cdf.py
+++ b/tests/test_cdf.py
@@ -1,0 +1,269 @@
+"""Tests for latency CDF export."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.cdf import CDFGenerator, CDFReport, generate_cdf
+
+
+def _make_benchmark(num_requests: int = 200) -> BenchmarkData:
+    """Create benchmark data with known latency distribution."""
+    requests = []
+    for i in range(num_requests):
+        requests.append(
+            BenchmarkRequest(
+                request_id=f"req-{i}",
+                prompt_tokens=50 + i * 5,
+                output_tokens=20 + i * 3,
+                ttft_ms=10.0 + i * 0.5,
+                tpot_ms=5.0 + i * 0.3,
+                total_latency_ms=100.0 + i * 2.0,
+                timestamp=1000.0 + i * 0.1,
+            )
+        )
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=4,
+            total_instances=6,
+            measured_qps=50.0,
+        ),
+        requests=requests,
+    )
+
+
+def _write_benchmark(data: BenchmarkData, path: Path) -> None:
+    with open(path, "w") as f:
+        json.dump(data.model_dump(), f)
+
+
+class TestCDFGenerator:
+    def test_basic_cdf(self):
+        data = _make_benchmark()
+        gen = CDFGenerator(data, source="test")
+        curve = gen.generate(metric="total_latency", n_points=50)
+        assert curve.source == "test"
+        assert curve.metric == "total_latency"
+        assert len(curve.points) == 50
+        assert curve.sla_marker is None
+
+    def test_cdf_monotonic(self):
+        data = _make_benchmark()
+        gen = CDFGenerator(data)
+        curve = gen.generate(n_points=100)
+        latencies = [p.latency_ms for p in curve.points]
+        for i in range(1, len(latencies)):
+            assert latencies[i] >= latencies[i - 1]
+
+    def test_cdf_probability_range(self):
+        data = _make_benchmark()
+        gen = CDFGenerator(data)
+        curve = gen.generate(n_points=100)
+        probs = [p.cumulative_probability for p in curve.points]
+        assert probs[0] == pytest.approx(0.0)
+        assert probs[-1] == pytest.approx(1.0)
+        for p in probs:
+            assert 0.0 <= p <= 1.0
+
+    def test_cdf_ttft_metric(self):
+        data = _make_benchmark()
+        gen = CDFGenerator(data)
+        curve = gen.generate(metric="ttft", n_points=20)
+        assert curve.metric == "ttft"
+        assert len(curve.points) == 20
+
+    def test_cdf_tpot_metric(self):
+        data = _make_benchmark()
+        gen = CDFGenerator(data)
+        curve = gen.generate(metric="tpot", n_points=30)
+        assert curve.metric == "tpot"
+        assert len(curve.points) == 30
+
+    def test_sla_marker(self):
+        data = _make_benchmark(num_requests=100)
+        gen = CDFGenerator(data)
+        # total_latency ranges from 100.0 to 298.0
+        curve = gen.generate(metric="total_latency", sla_threshold_ms=200.0)
+        assert curve.sla_marker is not None
+        assert curve.sla_marker.threshold_ms == 200.0
+        # About 50% should be below 200ms (requests 0-49 have total < 200)
+        assert 40.0 < curve.sla_marker.percentile_at_threshold < 60.0
+
+    def test_sla_marker_all_pass(self):
+        data = _make_benchmark(num_requests=50)
+        gen = CDFGenerator(data)
+        curve = gen.generate(metric="total_latency", sla_threshold_ms=9999.0)
+        assert curve.sla_marker is not None
+        assert curve.sla_marker.percentile_at_threshold == 100.0
+
+    def test_sla_marker_none_pass(self):
+        data = _make_benchmark(num_requests=50)
+        gen = CDFGenerator(data)
+        curve = gen.generate(metric="total_latency", sla_threshold_ms=0.0)
+        assert curve.sla_marker is not None
+        assert curve.sla_marker.percentile_at_threshold == 0.0
+
+    def test_custom_points(self):
+        data = _make_benchmark()
+        gen = CDFGenerator(data)
+        curve = gen.generate(n_points=10)
+        assert len(curve.points) == 10
+
+    def test_single_request(self):
+        data = BenchmarkData(
+            metadata=BenchmarkMetadata(
+                num_prefill_instances=1,
+                num_decode_instances=1,
+                total_instances=2,
+                measured_qps=1.0,
+            ),
+            requests=[
+                BenchmarkRequest(
+                    request_id="r-0",
+                    prompt_tokens=100,
+                    output_tokens=50,
+                    ttft_ms=20.0,
+                    tpot_ms=10.0,
+                    total_latency_ms=150.0,
+                    timestamp=1000.0,
+                )
+            ],
+        )
+        gen = CDFGenerator(data)
+        curve = gen.generate(n_points=5)
+        assert len(curve.points) == 5
+
+
+class TestGenerateCDF:
+    def test_single_file(self, tmp_path):
+        data = _make_benchmark(100)
+        path = tmp_path / "bench.json"
+        _write_benchmark(data, path)
+        report = generate_cdf([str(path)])
+        assert len(report.curves) == 1
+        assert report.curves[0].source == "bench.json"
+
+    def test_multi_file(self, tmp_path):
+        for name in ["a.json", "b.json", "c.json"]:
+            _write_benchmark(_make_benchmark(50), tmp_path / name)
+        report = generate_cdf(
+            [str(tmp_path / n) for n in ["a.json", "b.json", "c.json"]]
+        )
+        assert len(report.curves) == 3
+        sources = [c.source for c in report.curves]
+        assert sources == ["a.json", "b.json", "c.json"]
+
+    def test_custom_labels(self, tmp_path):
+        _write_benchmark(_make_benchmark(50), tmp_path / "bench.json")
+        report = generate_cdf(
+            [str(tmp_path / "bench.json")],
+            labels=["my-label"],
+        )
+        assert report.curves[0].source == "my-label"
+
+    def test_with_sla(self, tmp_path):
+        _write_benchmark(_make_benchmark(100), tmp_path / "b.json")
+        report = generate_cdf(
+            [str(tmp_path / "b.json")], sla_threshold_ms=200.0
+        )
+        assert report.curves[0].sla_marker is not None
+
+    def test_json_serialization(self, tmp_path):
+        _write_benchmark(_make_benchmark(50), tmp_path / "b.json")
+        report = generate_cdf([str(tmp_path / "b.json")], n_points=10)
+        d = report.model_dump()
+        assert "curves" in d
+        assert len(d["curves"][0]["points"]) == 10
+        # Roundtrip
+        CDFReport.model_validate(d)
+
+
+class TestCDFCli:
+    def test_table_output(self, tmp_path):
+        _write_benchmark(_make_benchmark(50), tmp_path / "b.json")
+        result = subprocess.run(
+            [
+                "xpyd-plan", "cdf",
+                "--benchmark", str(tmp_path / "b.json"),
+                "--points", "10",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "CDF" in result.stdout
+
+    def test_json_output(self, tmp_path):
+        _write_benchmark(_make_benchmark(50), tmp_path / "b.json")
+        result = subprocess.run(
+            [
+                "xpyd-plan", "cdf",
+                "--benchmark", str(tmp_path / "b.json"),
+                "--output-format", "json",
+                "--points", "10",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert "curves" in data
+
+    def test_csv_output(self, tmp_path):
+        _write_benchmark(_make_benchmark(50), tmp_path / "b.json")
+        result = subprocess.run(
+            [
+                "xpyd-plan", "cdf",
+                "--benchmark", str(tmp_path / "b.json"),
+                "--output-format", "csv",
+                "--points", "5",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        reader = csv.reader(io.StringIO(result.stdout))
+        rows = list(reader)
+        assert rows[0] == ["source", "metric", "latency_ms", "cumulative_probability"]
+        assert len(rows) == 6  # header + 5 data rows
+
+    def test_multi_benchmark_cli(self, tmp_path):
+        for name in ["a.json", "b.json"]:
+            _write_benchmark(_make_benchmark(30), tmp_path / name)
+        result = subprocess.run(
+            [
+                "xpyd-plan", "cdf",
+                "--benchmark", str(tmp_path / "a.json"), str(tmp_path / "b.json"),
+                "--output-format", "json",
+                "--points", "5",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert len(data["curves"]) == 2
+
+    def test_sla_threshold_cli(self, tmp_path):
+        _write_benchmark(_make_benchmark(50), tmp_path / "b.json")
+        result = subprocess.run(
+            [
+                "xpyd-plan", "cdf",
+                "--benchmark", str(tmp_path / "b.json"),
+                "--sla-threshold", "150.0",
+                "--output-format", "json",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["curves"][0]["sla_marker"] is not None


### PR DESCRIPTION
## Summary

Implement latency CDF (Cumulative Distribution Function) export for distribution visualization and multi-benchmark comparison.

### Changes
- `CDFGenerator` class in `cdf.py`
- `CDFPoint`, `CDFCurve`, `SLAMarker`, `CDFReport` Pydantic models
- Generate CDF data points via uniform quantile sampling (configurable point count)
- Multi-benchmark CDF overlay: load multiple files, tag curves by source
- SLA threshold markers: compute percentile of requests meeting threshold
- CLI `cdf` subcommand with `--benchmark` (multiple), `--points`, `--metric`, `--sla-threshold`, `--labels`
- Output formats: table, JSON, CSV
- Programmatic `generate_cdf()` API
- 20 new tests (1556 total)

Closes #157