### PR TITLE
feat: M76 — Benchmark Reproducibility Score

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -991,3 +991,18 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `concurrency-util` subcommand with `--benchmark`, `--window-size`, table + JSON output
 - Programmatic `analyze_concurrency_util()` API
 - 19 new tests (1674 total)
+
+### M76 ✅ Benchmark Reproducibility Score
+
+*Completed — PR #TBD*
+
+- `ReproducibilityAnalyzer` class in `reproducibility.py`
+- `ReproducibilityReport`, `MetricReproducibility`, `ReproducibilityGrade`, `RunPairTest` Pydantic models
+- Per-metric coefficient of variation (CV) across repeated runs
+- KS two-sample test between all run pairs for distribution consistency
+- Composite 0-100 reproducibility score with grade classification (EXCELLENT/GOOD/FAIR/POOR)
+- Unreliable metric flagging when CV exceeds configurable threshold
+- Recommended minimum runs based on observed variance
+- CLI `reproducibility` subcommand with `--benchmark` (multiple), `--cv-threshold`, table + JSON output
+- Programmatic `analyze_reproducibility()` API
+- ~20 new tests

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -860,3 +860,21 @@ __all__ += [
     "ReplaySchedule",
     "generate_replay",
 ]
+
+from xpyd_plan.reproducibility import (  # noqa: E402
+    MetricReproducibility,
+    ReproducibilityAnalyzer,
+    ReproducibilityGrade,
+    ReproducibilityReport,
+    RunPairTest,
+    analyze_reproducibility,
+)
+
+__all__ += [
+    "MetricReproducibility",
+    "ReproducibilityAnalyzer",
+    "ReproducibilityGrade",
+    "ReproducibilityReport",
+    "RunPairTest",
+    "analyze_reproducibility",
+]

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -48,6 +48,7 @@ from xpyd_plan.cli._queue import add_queue_parser
 from xpyd_plan.cli._recommend import _cmd_recommend
 from xpyd_plan.cli._regression import _cmd_regression, add_regression_parser
 from xpyd_plan.cli._replay import add_replay_parser
+from xpyd_plan.cli._reproducibility import _cmd_reproducibility, add_reproducibility_parser
 from xpyd_plan.cli._roi import add_roi_parser
 from xpyd_plan.cli._root_cause import _cmd_root_cause, add_root_cause_parser
 from xpyd_plan.cli._sample import add_sample_parser
@@ -906,6 +907,7 @@ def main(argv: list[str] | None = None) -> None:
     add_migrate_parser(subparsers)
     add_cdf_parser(subparsers)
     add_concurrency_util_parser(subparsers)
+    add_reproducibility_parser(subparsers)
     add_regression_parser(subparsers)
     add_replay_parser(subparsers)
     add_roi_parser(subparsers)
@@ -1089,6 +1091,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_cdf(args)
     elif args.command == "concurrency-util":
         _cmd_concurrency_util(args)
+    elif args.command == "reproducibility":
+        _cmd_reproducibility(args)
     elif args.command == "size-distribution":
         _cmd_size_distribution(args)
     else:

--- a/src/xpyd_plan/cli/_reproducibility.py
+++ b/src/xpyd_plan/cli/_reproducibility.py
@@ -1,0 +1,104 @@
+"""CLI reproducibility command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.reproducibility import ReproducibilityAnalyzer
+
+
+def _cmd_reproducibility(args: argparse.Namespace) -> None:
+    """Handle the 'reproducibility' subcommand."""
+    console = Console()
+
+    datasets = [load_benchmark_auto(f) for f in args.benchmark]
+    analyzer = ReproducibilityAnalyzer(cv_threshold=args.cv_threshold)
+    report = analyzer.analyze(datasets)
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        console.print(json.dumps(report.model_dump(), indent=2))
+        return
+
+    # Summary
+    console.print(
+        f"\n[bold]Benchmark Reproducibility Analysis[/bold]"
+        f" ({report.num_runs} runs, {report.total_requests} total requests)\n"
+    )
+
+    grade_style = {
+        "EXCELLENT": "bright_green",
+        "GOOD": "green",
+        "FAIR": "yellow",
+        "POOR": "red",
+    }.get(report.grade.value, "")
+    console.print(
+        f"  Score: [bold]{report.composite_score}[/bold] / 100"
+        f"  Grade: [{grade_style}]{report.grade.value}[/{grade_style}]"
+    )
+    console.print(f"  Recommended minimum runs: {report.recommended_min_runs}\n")
+
+    if report.unreliable_metrics:
+        console.print(
+            f"  [yellow]⚠ Unreliable metrics (CV > {args.cv_threshold:.0%}):"
+            f" {', '.join(report.unreliable_metrics)}[/yellow]\n"
+        )
+
+    # Metrics table
+    table = Table(title="Metric Reproducibility")
+    table.add_column("Metric", style="cyan")
+    table.add_column("Mean", justify="right")
+    table.add_column("Std", justify="right")
+    table.add_column("CV", justify="right")
+    table.add_column("Reliable", justify="center")
+
+    for m in report.metrics:
+        reliable_str = "[green]✓[/green]" if m.reliable else "[red]✗[/red]"
+        table.add_row(
+            m.metric_name,
+            f"{m.mean:.2f}",
+            f"{m.std:.2f}",
+            f"{m.cv:.4f}",
+            reliable_str,
+        )
+    console.print(table)
+
+    # KS test summary
+    if report.pair_tests:
+        console.print("\n[bold]Distribution Consistency (KS Tests)[/bold]")
+        consistent = sum(1 for t in report.pair_tests if t.distributions_consistent)
+        total = len(report.pair_tests)
+        console.print(
+            f"  {consistent}/{total} pairs consistent (p > 0.05)\n"
+        )
+
+
+def add_reproducibility_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the reproducibility subcommand parser."""
+    parser = subparsers.add_parser(
+        "reproducibility",
+        help="Analyze benchmark reproducibility across repeated runs",
+    )
+    parser.add_argument(
+        "--benchmark",
+        required=True,
+        nargs="+",
+        help="Paths to benchmark JSON files (2+ required)",
+    )
+    parser.add_argument(
+        "--cv-threshold",
+        type=float,
+        default=0.10,
+        help="CV threshold for reliability flagging (default: 0.10)",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )

--- a/src/xpyd_plan/reproducibility.py
+++ b/src/xpyd_plan/reproducibility.py
@@ -1,0 +1,226 @@
+"""Benchmark reproducibility analysis — quantify result consistency across repeated runs."""
+
+from __future__ import annotations
+
+import enum
+from itertools import combinations
+
+import numpy as np
+from pydantic import BaseModel, Field
+from scipy.stats import ks_2samp
+
+from xpyd_plan.benchmark_models import BenchmarkData
+
+
+class ReproducibilityGrade(str, enum.Enum):
+    """Reproducibility grade classification."""
+
+    EXCELLENT = "EXCELLENT"
+    GOOD = "GOOD"
+    FAIR = "FAIR"
+    POOR = "POOR"
+
+
+class MetricReproducibility(BaseModel):
+    """Reproducibility statistics for a single metric across runs."""
+
+    metric_name: str = Field(..., description="Metric name (e.g., 'ttft_p95')")
+    values: list[float] = Field(..., description="Per-run values")
+    mean: float = Field(..., description="Mean across runs")
+    std: float = Field(..., description="Standard deviation across runs")
+    cv: float = Field(..., description="Coefficient of variation (std/mean)")
+    reliable: bool = Field(
+        ..., description="True if CV is below reliability threshold"
+    )
+
+
+class RunPairTest(BaseModel):
+    """KS test result between two runs."""
+
+    run_a: int = Field(..., description="Index of first run (0-based)")
+    run_b: int = Field(..., description="Index of second run (0-based)")
+    metric: str = Field(..., description="Latency metric tested")
+    ks_statistic: float = Field(..., description="KS test statistic")
+    p_value: float = Field(..., description="KS test p-value")
+    distributions_consistent: bool = Field(
+        ..., description="True if p-value > 0.05 (distributions not significantly different)"
+    )
+
+
+class ReproducibilityReport(BaseModel):
+    """Complete reproducibility analysis report."""
+
+    num_runs: int = Field(..., description="Number of benchmark runs analyzed")
+    total_requests: int = Field(..., description="Total requests across all runs")
+    metrics: list[MetricReproducibility] = Field(
+        default_factory=list, description="Per-metric reproducibility stats"
+    )
+    pair_tests: list[RunPairTest] = Field(
+        default_factory=list, description="KS test results between run pairs"
+    )
+    composite_score: float = Field(
+        ..., ge=0, le=100, description="Composite reproducibility score (0-100)"
+    )
+    grade: ReproducibilityGrade = Field(..., description="Reproducibility grade")
+    unreliable_metrics: list[str] = Field(
+        default_factory=list, description="Metrics with CV above threshold"
+    )
+    recommended_min_runs: int = Field(
+        ..., description="Recommended minimum runs for reliable results"
+    )
+
+
+def _grade_from_score(score: float) -> ReproducibilityGrade:
+    """Classify score into grade."""
+    if score >= 90:
+        return ReproducibilityGrade.EXCELLENT
+    if score >= 75:
+        return ReproducibilityGrade.GOOD
+    if score >= 60:
+        return ReproducibilityGrade.FAIR
+    return ReproducibilityGrade.POOR
+
+
+class ReproducibilityAnalyzer:
+    """Analyze reproducibility of benchmark results across multiple runs."""
+
+    def __init__(self, cv_threshold: float = 0.10) -> None:
+        """Initialize analyzer.
+
+        Args:
+            cv_threshold: CV threshold above which a metric is flagged as unreliable.
+                Default 0.10 (10%).
+        """
+        if cv_threshold <= 0:
+            raise ValueError("cv_threshold must be > 0")
+        self.cv_threshold = cv_threshold
+
+    def analyze(self, datasets: list[BenchmarkData]) -> ReproducibilityReport:
+        """Analyze reproducibility across multiple benchmark runs.
+
+        Args:
+            datasets: List of BenchmarkData from repeated runs of the same config.
+
+        Returns:
+            ReproducibilityReport with scores and KS test results.
+
+        Raises:
+            ValueError: If fewer than 2 datasets provided.
+        """
+        if len(datasets) < 2:
+            raise ValueError("At least 2 benchmark runs required for reproducibility analysis")
+
+        total_requests = sum(len(d.requests) for d in datasets)
+
+        # Extract per-run metrics
+        metric_defs = [
+            ("ttft_p50", lambda reqs: float(np.percentile([r.ttft_ms for r in reqs], 50))),
+            ("ttft_p95", lambda reqs: float(np.percentile([r.ttft_ms for r in reqs], 95))),
+            ("ttft_p99", lambda reqs: float(np.percentile([r.ttft_ms for r in reqs], 99))),
+            ("tpot_p50", lambda reqs: float(np.percentile([r.tpot_ms for r in reqs], 50))),
+            ("tpot_p95", lambda reqs: float(np.percentile([r.tpot_ms for r in reqs], 95))),
+            ("tpot_p99", lambda reqs: float(np.percentile([r.tpot_ms for r in reqs], 99))),
+            ("total_latency_p50", lambda reqs: float(
+                np.percentile([r.total_latency_ms for r in reqs], 50))),
+            ("total_latency_p95", lambda reqs: float(
+                np.percentile([r.total_latency_ms for r in reqs], 95))),
+            ("total_latency_p99", lambda reqs: float(
+                np.percentile([r.total_latency_ms for r in reqs], 99))),
+            ("qps", lambda reqs: None),  # handled separately
+        ]
+
+        metrics: list[MetricReproducibility] = []
+        unreliable: list[str] = []
+
+        for name, extractor in metric_defs:
+            if name == "qps":
+                values = [d.metadata.measured_qps for d in datasets]
+            else:
+                values = [extractor(d.requests) for d in datasets]
+
+            arr = np.array(values, dtype=float)
+            mean_val = float(np.mean(arr))
+            std_val = float(np.std(arr, ddof=1)) if len(arr) > 1 else 0.0
+            cv = std_val / mean_val if mean_val > 0 else 0.0
+            reliable = cv <= self.cv_threshold
+
+            if not reliable:
+                unreliable.append(name)
+
+            metrics.append(
+                MetricReproducibility(
+                    metric_name=name,
+                    values=[round(v, 4) for v in values],
+                    mean=round(mean_val, 4),
+                    std=round(std_val, 4),
+                    cv=round(cv, 6),
+                    reliable=reliable,
+                )
+            )
+
+        # KS tests between run pairs for raw latency distributions
+        pair_tests: list[RunPairTest] = []
+        ks_metrics = ["ttft_ms", "tpot_ms", "total_latency_ms"]
+        for (i, da), (j, db) in combinations(enumerate(datasets), 2):
+            for metric_field in ks_metrics:
+                a_vals = np.array([getattr(r, metric_field) for r in da.requests])
+                b_vals = np.array([getattr(r, metric_field) for r in db.requests])
+                stat, pval = ks_2samp(a_vals, b_vals)
+                pair_tests.append(
+                    RunPairTest(
+                        run_a=i,
+                        run_b=j,
+                        metric=metric_field,
+                        ks_statistic=round(float(stat), 6),
+                        p_value=round(float(pval), 6),
+                        distributions_consistent=pval > 0.05,
+                    )
+                )
+
+        # Composite score: 100 - mean(CV * 500), clamped to [0, 100]
+        # CV of 0 → 100, CV of 0.20 → 0
+        cvs = [m.cv for m in metrics]
+        mean_cv = float(np.mean(cvs))
+        composite = max(0.0, min(100.0, 100.0 - mean_cv * 500.0))
+        composite = round(composite, 1)
+
+        grade = _grade_from_score(composite)
+
+        # Recommended min runs: based on observed variance
+        # If CV is high, suggest more runs. Minimum 3, scale with mean CV.
+        if mean_cv < 0.02:
+            recommended = 3
+        elif mean_cv < 0.05:
+            recommended = 5
+        elif mean_cv < 0.10:
+            recommended = 7
+        else:
+            recommended = 10
+
+        return ReproducibilityReport(
+            num_runs=len(datasets),
+            total_requests=total_requests,
+            metrics=metrics,
+            pair_tests=pair_tests,
+            composite_score=composite,
+            grade=grade,
+            unreliable_metrics=unreliable,
+            recommended_min_runs=recommended,
+        )
+
+
+def analyze_reproducibility(
+    datasets: list[BenchmarkData],
+    cv_threshold: float = 0.10,
+) -> ReproducibilityReport:
+    """Programmatic API: analyze benchmark reproducibility.
+
+    Args:
+        datasets: List of BenchmarkData from repeated runs.
+        cv_threshold: CV threshold for reliability flagging (default 0.10).
+
+    Returns:
+        ReproducibilityReport with scores, KS tests, and recommendations.
+    """
+    analyzer = ReproducibilityAnalyzer(cv_threshold=cv_threshold)
+    return analyzer.analyze(datasets)

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -1,0 +1,176 @@
+"""Tests for benchmark reproducibility analysis."""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.reproducibility import (
+    ReproducibilityAnalyzer,
+    ReproducibilityGrade,
+    analyze_reproducibility,
+)
+
+
+def _make_data(
+    n: int = 100,
+    seed: int = 42,
+    total_instances: int = 4,
+    prefill: int = 2,
+    decode: int = 2,
+    qps: float = 50.0,
+    latency_scale: float = 1.0,
+) -> BenchmarkData:
+    """Create benchmark data with controllable noise."""
+    rng = random.Random(seed)
+    requests = []
+    base_ts = 1700000000.0
+    for i in range(n):
+        pt = rng.randint(50, 2000)
+        ot = rng.randint(10, 500)
+        ttft = (pt * 0.05 + rng.uniform(5, 30)) * latency_scale
+        tpot = (ot * 0.03 + rng.uniform(2, 15)) * latency_scale
+        total = (ttft + tpot * ot + rng.uniform(10, 200)) * latency_scale
+        ts = base_ts + i / qps
+        requests.append(
+            BenchmarkRequest(
+                request_id=f"req-{i}",
+                prompt_tokens=pt,
+                output_tokens=ot,
+                ttft_ms=ttft,
+                tpot_ms=tpot,
+                total_latency_ms=total,
+                timestamp=ts,
+            )
+        )
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=prefill,
+            num_decode_instances=decode,
+            total_instances=total_instances,
+            measured_qps=qps,
+        ),
+        requests=requests,
+    )
+
+
+class TestReproducibilityAnalyzer:
+    def test_basic_analysis(self) -> None:
+        d1 = _make_data(100, seed=1)
+        d2 = _make_data(100, seed=2)
+        report = analyze_reproducibility([d1, d2])
+        assert report.num_runs == 2
+        assert report.total_requests == 200
+        assert 0 <= report.composite_score <= 100
+        assert isinstance(report.grade, ReproducibilityGrade)
+
+    def test_identical_runs_high_score(self) -> None:
+        d1 = _make_data(100, seed=42)
+        d2 = _make_data(100, seed=42)
+        report = analyze_reproducibility([d1, d2])
+        assert report.composite_score >= 90
+        assert report.grade == ReproducibilityGrade.EXCELLENT
+
+    def test_very_different_runs_low_score(self) -> None:
+        d1 = _make_data(100, seed=1, latency_scale=1.0)
+        d2 = _make_data(100, seed=2, latency_scale=5.0)
+        report = analyze_reproducibility([d1, d2])
+        assert report.composite_score < 75
+
+    def test_three_runs(self) -> None:
+        runs = [_make_data(50, seed=i) for i in range(3)]
+        report = analyze_reproducibility(runs)
+        assert report.num_runs == 3
+        assert len(report.pair_tests) > 0
+
+    def test_fewer_than_two_raises(self) -> None:
+        with pytest.raises(ValueError, match="At least 2"):
+            analyze_reproducibility([_make_data(50)])
+
+    def test_metrics_count(self) -> None:
+        report = analyze_reproducibility([_make_data(50, seed=1), _make_data(50, seed=2)])
+        assert len(report.metrics) == 10  # 9 latency percentiles + QPS
+
+    def test_metric_fields(self) -> None:
+        report = analyze_reproducibility([_make_data(50, seed=1), _make_data(50, seed=2)])
+        for m in report.metrics:
+            assert len(m.values) == 2
+            assert m.mean > 0
+            assert m.std >= 0
+            assert m.cv >= 0
+
+    def test_pair_tests_count_two_runs(self) -> None:
+        report = analyze_reproducibility([_make_data(50, seed=1), _make_data(50, seed=2)])
+        # 1 pair × 3 metrics = 3
+        assert len(report.pair_tests) == 3
+
+    def test_pair_tests_count_three_runs(self) -> None:
+        runs = [_make_data(50, seed=i) for i in range(3)]
+        report = analyze_reproducibility(runs)
+        # 3 pairs × 3 metrics = 9
+        assert len(report.pair_tests) == 9
+
+    def test_ks_test_identical_consistent(self) -> None:
+        d = _make_data(100, seed=42)
+        report = analyze_reproducibility([d, d])
+        for t in report.pair_tests:
+            assert t.distributions_consistent is True
+            assert t.p_value >= 0.05
+
+    def test_unreliable_metrics(self) -> None:
+        d1 = _make_data(100, seed=1, latency_scale=1.0)
+        d2 = _make_data(100, seed=2, latency_scale=3.0)
+        report = analyze_reproducibility([d1, d2], cv_threshold=0.05)
+        assert len(report.unreliable_metrics) > 0
+
+    def test_custom_cv_threshold(self) -> None:
+        d1 = _make_data(100, seed=1)
+        d2 = _make_data(100, seed=2)
+        strict = analyze_reproducibility([d1, d2], cv_threshold=0.001)
+        lenient = analyze_reproducibility([d1, d2], cv_threshold=1.0)
+        assert len(strict.unreliable_metrics) >= len(lenient.unreliable_metrics)
+
+    def test_invalid_cv_threshold(self) -> None:
+        with pytest.raises(ValueError, match="cv_threshold must be > 0"):
+            ReproducibilityAnalyzer(cv_threshold=0)
+
+    def test_recommended_min_runs(self) -> None:
+        report = analyze_reproducibility([_make_data(50, seed=1), _make_data(50, seed=2)])
+        assert report.recommended_min_runs >= 3
+
+    def test_grade_excellent(self) -> None:
+        d = _make_data(100, seed=42)
+        report = analyze_reproducibility([d, d])
+        assert report.grade == ReproducibilityGrade.EXCELLENT
+
+    def test_json_serialization(self) -> None:
+        report = analyze_reproducibility([_make_data(50, seed=1), _make_data(50, seed=2)])
+        d = report.model_dump()
+        assert "metrics" in d
+        assert "pair_tests" in d
+        assert "composite_score" in d
+        assert "grade" in d
+
+    def test_programmatic_api(self) -> None:
+        report = analyze_reproducibility(
+            [_make_data(50, seed=1), _make_data(50, seed=2)],
+            cv_threshold=0.15,
+        )
+        assert isinstance(report.num_runs, int)
+
+    def test_five_runs(self) -> None:
+        runs = [_make_data(30, seed=i) for i in range(5)]
+        report = analyze_reproducibility(runs)
+        assert report.num_runs == 5
+        # 10 pairs × 3 metrics = 30
+        assert len(report.pair_tests) == 30
+
+    def test_pair_test_fields(self) -> None:
+        report = analyze_reproducibility([_make_data(50, seed=1), _make_data(50, seed=2)])
+        for t in report.pair_tests:
+            assert t.run_a < t.run_b
+            assert 0 <= t.ks_statistic <= 1
+            assert 0 <= t.p_value <= 1
+            assert t.metric in ("ttft_ms", "tpot_ms", "total_latency_ms")


### PR DESCRIPTION
## Summary

Add benchmark reproducibility analysis to quantify result consistency across repeated runs.

### Changes
- `ReproducibilityAnalyzer` class in `reproducibility.py`
- `ReproducibilityReport`, `MetricReproducibility`, `ReproducibilityGrade`, `RunPairTest` Pydantic models
- Per-metric coefficient of variation (CV) across repeated runs
- KS two-sample test between all run pairs for distribution consistency
- Composite 0-100 reproducibility score with grade classification (EXCELLENT/GOOD/FAIR/POOR)
- Unreliable metric flagging when CV exceeds configurable threshold
- Recommended minimum runs based on observed variance
- CLI `reproducibility` subcommand with `--benchmark` (multiple), `--cv-threshold`, table + JSON output
- Programmatic `analyze_reproducibility()` API
- 19 new tests (1693 total)

Closes #171