### PR TITLE
feat: add latency percentile comparison across P:D ratios (M82)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1079,3 +1079,17 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `timeout` subcommand with `--benchmark`, `--timeout-ttft`, `--timeout-tpot`, `--timeout-total`, table + JSON output
 - Programmatic `analyze_timeouts()` API
 - 29 new tests (1820 total)
+
+### M82 ✅ Latency Percentile Comparison Across Ratios
+
+*Completed — PR #TBD*
+
+- `RatioComparer` class in `ratio_compare.py`
+- `RatioComparison`, `RatioMetrics`, `PercentileStats`, `BestRatio` Pydantic models
+- Load multiple benchmarks with different P:D ratios
+- Per-ratio latency stats at P50/P95/P99 for TTFT, TPOT, total_latency
+- Best ratio identification per metric+percentile combination
+- Overall best ratio (most wins across all combinations)
+- CLI `ratio-compare` subcommand with `--benchmark` (multiple), table + JSON output
+- Programmatic `compare_ratios()` API
+- ~22 new tests

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -968,3 +968,21 @@ __all__ += [
     "TokenCharacterization",
     "analyze_timeouts",
 ]
+
+from xpyd_plan.ratio_compare import (  # noqa: E402
+    BestRatio,
+    PercentileStats,
+    RatioComparer,
+    RatioComparison,
+    RatioMetrics,
+    compare_ratios,
+)
+
+__all__ += [
+    "BestRatio",
+    "PercentileStats",
+    "RatioComparer",
+    "RatioComparison",
+    "RatioMetrics",
+    "compare_ratios",
+]

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -48,6 +48,7 @@ from xpyd_plan.cli._pareto import _cmd_pareto
 from xpyd_plan.cli._pipeline import _cmd_pipeline
 from xpyd_plan.cli._plan_benchmarks import _cmd_plan_benchmarks, add_plan_benchmarks_parser
 from xpyd_plan.cli._queue import add_queue_parser
+from xpyd_plan.cli._ratio_compare import add_ratio_compare_parser
 from xpyd_plan.cli._recommend import _cmd_recommend
 from xpyd_plan.cli._regression import _cmd_regression, add_regression_parser
 from xpyd_plan.cli._replay import add_replay_parser
@@ -904,6 +905,7 @@ def main(argv: list[str] | None = None) -> None:
     add_cold_start_parser(subparsers)
     add_dedup_parser(subparsers)
     add_timeout_parser(subparsers)
+    add_ratio_compare_parser(subparsers)
     add_spike_parser(subparsers)
 
     # --- fairness subcommand ---

--- a/src/xpyd_plan/cli/_ratio_compare.py
+++ b/src/xpyd_plan/cli/_ratio_compare.py
@@ -1,0 +1,110 @@
+"""CLI ratio-compare command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.ratio_compare import RatioComparer
+
+
+def _cmd_ratio_compare(args: argparse.Namespace) -> None:
+    """Handle the 'ratio-compare' subcommand."""
+    console = Console()
+
+    datasets = [load_benchmark_auto(path) for path in args.benchmark]
+    comparer = RatioComparer()
+    report = comparer.compare(datasets)
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Comparison matrix
+    console.print("\n[bold]P:D Ratio Latency Comparison[/bold]\n")
+
+    table = Table(title="Latency Percentiles by P:D Ratio")
+    table.add_column("Ratio", justify="center")
+    table.add_column("Requests", justify="right")
+    table.add_column("QPS", justify="right")
+    table.add_column("TTFT P50", justify="right")
+    table.add_column("TTFT P95", justify="right")
+    table.add_column("TTFT P99", justify="right")
+    table.add_column("TPOT P50", justify="right")
+    table.add_column("TPOT P95", justify="right")
+    table.add_column("TPOT P99", justify="right")
+    table.add_column("Total P50", justify="right")
+    table.add_column("Total P95", justify="right")
+    table.add_column("Total P99", justify="right")
+
+    # Build set of best values for highlighting
+    best_set: set[tuple[str, str]] = set()
+    for br in report.best_ratios:
+        best_set.add((br.ratio_label, f"{br.metric}_{br.percentile}"))
+
+    for r in report.ratios:
+        def _fmt(metric: str, pct: str, val: float) -> str:
+            s = f"{val:.1f}"
+            if (r.ratio_label, f"{metric}_{pct}") in best_set:
+                return f"[bold green]{s}[/bold green]"
+            return s
+
+        table.add_row(
+            r.ratio_label,
+            str(r.request_count),
+            f"{r.measured_qps:.1f}",
+            _fmt("ttft", "p50", r.ttft.p50),
+            _fmt("ttft", "p95", r.ttft.p95),
+            _fmt("ttft", "p99", r.ttft.p99),
+            _fmt("tpot", "p50", r.tpot.p50),
+            _fmt("tpot", "p95", r.tpot.p95),
+            _fmt("tpot", "p99", r.tpot.p99),
+            _fmt("total_latency", "p50", r.total_latency.p50),
+            _fmt("total_latency", "p95", r.total_latency.p95),
+            _fmt("total_latency", "p99", r.total_latency.p99),
+        )
+
+    console.print(table)
+
+    # Best ratios summary
+    console.print(f"\n[bold]Overall Best Ratio: {report.overall_best}[/bold]")
+    console.print("(Wins the most metric+percentile combinations)\n")
+
+    best_table = Table(title="Best Ratio per Metric")
+    best_table.add_column("Metric")
+    best_table.add_column("Percentile")
+    best_table.add_column("Best Ratio")
+    best_table.add_column("Value (ms)", justify="right")
+
+    for br in report.best_ratios:
+        best_table.add_row(br.metric, br.percentile, br.ratio_label, f"{br.value_ms:.1f}")
+
+    console.print(best_table)
+
+
+def add_ratio_compare_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the ratio-compare subcommand parser."""
+    parser = subparsers.add_parser(
+        "ratio-compare",
+        help="Compare latency percentiles across P:D ratio configurations",
+    )
+    parser.add_argument(
+        "--benchmark",
+        required=True,
+        nargs="+",
+        help="Paths to benchmark JSON files (one per P:D ratio)",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_ratio_compare)

--- a/src/xpyd_plan/ratio_compare.py
+++ b/src/xpyd_plan/ratio_compare.py
@@ -1,0 +1,153 @@
+"""Latency percentile comparison across P:D ratios."""
+
+from __future__ import annotations
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData
+
+
+class PercentileStats(BaseModel):
+    """Latency percentiles for a single metric."""
+
+    p50: float = Field(..., description="50th percentile latency (ms)")
+    p95: float = Field(..., description="95th percentile latency (ms)")
+    p99: float = Field(..., description="99th percentile latency (ms)")
+
+
+class RatioMetrics(BaseModel):
+    """All latency metrics for a single P:D ratio configuration."""
+
+    ratio_label: str = Field(..., description="P:D ratio label (e.g. '4:2')")
+    num_prefill: int = Field(..., ge=1)
+    num_decode: int = Field(..., ge=1)
+    total_instances: int = Field(..., ge=2)
+    request_count: int = Field(..., ge=1)
+    measured_qps: float = Field(..., gt=0)
+    ttft: PercentileStats = Field(..., description="TTFT percentiles")
+    tpot: PercentileStats = Field(..., description="TPOT percentiles")
+    total_latency: PercentileStats = Field(..., description="Total latency percentiles")
+
+
+class BestRatio(BaseModel):
+    """Best ratio for a specific metric+percentile combination."""
+
+    metric: str = Field(..., description="Metric name (ttft, tpot, total_latency)")
+    percentile: str = Field(..., description="Percentile level (p50, p95, p99)")
+    ratio_label: str = Field(..., description="Best ratio label")
+    value_ms: float = Field(..., description="Best value in ms")
+
+
+class RatioComparison(BaseModel):
+    """Complete ratio comparison report."""
+
+    ratios: list[RatioMetrics] = Field(..., description="Per-ratio metrics")
+    best_ratios: list[BestRatio] = Field(..., description="Best ratio per metric+percentile")
+    overall_best: str = Field(..., description="Overall best ratio (most wins)")
+
+
+class RatioComparer:
+    """Compare latency percentiles across P:D ratio configurations."""
+
+    def compare(self, datasets: list[BenchmarkData]) -> RatioComparison:
+        """Compare multiple benchmark datasets with different P:D ratios.
+
+        Args:
+            datasets: List of BenchmarkData, each from a different P:D ratio.
+
+        Returns:
+            RatioComparison with per-ratio metrics and best-ratio identification.
+
+        Raises:
+            ValueError: If fewer than 2 datasets provided.
+        """
+        if len(datasets) < 2:
+            raise ValueError("At least 2 benchmark datasets required for comparison")
+
+        ratios: list[RatioMetrics] = []
+        for data in datasets:
+            meta = data.metadata
+            label = f"{meta.num_prefill_instances}:{meta.num_decode_instances}"
+            requests = data.requests
+
+            ttft_vals = [r.ttft_ms for r in requests]
+            tpot_vals = [r.tpot_ms for r in requests]
+            total_vals = [r.total_latency_ms for r in requests]
+
+            ratios.append(
+                RatioMetrics(
+                    ratio_label=label,
+                    num_prefill=meta.num_prefill_instances,
+                    num_decode=meta.num_decode_instances,
+                    total_instances=meta.total_instances,
+                    request_count=len(requests),
+                    measured_qps=meta.measured_qps,
+                    ttft=self._compute_percentiles(ttft_vals),
+                    tpot=self._compute_percentiles(tpot_vals),
+                    total_latency=self._compute_percentiles(total_vals),
+                )
+            )
+
+        best_ratios = self._find_best_ratios(ratios)
+        overall_best = self._find_overall_best(best_ratios)
+
+        return RatioComparison(
+            ratios=ratios,
+            best_ratios=best_ratios,
+            overall_best=overall_best,
+        )
+
+    @staticmethod
+    def _compute_percentiles(values: list[float]) -> PercentileStats:
+        """Compute P50/P95/P99 for a list of values."""
+        arr = np.array(values)
+        return PercentileStats(
+            p50=float(np.percentile(arr, 50)),
+            p95=float(np.percentile(arr, 95)),
+            p99=float(np.percentile(arr, 99)),
+        )
+
+    @staticmethod
+    def _find_best_ratios(ratios: list[RatioMetrics]) -> list[BestRatio]:
+        """Find the best ratio for each metric+percentile combination."""
+        results: list[BestRatio] = []
+        for metric_name in ("ttft", "tpot", "total_latency"):
+            for pct in ("p50", "p95", "p99"):
+                best_label = ""
+                best_val = float("inf")
+                for r in ratios:
+                    stats: PercentileStats = getattr(r, metric_name)
+                    val = getattr(stats, pct)
+                    if val < best_val:
+                        best_val = val
+                        best_label = r.ratio_label
+                results.append(
+                    BestRatio(
+                        metric=metric_name,
+                        percentile=pct,
+                        ratio_label=best_label,
+                        value_ms=best_val,
+                    )
+                )
+        return results
+
+    @staticmethod
+    def _find_overall_best(best_ratios: list[BestRatio]) -> str:
+        """Find the ratio that wins in the most metric+percentile combinations."""
+        wins: dict[str, int] = {}
+        for br in best_ratios:
+            wins[br.ratio_label] = wins.get(br.ratio_label, 0) + 1
+        return max(wins, key=lambda k: wins[k])
+
+
+def compare_ratios(datasets: list[BenchmarkData]) -> RatioComparison:
+    """Programmatic API for ratio comparison.
+
+    Args:
+        datasets: List of BenchmarkData from different P:D ratios.
+
+    Returns:
+        RatioComparison report.
+    """
+    return RatioComparer().compare(datasets)

--- a/tests/test_ratio_compare.py
+++ b/tests/test_ratio_compare.py
@@ -1,0 +1,239 @@
+"""Tests for latency percentile comparison across P:D ratios."""
+
+from __future__ import annotations
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.ratio_compare import (
+    PercentileStats,
+    RatioComparer,
+    RatioComparison,
+    compare_ratios,
+)
+
+
+def _make_request(
+    request_id: str = "r1",
+    prompt_tokens: int = 100,
+    output_tokens: int = 50,
+    ttft_ms: float = 20.0,
+    tpot_ms: float = 10.0,
+    total_latency_ms: float = 520.0,
+    timestamp: float = 1000.0,
+) -> BenchmarkRequest:
+    return BenchmarkRequest(
+        request_id=request_id,
+        prompt_tokens=prompt_tokens,
+        output_tokens=output_tokens,
+        ttft_ms=ttft_ms,
+        tpot_ms=tpot_ms,
+        total_latency_ms=total_latency_ms,
+        timestamp=timestamp,
+    )
+
+
+def _make_data(
+    requests: list[BenchmarkRequest],
+    num_prefill: int = 2,
+    num_decode: int = 2,
+    qps: float = 10.0,
+) -> BenchmarkData:
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=num_prefill,
+            num_decode_instances=num_decode,
+            total_instances=num_prefill + num_decode,
+            measured_qps=qps,
+        ),
+        requests=requests,
+    )
+
+
+def _make_dataset(
+    num_prefill: int,
+    num_decode: int,
+    ttft_base: float = 20.0,
+    tpot_base: float = 10.0,
+    total_base: float = 500.0,
+    n: int = 100,
+    qps: float = 10.0,
+) -> BenchmarkData:
+    """Create a dataset with some variance around base values."""
+    requests = []
+    for i in range(n):
+        # Add some variance
+        factor = 1.0 + (i % 10) * 0.1
+        requests.append(
+            _make_request(
+                request_id=f"r{i}",
+                ttft_ms=ttft_base * factor,
+                tpot_ms=tpot_base * factor,
+                total_latency_ms=total_base * factor,
+                timestamp=1000.0 + i,
+            )
+        )
+    return _make_data(requests, num_prefill=num_prefill, num_decode=num_decode, qps=qps)
+
+
+class TestRatioComparerBasic:
+    """Basic comparison tests."""
+
+    def test_two_ratios(self):
+        d1 = _make_dataset(3, 1, ttft_base=30.0)
+        d2 = _make_dataset(1, 3, ttft_base=20.0)
+        report = RatioComparer().compare([d1, d2])
+        assert len(report.ratios) == 2
+        assert report.ratios[0].ratio_label == "3:1"
+        assert report.ratios[1].ratio_label == "1:3"
+
+    def test_three_ratios(self):
+        d1 = _make_dataset(3, 1)
+        d2 = _make_dataset(2, 2)
+        d3 = _make_dataset(1, 3)
+        report = RatioComparer().compare([d1, d2, d3])
+        assert len(report.ratios) == 3
+
+    def test_requires_at_least_two(self):
+        d1 = _make_dataset(2, 2)
+        with pytest.raises(ValueError, match="At least 2"):
+            RatioComparer().compare([d1])
+
+    def test_empty_list_raises(self):
+        with pytest.raises(ValueError, match="At least 2"):
+            RatioComparer().compare([])
+
+
+class TestRatioMetrics:
+    """Test that per-ratio metrics are computed correctly."""
+
+    def test_ratio_label(self):
+        d = _make_dataset(4, 2)
+        d2 = _make_dataset(2, 4)
+        report = RatioComparer().compare([d, d2])
+        assert report.ratios[0].ratio_label == "4:2"
+        assert report.ratios[0].num_prefill == 4
+        assert report.ratios[0].num_decode == 2
+
+    def test_request_count(self):
+        d1 = _make_dataset(2, 2, n=50)
+        d2 = _make_dataset(3, 1, n=75)
+        report = RatioComparer().compare([d1, d2])
+        assert report.ratios[0].request_count == 50
+        assert report.ratios[1].request_count == 75
+
+    def test_measured_qps(self):
+        d1 = _make_dataset(2, 2, qps=15.0)
+        d2 = _make_dataset(3, 1, qps=20.0)
+        report = RatioComparer().compare([d1, d2])
+        assert report.ratios[0].measured_qps == 15.0
+        assert report.ratios[1].measured_qps == 20.0
+
+    def test_percentile_ordering(self):
+        d1 = _make_dataset(2, 2)
+        d2 = _make_dataset(3, 1)
+        report = RatioComparer().compare([d1, d2])
+        for r in report.ratios:
+            assert r.ttft.p50 <= r.ttft.p95 <= r.ttft.p99
+            assert r.tpot.p50 <= r.tpot.p95 <= r.tpot.p99
+            assert r.total_latency.p50 <= r.total_latency.p95 <= r.total_latency.p99
+
+
+class TestBestRatioDetection:
+    """Test best ratio identification."""
+
+    def test_lower_latency_wins(self):
+        d1 = _make_dataset(3, 1, ttft_base=30.0, tpot_base=15.0, total_base=600.0)
+        d2 = _make_dataset(1, 3, ttft_base=20.0, tpot_base=10.0, total_base=400.0)
+        report = RatioComparer().compare([d1, d2])
+        # d2 has lower everything, should win all
+        for br in report.best_ratios:
+            assert br.ratio_label == "1:3"
+
+    def test_best_ratios_cover_all_combinations(self):
+        d1 = _make_dataset(2, 2)
+        d2 = _make_dataset(3, 1)
+        report = RatioComparer().compare([d1, d2])
+        # 3 metrics × 3 percentiles = 9
+        assert len(report.best_ratios) == 9
+        metrics = {(br.metric, br.percentile) for br in report.best_ratios}
+        for m in ("ttft", "tpot", "total_latency"):
+            for p in ("p50", "p95", "p99"):
+                assert (m, p) in metrics
+
+    def test_mixed_winners(self):
+        # d1 better TTFT, d2 better TPOT
+        d1 = _make_dataset(3, 1, ttft_base=10.0, tpot_base=20.0, total_base=500.0)
+        d2 = _make_dataset(1, 3, ttft_base=20.0, tpot_base=10.0, total_base=500.0)
+        report = RatioComparer().compare([d1, d2])
+        ttft_winners = {br.ratio_label for br in report.best_ratios if br.metric == "ttft"}
+        tpot_winners = {br.ratio_label for br in report.best_ratios if br.metric == "tpot"}
+        assert "3:1" in ttft_winners
+        assert "1:3" in tpot_winners
+
+
+class TestOverallBest:
+    """Test overall best ratio selection."""
+
+    def test_clear_winner(self):
+        d1 = _make_dataset(3, 1, ttft_base=30.0, tpot_base=30.0, total_base=600.0)
+        d2 = _make_dataset(1, 3, ttft_base=10.0, tpot_base=10.0, total_base=200.0)
+        report = RatioComparer().compare([d1, d2])
+        assert report.overall_best == "1:3"
+
+    def test_overall_best_is_string(self):
+        d1 = _make_dataset(2, 2)
+        d2 = _make_dataset(3, 1)
+        report = RatioComparer().compare([d1, d2])
+        assert isinstance(report.overall_best, str)
+        assert ":" in report.overall_best
+
+
+class TestProgrammaticAPI:
+    """Test the compare_ratios() convenience function."""
+
+    def test_basic(self):
+        d1 = _make_dataset(2, 2)
+        d2 = _make_dataset(3, 1)
+        report = compare_ratios([d1, d2])
+        assert isinstance(report, RatioComparison)
+        assert len(report.ratios) == 2
+
+    def test_raises_on_single(self):
+        with pytest.raises(ValueError):
+            compare_ratios([_make_dataset(2, 2)])
+
+
+class TestReportSerialization:
+    """Test that reports serialize correctly."""
+
+    def test_model_dump(self):
+        d1 = _make_dataset(2, 2)
+        d2 = _make_dataset(3, 1)
+        report = RatioComparer().compare([d1, d2])
+        dumped = report.model_dump()
+        assert isinstance(dumped, dict)
+        assert len(dumped["ratios"]) == 2
+        assert len(dumped["best_ratios"]) == 9
+        assert isinstance(dumped["overall_best"], str)
+
+    def test_model_dump_json(self):
+        d1 = _make_dataset(2, 2)
+        d2 = _make_dataset(3, 1)
+        report = RatioComparer().compare([d1, d2])
+        json_str = report.model_dump_json()
+        assert isinstance(json_str, str)
+        assert "ratio_label" in json_str
+
+
+class TestPercentileStats:
+    """Test PercentileStats model."""
+
+    def test_valid(self):
+        stats = PercentileStats(p50=10.0, p95=20.0, p99=30.0)
+        assert stats.p50 == 10.0
+
+    def test_serialization(self):
+        stats = PercentileStats(p50=10.0, p95=20.0, p99=30.0)
+        d = stats.model_dump()
+        assert d == {"p50": 10.0, "p95": 20.0, "p99": 30.0}


### PR DESCRIPTION
## Summary

Add `RatioComparer` class for comparing latency percentiles across different P:D ratio configurations side-by-side.

### Changes
- `ratio_compare.py`: `RatioComparer` class with `PercentileStats`, `RatioMetrics`, `BestRatio`, `RatioComparison` models
- CLI `ratio-compare` subcommand with `--benchmark` (multiple files), table + JSON output
- Best ratio identification per metric+percentile, overall best ratio by win count
- Programmatic `compare_ratios()` API
- 19 new tests

Closes #183