### PR TITLE
feat: add request timeout analysis (M81)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1063,3 +1063,19 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `dedup` subcommand with `--benchmark`, `--tolerance`, `--output`, table + JSON output
 - Programmatic `analyze_dedup()` API
 - ~22 new tests
+
+### M81 ✅ Request Timeout Analysis
+
+*Completed — PR #TBD*
+
+- `TimeoutAnalyzer` class in `timeout.py`
+- `TimeoutReport`, `TimeoutEvent`, `TimeoutSeverity`, `TimeoutConfig`, `TokenCharacterization`, `TemporalCluster` Pydantic models
+- Configurable per-metric timeout thresholds (TTFT, TPOT, total latency)
+- Timeout rate computation and severity classification (NONE/LOW/MODERATE/HIGH/CRITICAL)
+- Token characterization of timed-out requests (mean, median, min, max for prompt/output tokens)
+- Temporal clustering of timeout events (configurable gap threshold)
+- Per-metric breakdown counts
+- Actionable recommendations based on severity and dominant bottleneck metric
+- CLI `timeout` subcommand with `--benchmark`, `--timeout-ttft`, `--timeout-tpot`, `--timeout-total`, table + JSON output
+- Programmatic `analyze_timeouts()` API
+- 29 new tests (1820 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -946,3 +946,25 @@ __all__ += [
     "DuplicateGroup",
     "analyze_dedup",
 ]
+
+from xpyd_plan.timeout import (  # noqa: E402
+    TemporalCluster,
+    TimeoutAnalyzer,
+    TimeoutConfig,
+    TimeoutEvent,
+    TimeoutReport,
+    TimeoutSeverity,
+    TokenCharacterization,
+    analyze_timeouts,
+)
+
+__all__ += [
+    "TemporalCluster",
+    "TimeoutAnalyzer",
+    "TimeoutConfig",
+    "TimeoutEvent",
+    "TimeoutReport",
+    "TimeoutSeverity",
+    "TokenCharacterization",
+    "analyze_timeouts",
+]

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -67,6 +67,7 @@ from xpyd_plan.cli._tail import _cmd_tail, add_tail_parser
 from xpyd_plan.cli._threshold_advisor import _cmd_threshold_advisor, add_threshold_advisor_parser
 from xpyd_plan.cli._throughput import add_throughput_parser
 from xpyd_plan.cli._timeline import _cmd_timeline, add_timeline_parser
+from xpyd_plan.cli._timeout import add_timeout_parser
 from xpyd_plan.cli._token_efficiency import add_token_efficiency_parser, handle_token_efficiency
 from xpyd_plan.cli._trend import _cmd_trend
 from xpyd_plan.cli._validate import _cmd_validate
@@ -902,6 +903,7 @@ def main(argv: list[str] | None = None) -> None:
     add_jitter_parser(subparsers)
     add_cold_start_parser(subparsers)
     add_dedup_parser(subparsers)
+    add_timeout_parser(subparsers)
     add_spike_parser(subparsers)
 
     # --- fairness subcommand ---

--- a/src/xpyd_plan/cli/_timeout.py
+++ b/src/xpyd_plan/cli/_timeout.py
@@ -1,0 +1,138 @@
+"""CLI timeout command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.timeout import TimeoutAnalyzer
+
+
+def _cmd_timeout(args: argparse.Namespace) -> None:
+    """Handle the 'timeout' subcommand."""
+    console = Console()
+
+    data = load_benchmark_auto(args.benchmark)
+    analyzer = TimeoutAnalyzer()
+    report = analyzer.analyze(
+        data,
+        ttft_ms=args.timeout_ttft,
+        tpot_ms=args.timeout_tpot,
+        total_latency_ms=args.timeout_total,
+    )
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Summary
+    console.print("\n[bold]Request Timeout Analysis[/bold]")
+    console.print(f"Total requests: {report.total_requests}")
+    console.print(f"Timed out: {report.timeout_count}")
+    console.print(f"Timeout rate: {report.timeout_rate:.2%}")
+    console.print(f"Severity: {report.severity.value}")
+
+    if report.per_metric_counts:
+        console.print("\n[bold]Per-Metric Breakdown[/bold]")
+        for metric, count in report.per_metric_counts.items():
+            if count > 0:
+                console.print(f"  {metric}: {count} requests")
+
+    if report.token_characterization:
+        tc = report.token_characterization
+        console.print("\n[bold]Timed-Out Request Characteristics[/bold]")
+        console.print(
+            f"  Prompt tokens: mean={tc.prompt_tokens_mean:.0f}, "
+            f"median={tc.prompt_tokens_median:.0f}, "
+            f"range=[{tc.prompt_tokens_min}, {tc.prompt_tokens_max}]"
+        )
+        console.print(
+            f"  Output tokens: mean={tc.output_tokens_mean:.0f}, "
+            f"median={tc.output_tokens_median:.0f}, "
+            f"range=[{tc.output_tokens_min}, {tc.output_tokens_max}]"
+        )
+
+    if report.temporal_clusters:
+        console.print(f"\n[bold]Temporal Clusters ({len(report.temporal_clusters)})[/bold]")
+        cluster_table = Table()
+        cluster_table.add_column("Cluster", justify="right")
+        cluster_table.add_column("Count", justify="right")
+        cluster_table.add_column("Duration (s)", justify="right")
+        for i, c in enumerate(report.temporal_clusters[:10]):
+            cluster_table.add_row(str(i + 1), str(c.count), f"{c.duration_seconds:.1f}")
+        console.print(cluster_table)
+
+    console.print(f"\n[italic]{report.recommendation}[/italic]\n")
+
+    if report.events:
+        table = Table(title="Timeout Events (first 20)")
+        table.add_column("Index", justify="right")
+        table.add_column("Request ID")
+        table.add_column("Prompt Tokens", justify="right")
+        table.add_column("Output Tokens", justify="right")
+        table.add_column("TTFT (ms)", justify="right")
+        table.add_column("TPOT (ms)", justify="right")
+        table.add_column("Total (ms)", justify="right")
+        table.add_column("Exceeded")
+
+        for e in report.events[:20]:
+            table.add_row(
+                str(e.index),
+                e.request_id,
+                str(e.prompt_tokens),
+                str(e.output_tokens),
+                f"{e.ttft_ms:.1f}",
+                f"{e.tpot_ms:.1f}",
+                f"{e.total_latency_ms:.1f}",
+                ", ".join(e.exceeded_metrics),
+            )
+
+        if len(report.events) > 20:
+            console.print(f"  ... and {len(report.events) - 20} more timeout events")
+
+        console.print(table)
+
+
+def add_timeout_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the timeout subcommand parser."""
+    parser = subparsers.add_parser(
+        "timeout",
+        help="Identify and characterize requests exceeding latency thresholds",
+    )
+    parser.add_argument(
+        "--benchmark",
+        required=True,
+        help="Path to benchmark JSON file",
+    )
+    parser.add_argument(
+        "--timeout-ttft",
+        type=float,
+        default=None,
+        help="TTFT timeout threshold in ms",
+    )
+    parser.add_argument(
+        "--timeout-tpot",
+        type=float,
+        default=None,
+        help="TPOT timeout threshold in ms",
+    )
+    parser.add_argument(
+        "--timeout-total",
+        type=float,
+        default=None,
+        help="Total latency timeout threshold in ms",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_timeout)

--- a/src/xpyd_plan/timeout.py
+++ b/src/xpyd_plan/timeout.py
@@ -1,0 +1,321 @@
+"""Request timeout analysis — identify and characterize requests exceeding latency bounds."""
+
+from __future__ import annotations
+
+from enum import Enum
+from statistics import mean, median
+
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData, BenchmarkRequest
+
+
+class TimeoutSeverity(str, Enum):
+    """Severity classification based on timeout rate."""
+
+    NONE = "NONE"
+    LOW = "LOW"
+    MODERATE = "MODERATE"
+    HIGH = "HIGH"
+    CRITICAL = "CRITICAL"
+
+
+class TimeoutConfig(BaseModel):
+    """Configuration for timeout thresholds."""
+
+    ttft_ms: float | None = Field(default=None, ge=0, description="TTFT timeout threshold in ms")
+    tpot_ms: float | None = Field(default=None, ge=0, description="TPOT timeout threshold in ms")
+    total_latency_ms: float | None = Field(
+        default=None, ge=0, description="Total latency timeout threshold in ms"
+    )
+
+
+class TimeoutEvent(BaseModel):
+    """A single timed-out request."""
+
+    request_id: str = Field(..., description="Request identifier")
+    index: int = Field(..., description="Index in the benchmark data")
+    prompt_tokens: int = Field(..., description="Prompt token count")
+    output_tokens: int = Field(..., description="Output token count")
+    ttft_ms: float = Field(..., description="TTFT in ms")
+    tpot_ms: float = Field(..., description="TPOT in ms")
+    total_latency_ms: float = Field(..., description="Total latency in ms")
+    timestamp: float = Field(..., description="Request timestamp")
+    exceeded_metrics: list[str] = Field(..., description="Which thresholds were exceeded")
+
+
+class TokenCharacterization(BaseModel):
+    """Token distribution stats for timed-out requests."""
+
+    prompt_tokens_mean: float = Field(..., description="Mean prompt tokens")
+    prompt_tokens_median: float = Field(..., description="Median prompt tokens")
+    prompt_tokens_min: int = Field(..., description="Min prompt tokens")
+    prompt_tokens_max: int = Field(..., description="Max prompt tokens")
+    output_tokens_mean: float = Field(..., description="Mean output tokens")
+    output_tokens_median: float = Field(..., description="Median output tokens")
+    output_tokens_min: int = Field(..., description="Min output tokens")
+    output_tokens_max: int = Field(..., description="Max output tokens")
+
+
+class TemporalCluster(BaseModel):
+    """A temporal cluster of timeout events."""
+
+    start_timestamp: float = Field(..., description="Cluster start time")
+    end_timestamp: float = Field(..., description="Cluster end time")
+    count: int = Field(..., ge=1, description="Number of timeouts in cluster")
+    duration_seconds: float = Field(..., ge=0, description="Cluster duration in seconds")
+
+
+class TimeoutReport(BaseModel):
+    """Complete timeout analysis report."""
+
+    total_requests: int = Field(..., description="Total requests in benchmark")
+    timeout_count: int = Field(..., ge=0, description="Number of timed-out requests")
+    timeout_rate: float = Field(..., ge=0, le=1, description="Fraction of requests that timed out")
+    severity: TimeoutSeverity = Field(..., description="Timeout severity classification")
+    config: TimeoutConfig = Field(..., description="Timeout thresholds used")
+    events: list[TimeoutEvent] = Field(..., description="Individual timeout events")
+    token_characterization: TokenCharacterization | None = Field(
+        default=None, description="Token stats of timed-out requests"
+    )
+    temporal_clusters: list[TemporalCluster] = Field(
+        default_factory=list, description="Temporal clusters of timeouts"
+    )
+    recommendation: str = Field(..., description="Actionable recommendation")
+    per_metric_counts: dict[str, int] = Field(
+        default_factory=dict, description="Timeout counts per metric"
+    )
+
+
+class TimeoutAnalyzer:
+    """Identify and characterize requests exceeding latency thresholds."""
+
+    def analyze(
+        self,
+        data: BenchmarkData,
+        config: TimeoutConfig | None = None,
+        ttft_ms: float | None = None,
+        tpot_ms: float | None = None,
+        total_latency_ms: float | None = None,
+    ) -> TimeoutReport:
+        """Analyze benchmark data for timeout events.
+
+        Args:
+            data: Benchmark data to analyze.
+            config: Timeout configuration. If None, uses individual threshold args.
+            ttft_ms: TTFT timeout threshold (overrides config).
+            tpot_ms: TPOT timeout threshold (overrides config).
+            total_latency_ms: Total latency timeout threshold (overrides config).
+
+        Returns:
+            TimeoutReport with analysis results.
+        """
+        if config is None:
+            config = TimeoutConfig(
+                ttft_ms=ttft_ms, tpot_ms=tpot_ms, total_latency_ms=total_latency_ms
+            )
+        else:
+            if ttft_ms is not None:
+                config = config.model_copy(update={"ttft_ms": ttft_ms})
+            if tpot_ms is not None:
+                config = config.model_copy(update={"tpot_ms": tpot_ms})
+            if total_latency_ms is not None:
+                config = config.model_copy(update={"total_latency_ms": total_latency_ms})
+
+        events = self._find_timeouts(data.requests, config)
+        timeout_count = len(events)
+        total = len(data.requests)
+        rate = timeout_count / total if total > 0 else 0.0
+        severity = self._classify_severity(rate)
+
+        per_metric: dict[str, int] = {}
+        for metric in ("ttft_ms", "tpot_ms", "total_latency_ms"):
+            per_metric[metric] = sum(1 for e in events if metric in e.exceeded_metrics)
+
+        token_char = self._characterize_tokens(events) if events else None
+        clusters = self._find_temporal_clusters(events) if events else []
+        recommendation = self._recommend(severity, rate, per_metric, timeout_count, total)
+
+        return TimeoutReport(
+            total_requests=total,
+            timeout_count=timeout_count,
+            timeout_rate=rate,
+            severity=severity,
+            config=config,
+            events=events,
+            token_characterization=token_char,
+            temporal_clusters=clusters,
+            recommendation=recommendation,
+            per_metric_counts=per_metric,
+        )
+
+    def _find_timeouts(
+        self, requests: list[BenchmarkRequest], config: TimeoutConfig
+    ) -> list[TimeoutEvent]:
+        """Identify requests exceeding any configured threshold."""
+        events: list[TimeoutEvent] = []
+        for i, req in enumerate(requests):
+            exceeded: list[str] = []
+            if config.ttft_ms is not None and req.ttft_ms > config.ttft_ms:
+                exceeded.append("ttft_ms")
+            if config.tpot_ms is not None and req.tpot_ms > config.tpot_ms:
+                exceeded.append("tpot_ms")
+            if (
+                config.total_latency_ms is not None
+                and req.total_latency_ms > config.total_latency_ms
+            ):
+                exceeded.append("total_latency_ms")
+            if exceeded:
+                events.append(
+                    TimeoutEvent(
+                        request_id=req.request_id,
+                        index=i,
+                        prompt_tokens=req.prompt_tokens,
+                        output_tokens=req.output_tokens,
+                        ttft_ms=req.ttft_ms,
+                        tpot_ms=req.tpot_ms,
+                        total_latency_ms=req.total_latency_ms,
+                        timestamp=req.timestamp,
+                        exceeded_metrics=exceeded,
+                    )
+                )
+        return events
+
+    @staticmethod
+    def _classify_severity(rate: float) -> TimeoutSeverity:
+        """Classify timeout severity based on rate."""
+        if rate == 0:
+            return TimeoutSeverity.NONE
+        if rate < 0.01:
+            return TimeoutSeverity.LOW
+        if rate < 0.05:
+            return TimeoutSeverity.MODERATE
+        if rate < 0.15:
+            return TimeoutSeverity.HIGH
+        return TimeoutSeverity.CRITICAL
+
+    @staticmethod
+    def _characterize_tokens(events: list[TimeoutEvent]) -> TokenCharacterization:
+        """Compute token distribution statistics for timed-out requests."""
+        prompt = [e.prompt_tokens for e in events]
+        output = [e.output_tokens for e in events]
+        return TokenCharacterization(
+            prompt_tokens_mean=mean(prompt),
+            prompt_tokens_median=median(prompt),
+            prompt_tokens_min=min(prompt),
+            prompt_tokens_max=max(prompt),
+            output_tokens_mean=mean(output),
+            output_tokens_median=median(output),
+            output_tokens_min=min(output),
+            output_tokens_max=max(output),
+        )
+
+    @staticmethod
+    def _find_temporal_clusters(
+        events: list[TimeoutEvent], gap_seconds: float = 5.0
+    ) -> list[TemporalCluster]:
+        """Group timeout events into temporal clusters.
+
+        Events within `gap_seconds` of each other are grouped together.
+        """
+        if not events:
+            return []
+
+        sorted_events = sorted(events, key=lambda e: e.timestamp)
+        clusters: list[TemporalCluster] = []
+        cluster_start = sorted_events[0].timestamp
+        cluster_end = sorted_events[0].timestamp
+        cluster_count = 1
+
+        for event in sorted_events[1:]:
+            if event.timestamp - cluster_end <= gap_seconds:
+                cluster_end = event.timestamp
+                cluster_count += 1
+            else:
+                clusters.append(
+                    TemporalCluster(
+                        start_timestamp=cluster_start,
+                        end_timestamp=cluster_end,
+                        count=cluster_count,
+                        duration_seconds=cluster_end - cluster_start,
+                    )
+                )
+                cluster_start = event.timestamp
+                cluster_end = event.timestamp
+                cluster_count = 1
+
+        clusters.append(
+            TemporalCluster(
+                start_timestamp=cluster_start,
+                end_timestamp=cluster_end,
+                count=cluster_count,
+                duration_seconds=cluster_end - cluster_start,
+            )
+        )
+        return clusters
+
+    @staticmethod
+    def _recommend(
+        severity: TimeoutSeverity,
+        rate: float,
+        per_metric: dict[str, int],
+        timeout_count: int,
+        total: int,
+    ) -> str:
+        """Generate actionable recommendation."""
+        if severity == TimeoutSeverity.NONE:
+            return "No timeouts detected. All requests completed within thresholds."
+
+        dominant = max(per_metric, key=lambda k: per_metric[k]) if per_metric else "unknown"
+        dominant_label = {
+            "ttft_ms": "TTFT (time to first token)",
+            "tpot_ms": "TPOT (time per output token)",
+            "total_latency_ms": "total latency",
+        }.get(dominant, dominant)
+
+        if severity == TimeoutSeverity.LOW:
+            return (
+                f"{timeout_count}/{total} requests ({rate:.1%}) timed out. "
+                f"Primary bottleneck: {dominant_label}. "
+                f"Low severity — monitor but likely acceptable."
+            )
+        if severity == TimeoutSeverity.MODERATE:
+            return (
+                f"{timeout_count}/{total} requests ({rate:.1%}) timed out. "
+                f"Primary bottleneck: {dominant_label}. "
+                f"Consider scaling {'prefill' if dominant == 'ttft_ms' else 'decode'} instances."
+            )
+        if severity == TimeoutSeverity.HIGH:
+            return (
+                f"{timeout_count}/{total} requests ({rate:.1%}) timed out. "
+                f"Primary bottleneck: {dominant_label}. "
+                f"Immediate action needed: increase instance count or adjust P:D ratio."
+            )
+        return (
+            f"CRITICAL: {timeout_count}/{total} requests ({rate:.1%}) timed out. "
+            f"Primary bottleneck: {dominant_label}. "
+            f"Configuration is severely under-provisioned. Urgent rebalancing required."
+        )
+
+
+def analyze_timeouts(
+    data: BenchmarkData,
+    ttft_ms: float | None = None,
+    tpot_ms: float | None = None,
+    total_latency_ms: float | None = None,
+) -> TimeoutReport:
+    """Programmatic API for timeout analysis.
+
+    Args:
+        data: Benchmark data to analyze.
+        ttft_ms: TTFT timeout threshold in ms.
+        tpot_ms: TPOT timeout threshold in ms.
+        total_latency_ms: Total latency timeout threshold in ms.
+
+    Returns:
+        TimeoutReport with analysis results.
+    """
+    analyzer = TimeoutAnalyzer()
+    return analyzer.analyze(
+        data, ttft_ms=ttft_ms, tpot_ms=tpot_ms, total_latency_ms=total_latency_ms
+    )

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,0 +1,296 @@
+"""Tests for request timeout analysis."""
+
+from __future__ import annotations
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.timeout import (
+    TimeoutAnalyzer,
+    TimeoutConfig,
+    TimeoutReport,
+    TimeoutSeverity,
+    analyze_timeouts,
+)
+
+
+def _make_request(
+    request_id: str = "r1",
+    prompt_tokens: int = 100,
+    output_tokens: int = 50,
+    ttft_ms: float = 20.0,
+    tpot_ms: float = 10.0,
+    total_latency_ms: float = 520.0,
+    timestamp: float = 1000.0,
+) -> BenchmarkRequest:
+    return BenchmarkRequest(
+        request_id=request_id,
+        prompt_tokens=prompt_tokens,
+        output_tokens=output_tokens,
+        ttft_ms=ttft_ms,
+        tpot_ms=tpot_ms,
+        total_latency_ms=total_latency_ms,
+        timestamp=timestamp,
+    )
+
+
+def _make_data(requests: list[BenchmarkRequest]) -> BenchmarkData:
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=2,
+            total_instances=4,
+            measured_qps=10.0,
+        ),
+        requests=requests,
+    )
+
+
+class TestTimeoutAnalyzerNoTimeouts:
+    """Tests where no requests time out."""
+
+    def test_no_thresholds_set(self):
+        data = _make_data([_make_request()])
+        report = TimeoutAnalyzer().analyze(data)
+        assert report.timeout_count == 0
+        assert report.timeout_rate == 0.0
+        assert report.severity == TimeoutSeverity.NONE
+
+    def test_all_within_threshold(self):
+        data = _make_data([_make_request(ttft_ms=10.0), _make_request(ttft_ms=15.0)])
+        report = TimeoutAnalyzer().analyze(data, ttft_ms=100.0)
+        assert report.timeout_count == 0
+        assert report.severity == TimeoutSeverity.NONE
+
+    def test_empty_data(self):
+        data = _make_data([_make_request(ttft_ms=10.0)])
+        # Single request within threshold
+        report = TimeoutAnalyzer().analyze(data, ttft_ms=100.0)
+        assert report.timeout_count == 0
+        assert report.timeout_rate == 0.0
+
+
+class TestTimeoutAnalyzerDetection:
+    """Tests for timeout detection."""
+
+    def test_ttft_timeout(self):
+        requests = [
+            _make_request(request_id="r1", ttft_ms=50.0),
+            _make_request(request_id="r2", ttft_ms=200.0),
+        ]
+        data = _make_data(requests)
+        report = TimeoutAnalyzer().analyze(data, ttft_ms=100.0)
+        assert report.timeout_count == 1
+        assert report.events[0].request_id == "r2"
+        assert "ttft_ms" in report.events[0].exceeded_metrics
+
+    def test_tpot_timeout(self):
+        requests = [
+            _make_request(request_id="r1", tpot_ms=5.0),
+            _make_request(request_id="r2", tpot_ms=50.0),
+        ]
+        data = _make_data(requests)
+        report = TimeoutAnalyzer().analyze(data, tpot_ms=20.0)
+        assert report.timeout_count == 1
+        assert "tpot_ms" in report.events[0].exceeded_metrics
+
+    def test_total_latency_timeout(self):
+        requests = [
+            _make_request(request_id="r1", total_latency_ms=100.0),
+            _make_request(request_id="r2", total_latency_ms=5000.0),
+        ]
+        data = _make_data(requests)
+        report = TimeoutAnalyzer().analyze(data, total_latency_ms=1000.0)
+        assert report.timeout_count == 1
+        assert "total_latency_ms" in report.events[0].exceeded_metrics
+
+    def test_multiple_metrics_exceeded(self):
+        req = _make_request(ttft_ms=200.0, tpot_ms=50.0, total_latency_ms=5000.0)
+        data = _make_data([req])
+        report = TimeoutAnalyzer().analyze(
+            data, ttft_ms=100.0, tpot_ms=20.0, total_latency_ms=1000.0
+        )
+        assert report.timeout_count == 1
+        assert len(report.events[0].exceeded_metrics) == 3
+
+    def test_per_metric_counts(self):
+        requests = [
+            _make_request(request_id="r1", ttft_ms=200.0, tpot_ms=5.0, total_latency_ms=100.0),
+            _make_request(request_id="r2", ttft_ms=10.0, tpot_ms=50.0, total_latency_ms=100.0),
+        ]
+        data = _make_data(requests)
+        report = TimeoutAnalyzer().analyze(data, ttft_ms=100.0, tpot_ms=20.0)
+        assert report.per_metric_counts["ttft_ms"] == 1
+        assert report.per_metric_counts["tpot_ms"] == 1
+
+    def test_exact_threshold_not_timeout(self):
+        """Requests exactly at threshold should NOT be counted as timeouts."""
+        req = _make_request(ttft_ms=100.0)
+        data = _make_data([req])
+        report = TimeoutAnalyzer().analyze(data, ttft_ms=100.0)
+        assert report.timeout_count == 0
+
+
+class TestTimeoutSeverity:
+    """Tests for severity classification."""
+
+    def test_none_severity(self):
+        assert TimeoutAnalyzer._classify_severity(0.0) == TimeoutSeverity.NONE
+
+    def test_low_severity(self):
+        assert TimeoutAnalyzer._classify_severity(0.005) == TimeoutSeverity.LOW
+
+    def test_moderate_severity(self):
+        assert TimeoutAnalyzer._classify_severity(0.03) == TimeoutSeverity.MODERATE
+
+    def test_high_severity(self):
+        assert TimeoutAnalyzer._classify_severity(0.10) == TimeoutSeverity.HIGH
+
+    def test_critical_severity(self):
+        assert TimeoutAnalyzer._classify_severity(0.20) == TimeoutSeverity.CRITICAL
+
+
+class TestTokenCharacterization:
+    """Tests for token characterization of timed-out requests."""
+
+    def test_single_timeout_characterization(self):
+        req = _make_request(prompt_tokens=200, output_tokens=100, ttft_ms=500.0)
+        data = _make_data([req])
+        report = TimeoutAnalyzer().analyze(data, ttft_ms=100.0)
+        assert report.token_characterization is not None
+        assert report.token_characterization.prompt_tokens_mean == 200.0
+        assert report.token_characterization.output_tokens_mean == 100.0
+
+    def test_multiple_timeout_characterization(self):
+        requests = [
+            _make_request(request_id="r1", prompt_tokens=100, output_tokens=50, ttft_ms=500.0),
+            _make_request(request_id="r2", prompt_tokens=300, output_tokens=150, ttft_ms=600.0),
+        ]
+        data = _make_data(requests)
+        report = TimeoutAnalyzer().analyze(data, ttft_ms=100.0)
+        tc = report.token_characterization
+        assert tc is not None
+        assert tc.prompt_tokens_mean == 200.0
+        assert tc.prompt_tokens_min == 100
+        assert tc.prompt_tokens_max == 300
+
+    def test_no_characterization_when_no_timeouts(self):
+        data = _make_data([_make_request(ttft_ms=10.0)])
+        report = TimeoutAnalyzer().analyze(data, ttft_ms=100.0)
+        assert report.token_characterization is None
+
+
+class TestTemporalClusters:
+    """Tests for temporal clustering."""
+
+    def test_single_cluster(self):
+        requests = [
+            _make_request(request_id=f"r{i}", ttft_ms=500.0, timestamp=1000.0 + i)
+            for i in range(5)
+        ]
+        data = _make_data(requests)
+        report = TimeoutAnalyzer().analyze(data, ttft_ms=100.0)
+        assert len(report.temporal_clusters) == 1
+        assert report.temporal_clusters[0].count == 5
+
+    def test_two_clusters(self):
+        requests = [
+            _make_request(request_id="r1", ttft_ms=500.0, timestamp=1000.0),
+            _make_request(request_id="r2", ttft_ms=500.0, timestamp=1002.0),
+            _make_request(request_id="r3", ttft_ms=500.0, timestamp=1020.0),
+            _make_request(request_id="r4", ttft_ms=500.0, timestamp=1022.0),
+        ]
+        data = _make_data(requests)
+        report = TimeoutAnalyzer().analyze(data, ttft_ms=100.0)
+        assert len(report.temporal_clusters) == 2
+        assert report.temporal_clusters[0].count == 2
+        assert report.temporal_clusters[1].count == 2
+
+    def test_no_clusters_when_no_timeouts(self):
+        data = _make_data([_make_request(ttft_ms=10.0)])
+        report = TimeoutAnalyzer().analyze(data, ttft_ms=100.0)
+        assert len(report.temporal_clusters) == 0
+
+
+class TestTimeoutConfig:
+    """Tests for TimeoutConfig model."""
+
+    def test_config_passed_to_analyzer(self):
+        config = TimeoutConfig(ttft_ms=50.0, tpot_ms=None, total_latency_ms=None)
+        req = _make_request(ttft_ms=100.0)
+        data = _make_data([req])
+        report = TimeoutAnalyzer().analyze(data, config=config)
+        assert report.timeout_count == 1
+        assert report.config.ttft_ms == 50.0
+
+    def test_args_override_config(self):
+        config = TimeoutConfig(ttft_ms=50.0)
+        req = _make_request(ttft_ms=100.0)
+        data = _make_data([req])
+        report = TimeoutAnalyzer().analyze(data, config=config, ttft_ms=200.0)
+        assert report.timeout_count == 0
+        assert report.config.ttft_ms == 200.0
+
+
+class TestProgrammaticAPI:
+    """Tests for the analyze_timeouts() convenience function."""
+
+    def test_basic(self):
+        requests = [
+            _make_request(request_id="r1", ttft_ms=10.0),
+            _make_request(request_id="r2", ttft_ms=500.0),
+        ]
+        data = _make_data(requests)
+        report = analyze_timeouts(data, ttft_ms=100.0)
+        assert isinstance(report, TimeoutReport)
+        assert report.timeout_count == 1
+
+    def test_no_thresholds(self):
+        data = _make_data([_make_request()])
+        report = analyze_timeouts(data)
+        assert report.timeout_count == 0
+
+
+class TestRecommendation:
+    """Tests for recommendation generation."""
+
+    def test_no_timeout_recommendation(self):
+        data = _make_data([_make_request(ttft_ms=10.0)])
+        report = TimeoutAnalyzer().analyze(data, ttft_ms=100.0)
+        assert "No timeouts" in report.recommendation
+
+    def test_critical_recommendation(self):
+        requests = [
+            _make_request(request_id=f"r{i}", ttft_ms=500.0, timestamp=1000.0 + i)
+            for i in range(20)
+        ]
+        data = _make_data(requests)
+        report = TimeoutAnalyzer().analyze(data, ttft_ms=100.0)
+        assert "CRITICAL" in report.recommendation
+
+    def test_moderate_mentions_bottleneck(self):
+        # 3 out of 100 = 3% -> MODERATE
+        requests = []
+        for i in range(100):
+            ttft = 500.0 if i < 3 else 10.0
+            requests.append(_make_request(request_id=f"r{i}", ttft_ms=ttft, timestamp=1000.0 + i))
+        data = _make_data(requests)
+        report = TimeoutAnalyzer().analyze(data, ttft_ms=100.0)
+        assert report.severity == TimeoutSeverity.MODERATE
+        assert "prefill" in report.recommendation
+
+
+class TestReportSerialization:
+    """Test that reports serialize correctly."""
+
+    def test_model_dump(self):
+        data = _make_data([_make_request(ttft_ms=500.0)])
+        report = TimeoutAnalyzer().analyze(data, ttft_ms=100.0)
+        dumped = report.model_dump()
+        assert isinstance(dumped, dict)
+        assert dumped["timeout_count"] == 1
+        assert dumped["severity"] == "CRITICAL"
+
+    def test_model_dump_json(self):
+        data = _make_data([_make_request()])
+        report = TimeoutAnalyzer().analyze(data, ttft_ms=100.0)
+        json_str = report.model_dump_json()
+        assert isinstance(json_str, str)


### PR DESCRIPTION
## M81: Request Timeout Analysis

Closes #181

### Changes

- `TimeoutAnalyzer` class in `timeout.py` with configurable per-metric timeout thresholds
- `TimeoutReport`, `TimeoutEvent`, `TimeoutSeverity`, `TimeoutConfig`, `TokenCharacterization`, `TemporalCluster` Pydantic models
- Timeout rate computation and severity classification (NONE/LOW/MODERATE/HIGH/CRITICAL)
- Token characterization of timed-out requests (mean, median, min, max for prompt/output tokens)
- Temporal clustering of timeout events (configurable gap threshold)
- Per-metric breakdown counts
- Actionable recommendations based on severity and dominant bottleneck metric
- CLI `timeout` subcommand with `--benchmark`, `--timeout-ttft`, `--timeout-tpot`, `--timeout-total`, table + JSON output
- Programmatic `analyze_timeouts()` API
- 29 new tests (1820 total, all passing)