### PR TITLE
feat: M71 — Warm-up Exclusion Filter

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -907,3 +907,28 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `regression` subcommand with table and JSON output
 - Programmatic `analyze_regression()` API
 - 18 new tests (1536 total)
+
+### M69 ✅ Latency CDF Export
+
+*Completed — PR #158*
+
+- `CDFGenerator` class in `cdf.py`
+- `CDFPoint`, `CDFCurve`, `SLAMarker`, `CDFReport` Pydantic models
+- Generate CDF data points for TTFT, TPOT, total_latency distributions
+- Multi-benchmark CDF overlay for visual comparison
+- SLA threshold markers with pass-rate at each threshold
+- CLI `cdf` subcommand with `--benchmark` (multiple), `--sla-*`, `--points`, table + JSON + CSV output
+- Programmatic `generate_cdf()` API
+- 20 new tests (1556 total)
+
+### M70 ✅ Benchmark Health Check
+
+*Completed — PR #160*
+
+- `HealthChecker` class in `health_check.py`
+- `CheckResult`, `HealthReport`, `HealthStatus` Pydantic models
+- Composite readiness check: data validation, percentile convergence, load profile, outlier impact
+- Single PASS/WARN/FAIL verdict with per-check details
+- CLI `health-check` subcommand with `--benchmark`, table + JSON output
+- Programmatic `check_health()` API
+- 18 new tests (1574 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -366,6 +366,13 @@ from xpyd_plan.validator import (
     ValidationResult,
     validate_benchmark,
 )
+from xpyd_plan.warmup import (
+    LatencyComparison,
+    WarmupFilter,
+    WarmupReport,
+    WarmupWindow,
+    filter_warmup,
+)
 from xpyd_plan.workload import (
     WorkloadCategory,
     WorkloadClass,
@@ -527,6 +534,11 @@ __all__ = [
     "WorkloadClassifier",
     "WorkloadProfile",
     "WorkloadReport",
+    "LatencyComparison",
+    "WarmupFilter",
+    "WarmupReport",
+    "WarmupWindow",
+    "filter_warmup",
     "classify_workload",
     "SaturationDetector",
     "SaturationPoint",

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -61,6 +61,7 @@ from xpyd_plan.cli._timeline import _cmd_timeline, add_timeline_parser
 from xpyd_plan.cli._token_efficiency import add_token_efficiency_parser, handle_token_efficiency
 from xpyd_plan.cli._trend import _cmd_trend
 from xpyd_plan.cli._validate import _cmd_validate
+from xpyd_plan.cli._warmup_filter import _cmd_warmup_filter, add_warmup_filter_parser
 from xpyd_plan.cli._whatif import _cmd_what_if
 from xpyd_plan.cli._workload import _cmd_workload
 
@@ -930,6 +931,7 @@ def main(argv: list[str] | None = None) -> None:
     add_discover_parser(subparsers)
     add_heatmap_parser(subparsers)
     add_health_check_parser(subparsers)
+    add_warmup_filter_parser(subparsers)
 
     # --- plan-benchmarks subcommand ---
     add_plan_benchmarks_parser(subparsers)
@@ -1046,6 +1048,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_heatmap(args)
     elif args.command == "health-check":
         _cmd_health_check(args)
+    elif args.command == "warmup-filter":
+        _cmd_warmup_filter(args)
     elif args.command == "plan-benchmarks":
         _cmd_plan_benchmarks(args)
     elif args.command == "threshold-advisor":

--- a/src/xpyd_plan/cli/_warmup_filter.py
+++ b/src/xpyd_plan/cli/_warmup_filter.py
@@ -1,0 +1,113 @@
+"""CLI warmup-filter command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.warmup import WarmupFilter
+
+
+def _cmd_warmup_filter(args: argparse.Namespace) -> None:
+    """Handle the 'warmup-filter' subcommand."""
+    console = Console()
+
+    data = load_benchmark_auto(args.benchmark)
+    warmup_seconds = getattr(args, "warmup_seconds", None)
+    warmup_factor = getattr(args, "warmup_factor", 2.0)
+    window_size = getattr(args, "window_size", 10.0)
+
+    filt = WarmupFilter(
+        warmup_seconds=warmup_seconds,
+        warmup_factor=warmup_factor,
+        window_size_s=window_size,
+    )
+    filtered_data, report = filt.filter(data)
+
+    output_format = getattr(args, "output_format", "table")
+    output_file = getattr(args, "output", None)
+
+    # Write filtered data if output requested
+    if output_file:
+        with open(output_file, "w") as f:
+            json.dump(filtered_data.model_dump(), f, indent=2)
+        console.print(f"Filtered benchmark written to {output_file}")
+
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Table output
+    if not report.warmup_detected:
+        console.print("\n✅ No warm-up period detected.\n")
+        return
+
+    console.print(f"\n🔥 Warm-up detected: {report.warmup_window.duration_s}s")
+    console.print(
+        f"   Excluded {report.warmup_window.requests_excluded} requests "
+        f"({report.original_request_count} → {report.filtered_request_count})\n"
+    )
+
+    if report.latency_comparison:
+        table = Table(title="Latency Comparison (total_latency_ms)")
+        table.add_column("Percentile", justify="center")
+        table.add_column("Before", justify="right")
+        table.add_column("After", justify="right")
+
+        lc = report.latency_comparison
+        table.add_row("P50", f"{lc.before_p50_ms:.1f}", f"{lc.after_p50_ms:.1f}")
+        table.add_row("P95", f"{lc.before_p95_ms:.1f}", f"{lc.after_p95_ms:.1f}")
+        table.add_row("P99", f"{lc.before_p99_ms:.1f}", f"{lc.after_p99_ms:.1f}")
+
+        console.print(table)
+
+    console.print(f"\nQPS: {report.original_qps:.1f} → {report.adjusted_qps:.1f}")
+
+
+def add_warmup_filter_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the warmup-filter subcommand parser."""
+    parser = subparsers.add_parser(
+        "warmup-filter",
+        help="Detect and remove warm-up requests from benchmark data",
+    )
+    parser.add_argument(
+        "--benchmark",
+        required=True,
+        help="Path to benchmark JSON file",
+    )
+    parser.add_argument(
+        "--warmup-seconds",
+        type=float,
+        default=None,
+        help="Fixed warm-up duration to exclude (seconds). Auto-detect if not set.",
+    )
+    parser.add_argument(
+        "--warmup-factor",
+        type=float,
+        default=2.0,
+        help="P95 multiplier threshold for auto warm-up detection (default: 2.0)",
+    )
+    parser.add_argument(
+        "--window-size",
+        type=float,
+        default=10.0,
+        help="Window size in seconds for warm-up detection (default: 10.0)",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output path for filtered benchmark JSON",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_warmup_filter)

--- a/src/xpyd_plan/warmup.py
+++ b/src/xpyd_plan/warmup.py
@@ -1,0 +1,279 @@
+"""Warm-up exclusion filter — detect and remove warm-up requests from benchmark data.
+
+Uses the timeline module's warm-up detection logic to identify the initial
+period where latency is elevated, then strips those requests to produce
+cleaner data for analysis.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata
+
+
+class WarmupWindow(BaseModel):
+    """Detected warm-up window details."""
+
+    start_timestamp: float = Field(..., description="Start of warm-up (epoch seconds)")
+    end_timestamp: float = Field(..., description="End of warm-up (epoch seconds)")
+    duration_s: float = Field(..., ge=0, description="Warm-up duration in seconds")
+    requests_excluded: int = Field(..., ge=0, description="Number of requests in warm-up window")
+
+
+class LatencyComparison(BaseModel):
+    """Before/after latency comparison."""
+
+    before_p50_ms: float = Field(..., ge=0)
+    before_p95_ms: float = Field(..., ge=0)
+    before_p99_ms: float = Field(..., ge=0)
+    after_p50_ms: float = Field(..., ge=0)
+    after_p95_ms: float = Field(..., ge=0)
+    after_p99_ms: float = Field(..., ge=0)
+
+
+class WarmupReport(BaseModel):
+    """Report of warm-up filtering operation."""
+
+    warmup_detected: bool = Field(..., description="Whether warm-up was detected")
+    warmup_window: Optional[WarmupWindow] = Field(
+        None, description="Warm-up window details"
+    )
+    original_request_count: int = Field(..., ge=0)
+    filtered_request_count: int = Field(..., ge=0)
+    original_qps: float = Field(..., ge=0)
+    adjusted_qps: float = Field(..., ge=0)
+    latency_comparison: Optional[LatencyComparison] = Field(
+        None, description="Total latency comparison before/after filtering"
+    )
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    """Compute percentile from sorted values."""
+    if not values:
+        return 0.0
+    arr = np.array(values)
+    return float(np.percentile(arr, pct))
+
+
+class WarmupFilter:
+    """Detect and remove warm-up requests from benchmark data."""
+
+    def __init__(
+        self,
+        warmup_seconds: Optional[float] = None,
+        warmup_factor: float = 2.0,
+        window_size_s: float = 10.0,
+    ) -> None:
+        """Initialize filter.
+
+        Args:
+            warmup_seconds: Fixed warm-up duration to exclude. If None, auto-detect.
+            warmup_factor: P95 multiplier threshold for warm-up detection.
+            window_size_s: Window size for warm-up detection.
+        """
+        if warmup_seconds is not None and warmup_seconds < 0:
+            raise ValueError("warmup_seconds must be non-negative")
+        if warmup_factor <= 0:
+            raise ValueError("warmup_factor must be positive")
+        if window_size_s <= 0:
+            raise ValueError("window_size_s must be positive")
+
+        self._warmup_seconds = warmup_seconds
+        self._warmup_factor = warmup_factor
+        self._window_size_s = window_size_s
+
+    def filter(self, data: BenchmarkData) -> tuple[BenchmarkData, WarmupReport]:
+        """Filter warm-up requests from benchmark data.
+
+        Returns:
+            Tuple of (filtered BenchmarkData, WarmupReport).
+        """
+        if not data.requests:
+            report = WarmupReport(
+                warmup_detected=False,
+                original_request_count=0,
+                filtered_request_count=0,
+                original_qps=data.metadata.measured_qps,
+                adjusted_qps=data.metadata.measured_qps,
+            )
+            return data, report
+
+        sorted_reqs = sorted(data.requests, key=lambda r: r.timestamp)
+        min_ts = sorted_reqs[0].timestamp
+        max_ts = sorted_reqs[-1].timestamp
+
+        if self._warmup_seconds is not None:
+            warmup_duration = self._warmup_seconds
+        else:
+            warmup_duration = self._auto_detect_warmup(sorted_reqs, min_ts)
+
+        if warmup_duration <= 0:
+            # No warm-up detected
+            report = WarmupReport(
+                warmup_detected=False,
+                original_request_count=len(data.requests),
+                filtered_request_count=len(data.requests),
+                original_qps=data.metadata.measured_qps,
+                adjusted_qps=data.metadata.measured_qps,
+            )
+            return data, report
+
+        cutoff_ts = min_ts + warmup_duration
+        warmup_reqs = [r for r in sorted_reqs if r.timestamp < cutoff_ts]
+        kept_reqs = [r for r in sorted_reqs if r.timestamp >= cutoff_ts]
+
+        if not kept_reqs:
+            # All requests are in warm-up — return original data with report
+            report = WarmupReport(
+                warmup_detected=True,
+                warmup_window=WarmupWindow(
+                    start_timestamp=min_ts,
+                    end_timestamp=cutoff_ts,
+                    duration_s=round(warmup_duration, 3),
+                    requests_excluded=len(warmup_reqs),
+                ),
+                original_request_count=len(data.requests),
+                filtered_request_count=0,
+                original_qps=data.metadata.measured_qps,
+                adjusted_qps=0.0,
+            )
+            # Cannot create empty BenchmarkData (min 1 request), return original
+            return data, report
+
+        # Compute adjusted QPS
+        total_duration = max_ts - min_ts
+        kept_duration = max_ts - cutoff_ts
+        if total_duration > 0 and kept_duration > 0:
+            adjusted_qps = data.metadata.measured_qps * (kept_duration / total_duration)
+        else:
+            adjusted_qps = data.metadata.measured_qps
+
+        # Latency comparison
+        before_totals = [r.total_latency_ms for r in sorted_reqs]
+        after_totals = [r.total_latency_ms for r in kept_reqs]
+        comparison = LatencyComparison(
+            before_p50_ms=round(_percentile(before_totals, 50), 3),
+            before_p95_ms=round(_percentile(before_totals, 95), 3),
+            before_p99_ms=round(_percentile(before_totals, 99), 3),
+            after_p50_ms=round(_percentile(after_totals, 50), 3),
+            after_p95_ms=round(_percentile(after_totals, 95), 3),
+            after_p99_ms=round(_percentile(after_totals, 99), 3),
+        )
+
+        report = WarmupReport(
+            warmup_detected=True,
+            warmup_window=WarmupWindow(
+                start_timestamp=min_ts,
+                end_timestamp=cutoff_ts,
+                duration_s=round(warmup_duration, 3),
+                requests_excluded=len(warmup_reqs),
+            ),
+            original_request_count=len(data.requests),
+            filtered_request_count=len(kept_reqs),
+            original_qps=data.metadata.measured_qps,
+            adjusted_qps=round(adjusted_qps, 3),
+            latency_comparison=comparison,
+        )
+
+        filtered_data = BenchmarkData(
+            metadata=BenchmarkMetadata(
+                num_prefill_instances=data.metadata.num_prefill_instances,
+                num_decode_instances=data.metadata.num_decode_instances,
+                total_instances=data.metadata.total_instances,
+                measured_qps=round(adjusted_qps, 3),
+            ),
+            requests=kept_reqs,
+        )
+
+        return filtered_data, report
+
+    def _auto_detect_warmup(
+        self, sorted_reqs: list, min_ts: float
+    ) -> float:
+        """Auto-detect warm-up duration using windowed P95 analysis.
+
+        Similar to timeline module logic: compute P95 per window,
+        identify contiguous initial windows exceeding threshold.
+        """
+        if len(sorted_reqs) < 2:
+            return 0.0
+
+        max_ts = sorted_reqs[-1].timestamp
+        total_duration = max_ts - min_ts
+        if total_duration <= 0:
+            return 0.0
+
+        # Build windows
+        n_windows = max(2, int(total_duration / self._window_size_s) + 1)
+        windows: list[list[float]] = [[] for _ in range(n_windows)]
+
+        for r in sorted_reqs:
+            idx = min(int((r.timestamp - min_ts) / self._window_size_s), n_windows - 1)
+            windows[idx].append(r.total_latency_ms)
+
+        # Get P95 per window (skip empty)
+        window_p95s: list[tuple[int, float]] = []
+        for i, w in enumerate(windows):
+            if w:
+                window_p95s.append((i, _percentile(w, 95)))
+
+        if len(window_p95s) < 2:
+            return 0.0
+
+        # Steady-state = median P95 from second half
+        half = len(window_p95s) // 2
+        second_half_vals = sorted([p for _, p in window_p95s[half:]])
+        steady_p95 = _percentile(second_half_vals, 50)
+
+        if steady_p95 == 0:
+            return 0.0
+
+        threshold = steady_p95 * self._warmup_factor
+        warmup_window_count = 0
+
+        for idx, p95 in window_p95s:
+            if p95 > threshold:
+                warmup_window_count += 1
+            else:
+                break
+
+        if warmup_window_count == 0:
+            return 0.0
+
+        return warmup_window_count * self._window_size_s
+
+
+def filter_warmup(
+    benchmark_path: str,
+    *,
+    warmup_seconds: Optional[float] = None,
+    warmup_factor: float = 2.0,
+    window_size_s: float = 10.0,
+) -> dict:
+    """Programmatic API for warm-up filtering.
+
+    Args:
+        benchmark_path: Path to benchmark JSON file.
+        warmup_seconds: Fixed warm-up duration. None for auto-detect.
+        warmup_factor: P95 multiplier for auto-detection.
+        window_size_s: Window size for auto-detection.
+
+    Returns:
+        Dict with 'report' and 'filtered_data' keys.
+    """
+    data = load_benchmark_auto(benchmark_path)
+    filt = WarmupFilter(
+        warmup_seconds=warmup_seconds,
+        warmup_factor=warmup_factor,
+        window_size_s=window_size_s,
+    )
+    filtered_data, report = filt.filter(data)
+    return {
+        "report": report.model_dump(),
+        "filtered_data": filtered_data.model_dump(),
+    }

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -1,0 +1,321 @@
+"""Tests for warm-up exclusion filter."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.cli import main
+from xpyd_plan.warmup import (
+    LatencyComparison,
+    WarmupFilter,
+    WarmupWindow,
+    filter_warmup,
+)
+
+
+def _make_requests(
+    n: int = 100,
+    base_ts: float = 1000.0,
+    warmup_count: int = 0,
+    warmup_latency_factor: float = 10.0,
+) -> list[BenchmarkRequest]:
+    """Generate benchmark requests with optional warm-up spike."""
+    requests = []
+    for i in range(n):
+        if i < warmup_count:
+            latency_mult = warmup_latency_factor
+        else:
+            latency_mult = 1.0
+        requests.append(
+            BenchmarkRequest(
+                request_id=f"req-{i:04d}",
+                prompt_tokens=100 + i * 2,
+                output_tokens=50 + i,
+                ttft_ms=10.0 * latency_mult + i * 0.1,
+                tpot_ms=5.0 * latency_mult + i * 0.05,
+                total_latency_ms=100.0 * latency_mult + i * 1.0,
+                timestamp=base_ts + i * 0.5,
+            )
+        )
+    return requests
+
+
+def _make_data(
+    n: int = 100,
+    warmup_count: int = 0,
+    warmup_latency_factor: float = 10.0,
+) -> BenchmarkData:
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=6,
+            total_instances=8,
+            measured_qps=50.0,
+        ),
+        requests=_make_requests(
+            n,
+            warmup_count=warmup_count,
+            warmup_latency_factor=warmup_latency_factor,
+        ),
+    )
+
+
+class TestWarmupFilter:
+    def test_no_warmup_detected(self):
+        """Steady data should have no warm-up."""
+        data = _make_data(100, warmup_count=0)
+        filt = WarmupFilter(window_size_s=5.0)
+        filtered, report = filt.filter(data)
+
+        assert not report.warmup_detected
+        assert report.filtered_request_count == 100
+        assert len(filtered.requests) == 100
+
+    def test_manual_warmup_seconds(self):
+        """Manual warm-up duration should exclude requests."""
+        data = _make_data(100)
+        filt = WarmupFilter(warmup_seconds=5.0)
+        filtered, report = filt.filter(data)
+
+        assert report.warmup_detected
+        assert report.warmup_window is not None
+        assert report.warmup_window.duration_s == 5.0
+        assert report.filtered_request_count < 100
+        assert len(filtered.requests) == report.filtered_request_count
+
+    def test_manual_warmup_zero(self):
+        """Zero warm-up should keep all requests."""
+        data = _make_data(100)
+        filt = WarmupFilter(warmup_seconds=0.0)
+        filtered, report = filt.filter(data)
+
+        assert not report.warmup_detected
+        assert report.filtered_request_count == 100
+
+    def test_auto_detect_warmup(self):
+        """Should auto-detect warm-up from latency spike."""
+        data = _make_data(200, warmup_count=20, warmup_latency_factor=10.0)
+        filt = WarmupFilter(window_size_s=5.0, warmup_factor=2.0)
+        filtered, report = filt.filter(data)
+
+        assert report.warmup_detected
+        assert report.warmup_window is not None
+        assert report.warmup_window.requests_excluded > 0
+        assert report.filtered_request_count < 200
+
+    def test_qps_adjusted(self):
+        """QPS should be adjusted proportionally after filtering."""
+        data = _make_data(100)
+        filt = WarmupFilter(warmup_seconds=10.0)
+        _, report = filt.filter(data)
+
+        assert report.adjusted_qps < report.original_qps
+
+    def test_latency_comparison(self):
+        """Should include before/after latency stats."""
+        data = _make_data(200, warmup_count=20, warmup_latency_factor=10.0)
+        filt = WarmupFilter(warmup_seconds=10.0)
+        _, report = filt.filter(data)
+
+        assert report.latency_comparison is not None
+        lc = report.latency_comparison
+        assert lc.before_p95_ms >= lc.after_p95_ms
+
+    def test_small_dataset(self):
+        """Should handle very small benchmark data."""
+        data = _make_data(2, warmup_count=0)
+        filt = WarmupFilter()
+        filtered, report = filt.filter(data)
+
+        assert not report.warmup_detected
+        assert report.filtered_request_count == 2
+
+    def test_warmup_exceeds_all_data(self):
+        """If warmup_seconds > total duration, report shows 0 filtered but data preserved."""
+        data = _make_data(10)  # 10 reqs at 0.5s apart = ~5s total
+        filt = WarmupFilter(warmup_seconds=100.0)
+        filtered, report = filt.filter(data)
+
+        assert report.warmup_detected
+        assert report.filtered_request_count == 0
+        # Original data returned since empty BenchmarkData not allowed
+        assert len(filtered.requests) == 10
+
+    def test_filtered_metadata_preserved(self):
+        """Filtered data should keep same instance config."""
+        data = _make_data(100)
+        filt = WarmupFilter(warmup_seconds=5.0)
+        filtered, _ = filt.filter(data)
+
+        assert filtered.metadata.num_prefill_instances == 2
+        assert filtered.metadata.num_decode_instances == 6
+        assert filtered.metadata.total_instances == 8
+
+    def test_invalid_warmup_seconds(self):
+        """Negative warmup_seconds should raise."""
+        import pytest
+        with pytest.raises(ValueError):
+            WarmupFilter(warmup_seconds=-1.0)
+
+    def test_invalid_warmup_factor(self):
+        """Non-positive warmup_factor should raise."""
+        import pytest
+        with pytest.raises(ValueError):
+            WarmupFilter(warmup_factor=0.0)
+
+    def test_invalid_window_size(self):
+        """Non-positive window_size should raise."""
+        import pytest
+        with pytest.raises(ValueError):
+            WarmupFilter(window_size_s=0.0)
+
+    def test_model_dump_serializable(self):
+        """Report should be JSON-serializable."""
+        data = _make_data(100, warmup_count=10, warmup_latency_factor=5.0)
+        filt = WarmupFilter(warmup_seconds=5.0)
+        _, report = filt.filter(data)
+
+        dumped = report.model_dump()
+        json_str = json.dumps(dumped)
+        parsed = json.loads(json_str)
+        assert "warmup_detected" in parsed
+
+    def test_single_request(self):
+        """Should handle single-request benchmark."""
+        data = BenchmarkData(
+            metadata=BenchmarkMetadata(
+                num_prefill_instances=1,
+                num_decode_instances=1,
+                total_instances=2,
+                measured_qps=1.0,
+            ),
+            requests=[
+                BenchmarkRequest(
+                    request_id="req-0000",
+                    prompt_tokens=100,
+                    output_tokens=50,
+                    ttft_ms=10.0,
+                    tpot_ms=5.0,
+                    total_latency_ms=100.0,
+                    timestamp=1000.0,
+                ),
+            ],
+        )
+        filt = WarmupFilter()
+        filtered, report = filt.filter(data)
+        assert report.filtered_request_count in (0, 1)
+
+    def test_warmup_window_model(self):
+        """WarmupWindow should have correct fields."""
+        w = WarmupWindow(
+            start_timestamp=1000.0,
+            end_timestamp=1010.0,
+            duration_s=10.0,
+            requests_excluded=5,
+        )
+        assert w.duration_s == 10.0
+        assert w.requests_excluded == 5
+
+    def test_latency_comparison_model(self):
+        """LatencyComparison should store values."""
+        lc = LatencyComparison(
+            before_p50_ms=100.0,
+            before_p95_ms=200.0,
+            before_p99_ms=300.0,
+            after_p50_ms=80.0,
+            after_p95_ms=150.0,
+            after_p99_ms=200.0,
+        )
+        assert lc.before_p95_ms == 200.0
+        assert lc.after_p95_ms == 150.0
+
+
+class TestFilterWarmup:
+    def test_programmatic_api(self, tmp_path):
+        data = _make_data(100)
+        path = tmp_path / "bench.json"
+        path.write_text(json.dumps(data.model_dump()))
+
+        result = filter_warmup(str(path), warmup_seconds=5.0)
+
+        assert isinstance(result, dict)
+        assert "report" in result
+        assert "filtered_data" in result
+        assert result["report"]["warmup_detected"]
+
+    def test_programmatic_api_auto_detect(self, tmp_path):
+        data = _make_data(200, warmup_count=20, warmup_latency_factor=10.0)
+        path = tmp_path / "bench.json"
+        path.write_text(json.dumps(data.model_dump()))
+
+        result = filter_warmup(str(path), window_size_s=5.0)
+        assert isinstance(result, dict)
+
+
+class TestCLIWarmupFilter:
+    def test_cli_table_output(self, tmp_path, capsys):
+        data = _make_data(100)
+        path = tmp_path / "bench.json"
+        path.write_text(json.dumps(data.model_dump()))
+
+        with patch("sys.argv", [
+            "xpyd-plan", "warmup-filter",
+            "--benchmark", str(path),
+            "--warmup-seconds", "5.0",
+        ]):
+            main()
+
+        captured = capsys.readouterr()
+        assert "Warm-up detected" in captured.out
+
+    def test_cli_json_output(self, tmp_path, capsys):
+        data = _make_data(100)
+        path = tmp_path / "bench.json"
+        path.write_text(json.dumps(data.model_dump()))
+
+        with patch("sys.argv", [
+            "xpyd-plan", "warmup-filter",
+            "--benchmark", str(path),
+            "--warmup-seconds", "5.0",
+            "--output-format", "json",
+        ]):
+            main()
+
+        captured = capsys.readouterr()
+        result = json.loads(captured.out)
+        assert "warmup_detected" in result
+
+    def test_cli_output_file(self, tmp_path, capsys):
+        data = _make_data(100)
+        path = tmp_path / "bench.json"
+        path.write_text(json.dumps(data.model_dump()))
+        out_path = tmp_path / "filtered.json"
+
+        with patch("sys.argv", [
+            "xpyd-plan", "warmup-filter",
+            "--benchmark", str(path),
+            "--warmup-seconds", "5.0",
+            "--output", str(out_path),
+        ]):
+            main()
+
+        assert out_path.exists()
+        filtered = json.loads(out_path.read_text())
+        assert "requests" in filtered
+        assert "metadata" in filtered
+
+    def test_cli_no_warmup(self, tmp_path, capsys):
+        data = _make_data(100)
+        path = tmp_path / "bench.json"
+        path.write_text(json.dumps(data.model_dump()))
+
+        with patch("sys.argv", [
+            "xpyd-plan", "warmup-filter",
+            "--benchmark", str(path),
+        ]):
+            main()
+
+        captured = capsys.readouterr()
+        assert "No warm-up" in captured.out or "Warm-up" in captured.out


### PR DESCRIPTION
## Summary

Implement automatic warm-up detection and exclusion for benchmark data.

### Changes
- `WarmupFilter` class in `warmup.py` with auto-detect and manual modes
- `WarmupReport`, `WarmupWindow`, `LatencyComparison` Pydantic models
- Auto-detect warm-up via windowed P95 latency analysis (same approach as timeline module)
- Manual `--warmup-seconds` override for fixed warm-up duration
- Output filtered benchmark JSON with adjusted QPS and metadata
- Before/after latency comparison (P50/P95/P99)
- CLI `warmup-filter` subcommand with table + JSON output
- Programmatic `filter_warmup()` API
- 22 new tests (1596 total, all passing)

Closes #161