### PR TITLE
feat: add request deduplication analysis (M80)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1048,3 +1048,18 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `spike` subcommand with `--benchmark`, `--window-size`, `--threshold`, table + JSON output
 - Programmatic `detect_spikes()` API
 - 27 new tests (1771 total)
+
+### M80 ✅ Request Deduplication Analysis
+
+*Completed — PR #TBD*
+
+- `DeduplicationAnalyzer` class in `dedup.py`
+- `DuplicateGroup`, `DeduplicationReport`, `DeduplicationConfig` Pydantic models
+- Exact duplicate detection (same prompt_tokens, output_tokens, ttft_ms, tpot_ms)
+- Near-duplicate detection with configurable latency tolerance
+- Duplication rate and group statistics
+- Deduplicate output with QPS adjustment
+- Recommendation engine based on duplication severity
+- CLI `dedup` subcommand with `--benchmark`, `--tolerance`, `--output`, table + JSON output
+- Programmatic `analyze_dedup()` API
+- ~22 new tests

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -930,3 +930,19 @@ __all__ += [
     "SpikeSummary",
     "detect_spikes",
 ]
+
+from xpyd_plan.dedup import (  # noqa: E402
+    DeduplicationAnalyzer,
+    DeduplicationConfig,
+    DeduplicationReport,
+    DuplicateGroup,
+    analyze_dedup,
+)
+
+__all__ += [
+    "DeduplicationAnalyzer",
+    "DeduplicationConfig",
+    "DeduplicationReport",
+    "DuplicateGroup",
+    "analyze_dedup",
+]

--- a/src/xpyd_plan/cli/_dedup.py
+++ b/src/xpyd_plan/cli/_dedup.py
@@ -1,0 +1,100 @@
+"""CLI dedup command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.dedup import DeduplicationAnalyzer
+
+
+def _cmd_dedup(args: argparse.Namespace) -> None:
+    """Handle the 'dedup' subcommand."""
+    console = Console()
+
+    data = load_benchmark_auto(args.benchmark)
+    analyzer = DeduplicationAnalyzer()
+    report = analyzer.analyze(data, tolerance_ms=args.tolerance)
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Summary
+    console.print("\n[bold]Deduplication Analysis[/bold]")
+    console.print(f"Total requests: {report.total_requests}")
+    console.print(f"Unique requests: {report.unique_requests}")
+    console.print(f"Duplicates: {report.duplicate_count}")
+    console.print(f"Duplication rate: {report.duplication_rate:.2%}")
+    console.print(f"Duplicate groups: {report.group_count}")
+    if report.largest_group_size > 0:
+        console.print(f"Largest group: {report.largest_group_size} requests")
+    console.print(f"\n[italic]{report.recommendation}[/italic]\n")
+
+    if report.groups:
+        table = Table(title="Duplicate Groups")
+        table.add_column("Group", justify="right")
+        table.add_column("Count", justify="right")
+        table.add_column("Prompt Tokens", justify="right")
+        table.add_column("Output Tokens", justify="right")
+        table.add_column("Exact", justify="center")
+
+        for g in report.groups[:20]:  # limit display
+            table.add_row(
+                str(g.group_id),
+                str(g.count),
+                str(g.representative_prompt_tokens),
+                str(g.representative_output_tokens),
+                "✓" if g.is_exact else "~",
+            )
+
+        if len(report.groups) > 20:
+            table.add_row("...", f"+{len(report.groups) - 20} more", "", "", "")
+
+        console.print(table)
+
+    # Optionally write deduplicated output
+    output = getattr(args, "output", None)
+    if output:
+        deduped = analyzer.deduplicate(data, tolerance_ms=args.tolerance)
+        with open(output, "w") as f:
+            json.dump(deduped.model_dump(), f, indent=2)
+        console.print(f"\nDeduplicated data written to {output}")
+
+
+def add_dedup_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the dedup subcommand parser."""
+    parser = subparsers.add_parser(
+        "dedup",
+        help="Detect and remove duplicate requests in benchmark data",
+    )
+    parser.add_argument(
+        "--benchmark",
+        required=True,
+        help="Path to benchmark JSON file",
+    )
+    parser.add_argument(
+        "--tolerance",
+        type=float,
+        default=0.0,
+        help="Latency tolerance in ms for near-duplicate detection (default: 0.0 = exact only)",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Path to write deduplicated benchmark JSON (optional)",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_dedup)

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -23,6 +23,7 @@ from xpyd_plan.cli._convergence import add_convergence_parser
 from xpyd_plan.cli._correlation import _cmd_correlation, add_correlation_parser
 from xpyd_plan.cli._dashboard import _cmd_dashboard
 from xpyd_plan.cli._decompose import _cmd_decompose, add_decompose_parser
+from xpyd_plan.cli._dedup import add_dedup_parser
 from xpyd_plan.cli._discover import _cmd_discover, add_discover_parser
 from xpyd_plan.cli._drift import _cmd_drift, add_drift_parser
 from xpyd_plan.cli._export import _cmd_export
@@ -900,6 +901,7 @@ def main(argv: list[str] | None = None) -> None:
     add_correlation_parser(subparsers)
     add_jitter_parser(subparsers)
     add_cold_start_parser(subparsers)
+    add_dedup_parser(subparsers)
     add_spike_parser(subparsers)
 
     # --- fairness subcommand ---
@@ -1107,6 +1109,9 @@ def main(argv: list[str] | None = None) -> None:
     elif args.command == "cold-start":
         from xpyd_plan.cli._cold_start import _cmd_cold_start
         _cmd_cold_start(args)
+    elif args.command == "dedup":
+        from xpyd_plan.cli._dedup import _cmd_dedup
+        _cmd_dedup(args)
     elif args.command == "spike":
         from xpyd_plan.cli._spike import _cmd_spike
         _cmd_spike(args)

--- a/src/xpyd_plan/dedup.py
+++ b/src/xpyd_plan/dedup.py
@@ -1,0 +1,275 @@
+"""Request deduplication analysis — detect duplicate requests in benchmark data."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData, BenchmarkRequest
+
+
+class DuplicateGroup(BaseModel):
+    """A group of duplicate or near-duplicate requests."""
+
+    group_id: int = Field(..., description="Unique group identifier")
+    count: int = Field(..., ge=2, description="Number of requests in group")
+    representative_prompt_tokens: int = Field(..., description="Prompt tokens of the group")
+    representative_output_tokens: int = Field(..., description="Output tokens of the group")
+    request_indices: list[int] = Field(..., description="Indices of duplicate requests")
+    is_exact: bool = Field(..., description="True if all duplicates are exact matches")
+
+
+class DeduplicationReport(BaseModel):
+    """Complete deduplication analysis report."""
+
+    total_requests: int = Field(..., description="Total requests in benchmark")
+    unique_requests: int = Field(..., description="Requests after deduplication")
+    duplicate_count: int = Field(..., ge=0, description="Number of duplicate requests removed")
+    duplication_rate: float = Field(
+        ..., ge=0, le=1, description="Fraction of requests that are duplicates"
+    )
+    group_count: int = Field(..., ge=0, description="Number of duplicate groups found")
+    largest_group_size: int = Field(..., ge=0, description="Size of largest duplicate group")
+    groups: list[DuplicateGroup] = Field(..., description="All duplicate groups")
+    recommendation: str = Field(..., description="Human-readable recommendation")
+
+
+class DeduplicationConfig(BaseModel):
+    """Configuration for deduplication analysis."""
+
+    tolerance_ms: float = Field(
+        default=0.0,
+        ge=0,
+        description="Latency tolerance in ms for near-duplicate detection",
+    )
+
+
+class DeduplicationAnalyzer:
+    """Detect and report duplicate requests in benchmark data."""
+
+    def analyze(
+        self,
+        data: BenchmarkData,
+        *,
+        tolerance_ms: float = 0.0,
+    ) -> DeduplicationReport:
+        """Analyze benchmark data for duplicate requests.
+
+        Args:
+            data: Benchmark data to analyze.
+            tolerance_ms: Latency tolerance for near-duplicate detection.
+                0.0 means exact match only.
+
+        Returns:
+            DeduplicationReport with duplicate groups and statistics.
+        """
+        requests = data.requests
+        total = len(requests)
+
+        if total == 0:
+            return DeduplicationReport(
+                total_requests=0,
+                unique_requests=0,
+                duplicate_count=0,
+                duplication_rate=0.0,
+                group_count=0,
+                largest_group_size=0,
+                groups=[],
+                recommendation="No requests to analyze.",
+            )
+
+        groups = self._find_groups(requests, tolerance_ms)
+
+        duplicate_count = sum(g.count - 1 for g in groups)
+        unique_requests = total - duplicate_count
+        duplication_rate = duplicate_count / total if total > 0 else 0.0
+        largest = max((g.count for g in groups), default=0)
+
+        if duplication_rate > 0.1:
+            recommendation = (
+                f"High duplication rate ({duplication_rate:.1%}). "
+                "Consider deduplicating before analysis to avoid biased results."
+            )
+        elif duplication_rate > 0.01:
+            recommendation = (
+                f"Moderate duplication rate ({duplication_rate:.1%}). "
+                "Duplicates are unlikely to significantly affect results."
+            )
+        else:
+            recommendation = "Minimal or no duplication detected. Data is clean."
+
+        return DeduplicationReport(
+            total_requests=total,
+            unique_requests=unique_requests,
+            duplicate_count=duplicate_count,
+            duplication_rate=duplication_rate,
+            group_count=len(groups),
+            largest_group_size=largest,
+            groups=groups,
+            recommendation=recommendation,
+        )
+
+    def deduplicate(
+        self,
+        data: BenchmarkData,
+        *,
+        tolerance_ms: float = 0.0,
+    ) -> BenchmarkData:
+        """Return a new BenchmarkData with duplicates removed (keep first occurrence).
+
+        Args:
+            data: Benchmark data to deduplicate.
+            tolerance_ms: Latency tolerance for near-duplicate detection.
+
+        Returns:
+            New BenchmarkData with duplicates removed.
+        """
+        requests = data.requests
+        if not requests:
+            return data.model_copy()
+
+        report = self.analyze(data, tolerance_ms=tolerance_ms)
+
+        # Collect indices to remove (all but first in each group)
+        remove_indices: set[int] = set()
+        for group in report.groups:
+            for idx in group.request_indices[1:]:
+                remove_indices.add(idx)
+
+        kept = [r for i, r in enumerate(requests) if i not in remove_indices]
+
+        # Adjust QPS proportionally
+        ratio = len(kept) / len(requests) if requests else 1.0
+        new_qps = data.metadata.measured_qps * ratio
+
+        new_metadata = data.metadata.model_copy(
+            update={"measured_qps": round(new_qps, 2)}
+        )
+
+        return data.model_copy(
+            update={
+                "requests": kept,
+                "metadata": new_metadata,
+            }
+        )
+
+    def _find_groups(
+        self,
+        requests: list[BenchmarkRequest],
+        tolerance_ms: float,
+    ) -> list[DuplicateGroup]:
+        """Find groups of duplicate requests."""
+        if tolerance_ms <= 0:
+            return self._find_exact_groups(requests)
+        return self._find_near_groups(requests, tolerance_ms)
+
+    def _find_exact_groups(
+        self,
+        requests: list[BenchmarkRequest],
+    ) -> list[DuplicateGroup]:
+        """Find exact duplicate groups."""
+        buckets: dict[tuple[int, int, float, float], list[int]] = defaultdict(list)
+        for i, r in enumerate(requests):
+            key = (r.prompt_tokens, r.output_tokens, r.ttft_ms, r.tpot_ms)
+            buckets[key].append(i)
+
+        groups: list[DuplicateGroup] = []
+        gid = 0
+        for key, indices in buckets.items():
+            if len(indices) >= 2:
+                groups.append(
+                    DuplicateGroup(
+                        group_id=gid,
+                        count=len(indices),
+                        representative_prompt_tokens=key[0],
+                        representative_output_tokens=key[1],
+                        request_indices=indices,
+                        is_exact=True,
+                    )
+                )
+                gid += 1
+
+        return groups
+
+    def _find_near_groups(
+        self,
+        requests: list[BenchmarkRequest],
+        tolerance_ms: float,
+    ) -> list[DuplicateGroup]:
+        """Find near-duplicate groups (same tokens, latency within tolerance)."""
+        # Group by token counts first
+        token_buckets: dict[tuple[int, int], list[int]] = defaultdict(list)
+        for i, r in enumerate(requests):
+            key = (r.prompt_tokens, r.output_tokens)
+            token_buckets[key].append(i)
+
+        groups: list[DuplicateGroup] = []
+        gid = 0
+
+        for (pt, ot), indices in token_buckets.items():
+            if len(indices) < 2:
+                continue
+
+            # Within same token bucket, cluster by latency proximity
+            assigned: set[int] = set()
+            for i, idx_a in enumerate(indices):
+                if idx_a in assigned:
+                    continue
+                cluster = [idx_a]
+                ra = requests[idx_a]
+                for idx_b in indices[i + 1 :]:
+                    if idx_b in assigned:
+                        continue
+                    rb = requests[idx_b]
+                    if (
+                        abs(ra.ttft_ms - rb.ttft_ms) <= tolerance_ms
+                        and abs(ra.tpot_ms - rb.tpot_ms) <= tolerance_ms
+                    ):
+                        cluster.append(idx_b)
+                        assigned.add(idx_b)
+
+                if len(cluster) >= 2:
+                    # Check if all are exact
+                    first = requests[cluster[0]]
+                    is_exact = all(
+                        requests[c].ttft_ms == first.ttft_ms
+                        and requests[c].tpot_ms == first.tpot_ms
+                        for c in cluster
+                    )
+                    groups.append(
+                        DuplicateGroup(
+                            group_id=gid,
+                            count=len(cluster),
+                            representative_prompt_tokens=pt,
+                            representative_output_tokens=ot,
+                            request_indices=cluster,
+                            is_exact=is_exact,
+                        )
+                    )
+                    gid += 1
+                    assigned.update(cluster)
+
+        return groups
+
+
+def analyze_dedup(
+    benchmark_path: str,
+    *,
+    tolerance_ms: float = 0.0,
+) -> dict:
+    """Programmatic API for deduplication analysis.
+
+    Args:
+        benchmark_path: Path to benchmark JSON file.
+        tolerance_ms: Latency tolerance for near-duplicate detection.
+
+    Returns:
+        Dict with deduplication analysis results.
+    """
+    from .bench_adapter import load_benchmark_auto
+
+    data = load_benchmark_auto(benchmark_path)
+    analyzer = DeduplicationAnalyzer()
+    report = analyzer.analyze(data, tolerance_ms=tolerance_ms)
+    return report.model_dump()

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,0 +1,295 @@
+"""Tests for deduplication analysis."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.dedup import DeduplicationAnalyzer, DeduplicationReport, DuplicateGroup
+
+
+def _make_request(
+    prompt_tokens: int = 100,
+    output_tokens: int = 50,
+    ttft_ms: float = 20.0,
+    tpot_ms: float = 10.0,
+    total_latency_ms: float = 520.0,
+    timestamp: float = 1000.0,
+    request_id: str = "r1",
+) -> BenchmarkRequest:
+    return BenchmarkRequest(
+        request_id=request_id,
+        prompt_tokens=prompt_tokens,
+        output_tokens=output_tokens,
+        ttft_ms=ttft_ms,
+        tpot_ms=tpot_ms,
+        total_latency_ms=total_latency_ms,
+        timestamp=timestamp,
+    )
+
+
+def _make_data(requests: list[BenchmarkRequest], qps: float = 10.0) -> BenchmarkData:
+    if not requests:
+        # BenchmarkData requires min_length=1, use a dummy for empty test
+        return BenchmarkData(
+            metadata=BenchmarkMetadata(
+                num_prefill_instances=2,
+                num_decode_instances=2,
+                total_instances=4,
+                measured_qps=qps,
+            ),
+            requests=[_make_request()],
+        )
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=2,
+            total_instances=4,
+            measured_qps=qps,
+        ),
+        requests=requests,
+    )
+
+
+class TestDeduplicationAnalyzerSingleRequest:
+    def test_single_request(self):
+        data = _make_data([_make_request()])
+        analyzer = DeduplicationAnalyzer()
+        report = analyzer.analyze(data)
+        assert report.total_requests == 1
+        assert report.duplicate_count == 0
+        assert report.group_count == 0
+
+
+class TestDeduplicationAnalyzerNoDuplicates:
+    def test_unique_requests(self):
+        requests = [
+            _make_request(prompt_tokens=100, ttft_ms=20.0, request_id="r1"),
+            _make_request(prompt_tokens=200, ttft_ms=30.0, request_id="r2"),
+            _make_request(prompt_tokens=300, ttft_ms=40.0, request_id="r3"),
+        ]
+        data = _make_data(requests)
+        analyzer = DeduplicationAnalyzer()
+        report = analyzer.analyze(data)
+        assert report.total_requests == 3
+        assert report.unique_requests == 3
+        assert report.duplicate_count == 0
+        assert report.duplication_rate == 0.0
+        assert report.group_count == 0
+
+
+class TestDeduplicationAnalyzerExactDuplicates:
+    def test_exact_duplicates_detected(self):
+        r = _make_request(request_id="r1")
+        requests = [r, r.model_copy(update={"request_id": "r2"})]
+        data = _make_data(requests)
+        analyzer = DeduplicationAnalyzer()
+        report = analyzer.analyze(data)
+        assert report.total_requests == 2
+        assert report.unique_requests == 1
+        assert report.duplicate_count == 1
+        assert report.group_count == 1
+        assert report.groups[0].is_exact is True
+        assert report.groups[0].count == 2
+
+    def test_multiple_exact_groups(self):
+        r1 = _make_request(prompt_tokens=100, request_id="r1")
+        r2 = _make_request(prompt_tokens=200, request_id="r2")
+        requests = [
+            r1,
+            r1.model_copy(update={"request_id": "r1b"}),
+            r2,
+            r2.model_copy(update={"request_id": "r2b"}),
+            r2.model_copy(update={"request_id": "r2c"}),
+        ]
+        data = _make_data(requests)
+        analyzer = DeduplicationAnalyzer()
+        report = analyzer.analyze(data)
+        assert report.total_requests == 5
+        assert report.duplicate_count == 3  # 1 from group1, 2 from group2
+        assert report.unique_requests == 2
+        assert report.group_count == 2
+
+    def test_large_group(self):
+        r = _make_request()
+        requests = [r.model_copy(update={"request_id": f"r{i}"}) for i in range(10)]
+        data = _make_data(requests)
+        analyzer = DeduplicationAnalyzer()
+        report = analyzer.analyze(data)
+        assert report.largest_group_size == 10
+        assert report.duplicate_count == 9
+
+
+class TestDeduplicationAnalyzerNearDuplicates:
+    def test_near_duplicates_with_tolerance(self):
+        r1 = _make_request(ttft_ms=20.0, tpot_ms=10.0, request_id="r1")
+        r2 = _make_request(ttft_ms=20.5, tpot_ms=10.3, request_id="r2")
+        data = _make_data([r1, r2])
+        analyzer = DeduplicationAnalyzer()
+
+        # Exact: no match
+        report_exact = analyzer.analyze(data, tolerance_ms=0.0)
+        assert report_exact.duplicate_count == 0
+
+        # Tolerance 1.0: match
+        report_near = analyzer.analyze(data, tolerance_ms=1.0)
+        assert report_near.duplicate_count == 1
+        assert report_near.groups[0].is_exact is False
+
+    def test_near_duplicates_different_tokens_not_grouped(self):
+        r1 = _make_request(prompt_tokens=100, ttft_ms=20.0, request_id="r1")
+        r2 = _make_request(prompt_tokens=200, ttft_ms=20.0, request_id="r2")
+        data = _make_data([r1, r2])
+        analyzer = DeduplicationAnalyzer()
+        report = analyzer.analyze(data, tolerance_ms=1.0)
+        assert report.duplicate_count == 0
+
+    def test_tolerance_boundary(self):
+        r1 = _make_request(ttft_ms=20.0, tpot_ms=10.0, request_id="r1")
+        r2 = _make_request(ttft_ms=21.0, tpot_ms=10.0, request_id="r2")
+        data = _make_data([r1, r2])
+        analyzer = DeduplicationAnalyzer()
+
+        # tolerance exactly 1.0 should match
+        report = analyzer.analyze(data, tolerance_ms=1.0)
+        assert report.duplicate_count == 1
+
+        # tolerance 0.5 should not match
+        report = analyzer.analyze(data, tolerance_ms=0.5)
+        assert report.duplicate_count == 0
+
+
+class TestDeduplicationAnalyzerRecommendation:
+    def test_high_duplication_recommendation(self):
+        r = _make_request()
+        # 20 copies = 19/20 = 95% duplication
+        requests = [r.model_copy(update={"request_id": f"r{i}"}) for i in range(20)]
+        data = _make_data(requests)
+        analyzer = DeduplicationAnalyzer()
+        report = analyzer.analyze(data)
+        assert "High duplication" in report.recommendation
+
+    def test_moderate_duplication_recommendation(self):
+        r = _make_request()
+        # 2 dups out of 50 = 2% duplication
+        requests = [_make_request(prompt_tokens=i, request_id=f"r{i}") for i in range(1, 49)]
+        requests.append(r.model_copy(update={"request_id": "dup1"}))
+        requests.append(r.model_copy(update={"request_id": "dup2"}))
+        data = _make_data(requests)
+        analyzer = DeduplicationAnalyzer()
+        report = analyzer.analyze(data)
+        assert "Moderate duplication" in report.recommendation
+
+    def test_clean_data_recommendation(self):
+        requests = [_make_request(prompt_tokens=i, request_id=f"r{i}") for i in range(1, 101)]
+        data = _make_data(requests)
+        analyzer = DeduplicationAnalyzer()
+        report = analyzer.analyze(data)
+        assert "clean" in report.recommendation.lower()
+
+
+class TestDeduplicate:
+    def test_deduplicate_removes_extras(self):
+        r = _make_request()
+        requests = [
+            r.model_copy(update={"request_id": "r1"}),
+            r.model_copy(update={"request_id": "r2"}),
+            r.model_copy(update={"request_id": "r3"}),
+        ]
+        data = _make_data(requests)
+        analyzer = DeduplicationAnalyzer()
+        deduped = analyzer.deduplicate(data)
+        assert len(deduped.requests) == 1
+        assert deduped.requests[0].request_id == "r1"
+
+    def test_deduplicate_adjusts_qps(self):
+        r = _make_request()
+        requests = [r.model_copy(update={"request_id": f"r{i}"}) for i in range(4)]
+        data = _make_data(requests)
+        analyzer = DeduplicationAnalyzer()
+        deduped = analyzer.deduplicate(data)
+        assert deduped.metadata.measured_qps == pytest.approx(2.5, abs=0.01)  # 10.0 * 1/4
+
+    def test_deduplicate_preserves_unique(self):
+        requests = [_make_request(prompt_tokens=i, request_id=f"r{i}") for i in range(1, 6)]
+        data = _make_data(requests)
+        analyzer = DeduplicationAnalyzer()
+        deduped = analyzer.deduplicate(data)
+        assert len(deduped.requests) == 5
+
+    def test_deduplicate_single_request(self):
+        data = _make_data([_make_request()])
+        analyzer = DeduplicationAnalyzer()
+        deduped = analyzer.deduplicate(data)
+        assert len(deduped.requests) == 1
+
+    def test_deduplicate_with_tolerance(self):
+        r1 = _make_request(ttft_ms=20.0, tpot_ms=10.0, request_id="r1")
+        r2 = _make_request(ttft_ms=20.2, tpot_ms=10.1, request_id="r2")
+        r3 = _make_request(prompt_tokens=500, request_id="r3")
+        data = _make_data([r1, r2, r3])
+        analyzer = DeduplicationAnalyzer()
+        deduped = analyzer.deduplicate(data, tolerance_ms=1.0)
+        assert len(deduped.requests) == 2
+
+
+class TestAnalyzeDedupAPI:
+    def test_programmatic_api(self, tmp_path):
+        from xpyd_plan.dedup import analyze_dedup
+
+        r = _make_request()
+        data = _make_data([
+            r.model_copy(update={"request_id": "r1"}),
+            r.model_copy(update={"request_id": "r2"}),
+            _make_request(prompt_tokens=999, request_id="r3"),
+        ])
+        path = tmp_path / "bench.json"
+        path.write_text(json.dumps(data.model_dump()))
+
+        result = analyze_dedup(str(path))
+        assert result["total_requests"] == 3
+        assert result["duplicate_count"] == 1
+        assert result["unique_requests"] == 2
+
+
+class TestDuplicateGroupModel:
+    def test_group_validation(self):
+        g = DuplicateGroup(
+            group_id=0,
+            count=3,
+            representative_prompt_tokens=100,
+            representative_output_tokens=50,
+            request_indices=[0, 1, 2],
+            is_exact=True,
+        )
+        assert g.count == 3
+
+    def test_group_min_count(self):
+        with pytest.raises(Exception):
+            DuplicateGroup(
+                group_id=0,
+                count=1,  # min 2
+                representative_prompt_tokens=100,
+                representative_output_tokens=50,
+                request_indices=[0],
+                is_exact=True,
+            )
+
+
+class TestDeduplicationReportModel:
+    def test_report_serialization(self):
+        report = DeduplicationReport(
+            total_requests=10,
+            unique_requests=8,
+            duplicate_count=2,
+            duplication_rate=0.2,
+            group_count=1,
+            largest_group_size=3,
+            groups=[],
+            recommendation="test",
+        )
+        d = report.model_dump()
+        assert d["total_requests"] == 10
+        assert d["duplication_rate"] == 0.2


### PR DESCRIPTION
## M80: Request Deduplication Analysis

Closes #179

### Changes

- `DeduplicationAnalyzer` class in `dedup.py` with exact and near-duplicate detection
- `DuplicateGroup`, `DeduplicationReport`, `DeduplicationConfig` Pydantic models
- Exact duplicate detection (same prompt_tokens, output_tokens, ttft_ms, tpot_ms)
- Near-duplicate detection with configurable latency tolerance (`--tolerance`)
- Duplication rate statistics and group analysis
- Deduplicate output with proportional QPS adjustment (`--output`)
- Severity-based recommendation engine
- CLI `dedup` subcommand with `--benchmark`, `--tolerance`, `--output`, table + JSON output
- Programmatic `analyze_dedup()` API
- 20 new tests (1791 total, all passing)