### PR TITLE
feat: M85 Benchmark Diff Report

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1124,3 +1124,19 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `weighted-goodput` subcommand with `--benchmark`, `--sla-*`, `--grace-factor`, `--aggregation`, table + JSON output
 - Programmatic `analyze_weighted_goodput()` API
 - 24 new tests (1887 total)
+
+### M85 ✅ Benchmark Diff Report
+
+*Completed — PR #TBD*
+
+- `DiffReporter` class in `diff_report.py`
+- `DiffReport`, `MetricDiff`, `LatencyDiffSection`, `DiffSummary`, `ChangeDirection` Pydantic models
+- Side-by-side latency percentile comparison (P50/P95/P99) for TTFT, TPOT, total_latency
+- QPS comparison with higher-is-better semantics
+- Token distribution comparison (mean prompt/output tokens)
+- Configurable regression threshold (default 5%)
+- Automatic verdict: BETTER, WORSE, MIXED, EQUIVALENT
+- Markdown report generation with tables and change icons
+- CLI `diff-report` subcommand with `--baseline`, `--target`, `--regression-threshold`, table + JSON + markdown output
+- Programmatic `generate_diff_report()` API
+- 25 new tests (1912 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -1018,3 +1018,23 @@ __all__ += [
     "RatioMetrics",
     "compare_ratios",
 ]
+
+from xpyd_plan.diff_report import (  # noqa: E402
+    ChangeDirection,
+    DiffReport,
+    DiffReporter,
+    DiffSummary,
+    LatencyDiffSection,
+    MetricDiff,
+    generate_diff_report,
+)
+
+__all__ += [
+    "ChangeDirection",
+    "DiffReport",
+    "DiffReporter",
+    "DiffSummary",
+    "LatencyDiffSection",
+    "MetricDiff",
+    "generate_diff_report",
+]

--- a/src/xpyd_plan/cli/_diff_report.py
+++ b/src/xpyd_plan/cli/_diff_report.py
@@ -1,0 +1,108 @@
+"""CLI subcommand for benchmark diff report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.diff_report import DiffReporter
+
+
+def _run(args: argparse.Namespace) -> None:
+    """Handle the 'diff-report' subcommand."""
+    console = Console()
+
+    baseline_data = load_benchmark_auto(args.baseline)
+    target_data = load_benchmark_auto(args.target)
+
+    reporter = DiffReporter(
+        regression_threshold_pct=args.regression_threshold,
+    )
+    report = reporter.compare(
+        baseline_data,
+        target_data,
+        baseline_name=args.baseline,
+        target_name=args.target,
+    )
+
+    if args.output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2, default=str)
+        sys.stdout.write("\n")
+    elif args.output_format == "markdown":
+        console.print(reporter.to_markdown(report))
+    else:
+        table = Table(title="Benchmark Diff Report")
+        table.add_column("Metric", style="cyan")
+        table.add_column("Baseline", justify="right")
+        table.add_column("Target", justify="right")
+        table.add_column("Delta", justify="right")
+        table.add_column("Status", justify="center")
+
+        qd = report.qps_diff
+        rel = (
+            f"{qd.relative_delta_pct:+.1f}%"
+            if qd.relative_delta_pct is not None
+            else "N/A"
+        )
+        table.add_row(
+            "QPS",
+            f"{qd.baseline_value:.2f}",
+            f"{qd.target_value:.2f}",
+            rel,
+            qd.direction.value,
+        )
+
+        for section in report.latency_diffs:
+            for label, diff in [
+                ("P50", section.p50),
+                ("P95", section.p95),
+                ("P99", section.p99),
+            ]:
+                rel = (
+                    f"{diff.relative_delta_pct:+.1f}%"
+                    if diff.relative_delta_pct is not None
+                    else "N/A"
+                )
+                table.add_row(
+                    f"{section.metric} {label}",
+                    f"{diff.baseline_value:.2f}",
+                    f"{diff.target_value:.2f}",
+                    rel,
+                    diff.direction.value,
+                )
+
+        console.print(table)
+        console.print(
+            f"\nVerdict: [bold]{report.summary.verdict}[/bold] — "
+            f"{report.summary.improvements} improved, "
+            f"{report.summary.regressions} regressed, "
+            f"{report.summary.unchanged} unchanged"
+        )
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register the diff-report subcommand."""
+    p = subparsers.add_parser(
+        "diff-report",
+        help="Comprehensive side-by-side benchmark diff report",
+    )
+    p.add_argument("--baseline", required=True, help="Baseline benchmark JSON file")
+    p.add_argument("--target", required=True, help="Target benchmark JSON file")
+    p.add_argument(
+        "--regression-threshold",
+        type=float,
+        default=5.0,
+        help="Regression threshold percentage (default: 5.0)",
+    )
+    p.add_argument(
+        "--output-format",
+        choices=["table", "json", "markdown"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    p.set_defaults(func=_run)

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -24,6 +24,7 @@ from xpyd_plan.cli._correlation import _cmd_correlation, add_correlation_parser
 from xpyd_plan.cli._dashboard import _cmd_dashboard
 from xpyd_plan.cli._decompose import _cmd_decompose, add_decompose_parser
 from xpyd_plan.cli._dedup import add_dedup_parser
+from xpyd_plan.cli._diff_report import register as _register_diff_report
 from xpyd_plan.cli._discover import _cmd_discover, add_discover_parser
 from xpyd_plan.cli._drift import _cmd_drift, add_drift_parser
 from xpyd_plan.cli._export import _cmd_export
@@ -915,6 +916,9 @@ def main(argv: list[str] | None = None) -> None:
 
     # --- weighted-goodput subcommand ---
     _register_weighted_goodput(subparsers)
+
+    # --- diff-report subcommand ---
+    _register_diff_report(subparsers)
 
     # --- fairness subcommand ---
     add_fairness_parser(subparsers)

--- a/src/xpyd_plan/diff_report.py
+++ b/src/xpyd_plan/diff_report.py
@@ -1,0 +1,370 @@
+"""Benchmark Diff Report — comprehensive side-by-side comparison of two benchmarks.
+
+Generates a structured diff report combining summary stats, latency percentiles,
+SLA compliance, throughput, and token distribution comparisons with
+regression/improvement annotations.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData
+
+
+class ChangeDirection(str, Enum):
+    """Direction of a metric change between baseline and target."""
+
+    IMPROVED = "IMPROVED"
+    REGRESSED = "REGRESSED"
+    UNCHANGED = "UNCHANGED"
+
+
+class MetricDiff(BaseModel):
+    """Diff for a single metric between baseline and target."""
+
+    metric_name: str = Field(..., description="Human-readable metric name")
+    baseline_value: float = Field(..., description="Value in baseline benchmark")
+    target_value: float = Field(..., description="Value in target benchmark")
+    absolute_delta: float = Field(..., description="target - baseline")
+    relative_delta_pct: Optional[float] = Field(
+        None, description="Percentage change (None if baseline is 0)"
+    )
+    direction: ChangeDirection = Field(
+        ..., description="Whether change is improvement, regression, or unchanged"
+    )
+
+
+class LatencyDiffSection(BaseModel):
+    """Latency percentile diffs for one latency metric (TTFT/TPOT/total)."""
+
+    metric: str = Field(..., description="Latency metric name")
+    p50: MetricDiff = Field(..., description="P50 diff")
+    p95: MetricDiff = Field(..., description="P95 diff")
+    p99: MetricDiff = Field(..., description="P99 diff")
+
+
+class DiffSummary(BaseModel):
+    """High-level summary of the diff."""
+
+    total_diffs: int = Field(..., ge=0, description="Total metrics compared")
+    improvements: int = Field(..., ge=0, description="Metrics that improved")
+    regressions: int = Field(..., ge=0, description="Metrics that regressed")
+    unchanged: int = Field(..., ge=0, description="Metrics unchanged")
+    verdict: str = Field(
+        ..., description="Overall verdict: BETTER, WORSE, MIXED, EQUIVALENT"
+    )
+
+
+class DiffReport(BaseModel):
+    """Complete benchmark diff report."""
+
+    baseline_file: str = Field(..., description="Baseline benchmark identifier")
+    target_file: str = Field(..., description="Target benchmark identifier")
+    baseline_requests: int = Field(..., ge=0, description="Request count in baseline")
+    target_requests: int = Field(..., ge=0, description="Request count in target")
+    baseline_qps: float = Field(..., ge=0, description="Baseline measured QPS")
+    target_qps: float = Field(..., ge=0, description="Target measured QPS")
+    qps_diff: MetricDiff = Field(..., description="QPS comparison")
+    latency_diffs: list[LatencyDiffSection] = Field(
+        ..., description="Per-metric latency diffs"
+    )
+    token_diffs: list[MetricDiff] = Field(
+        ..., description="Token distribution diffs"
+    )
+    summary: DiffSummary = Field(..., description="Overall diff summary")
+    regression_threshold_pct: float = Field(
+        ..., description="Threshold used for regression detection"
+    )
+
+
+class DiffReporter:
+    """Generate comprehensive diff reports between two benchmarks."""
+
+    def __init__(
+        self,
+        regression_threshold_pct: float = 5.0,
+    ) -> None:
+        """Initialize the reporter.
+
+        Args:
+            regression_threshold_pct: Percentage change threshold above which
+                a latency increase is classified as a regression (default 5%).
+        """
+        if regression_threshold_pct < 0:
+            raise ValueError("regression_threshold_pct must be >= 0")
+        self._threshold = regression_threshold_pct
+
+    def compare(
+        self,
+        baseline: BenchmarkData,
+        target: BenchmarkData,
+        baseline_name: str = "baseline",
+        target_name: str = "target",
+    ) -> DiffReport:
+        """Compare two benchmarks and produce a diff report.
+
+        Args:
+            baseline: The reference benchmark.
+            target: The benchmark to compare against baseline.
+            baseline_name: Label for baseline.
+            target_name: Label for target.
+
+        Returns:
+            A DiffReport with all comparisons.
+        """
+        b_reqs = baseline.requests
+        t_reqs = target.requests
+
+        # QPS diff (higher is better)
+        qps_diff = self._make_diff(
+            "measured_qps",
+            baseline.metadata.measured_qps,
+            target.metadata.measured_qps,
+            higher_is_better=True,
+        )
+
+        # Latency diffs (lower is better)
+        latency_diffs = []
+        for metric, field_p in [
+            ("TTFT", "ttft_ms"),
+            ("TPOT", "tpot_ms"),
+            ("Total Latency", "total_latency_ms"),
+        ]:
+            b_vals = np.array([getattr(r, field_p) for r in b_reqs])
+            t_vals = np.array([getattr(r, field_p) for r in t_reqs])
+
+            section = LatencyDiffSection(
+                metric=metric,
+                p50=self._make_diff(
+                    f"{metric} P50",
+                    float(np.percentile(b_vals, 50)),
+                    float(np.percentile(t_vals, 50)),
+                    higher_is_better=False,
+                ),
+                p95=self._make_diff(
+                    f"{metric} P95",
+                    float(np.percentile(b_vals, 95)),
+                    float(np.percentile(t_vals, 95)),
+                    higher_is_better=False,
+                ),
+                p99=self._make_diff(
+                    f"{metric} P99",
+                    float(np.percentile(b_vals, 99)),
+                    float(np.percentile(t_vals, 99)),
+                    higher_is_better=False,
+                ),
+            )
+            latency_diffs.append(section)
+
+        # Token distribution diffs (informational — no direction)
+        token_diffs = []
+        for label, field in [
+            ("Mean Prompt Tokens", "prompt_tokens"),
+            ("Mean Output Tokens", "output_tokens"),
+        ]:
+            b_mean = float(np.mean([getattr(r, field) for r in b_reqs]))
+            t_mean = float(np.mean([getattr(r, field) for r in t_reqs]))
+            token_diffs.append(
+                self._make_diff(label, b_mean, t_mean, higher_is_better=None)
+            )
+
+        # Aggregate summary
+        all_diffs: list[MetricDiff] = [qps_diff]
+        for section in latency_diffs:
+            all_diffs.extend([section.p50, section.p95, section.p99])
+        # Don't count token diffs in verdict — they're informational
+
+        improvements = sum(
+            1 for d in all_diffs if d.direction == ChangeDirection.IMPROVED
+        )
+        regressions = sum(
+            1 for d in all_diffs if d.direction == ChangeDirection.REGRESSED
+        )
+        unchanged = sum(
+            1 for d in all_diffs if d.direction == ChangeDirection.UNCHANGED
+        )
+        total = len(all_diffs)
+
+        if regressions == 0 and improvements > 0:
+            verdict = "BETTER"
+        elif improvements == 0 and regressions > 0:
+            verdict = "WORSE"
+        elif improvements == 0 and regressions == 0:
+            verdict = "EQUIVALENT"
+        else:
+            verdict = "MIXED"
+
+        return DiffReport(
+            baseline_file=baseline_name,
+            target_file=target_name,
+            baseline_requests=len(b_reqs),
+            target_requests=len(t_reqs),
+            baseline_qps=baseline.metadata.measured_qps,
+            target_qps=target.metadata.measured_qps,
+            qps_diff=qps_diff,
+            latency_diffs=latency_diffs,
+            token_diffs=token_diffs,
+            summary=DiffSummary(
+                total_diffs=total,
+                improvements=improvements,
+                regressions=regressions,
+                unchanged=unchanged,
+                verdict=verdict,
+            ),
+            regression_threshold_pct=self._threshold,
+        )
+
+    def to_markdown(self, report: DiffReport) -> str:
+        """Render a DiffReport as a Markdown string."""
+        lines: list[str] = []
+        lines.append(
+            f"# Benchmark Diff: {report.baseline_file} → {report.target_file}"
+        )
+        lines.append("")
+        lines.append(f"**Verdict: {report.summary.verdict}** "
+                      f"({report.summary.improvements} improved, "
+                      f"{report.summary.regressions} regressed, "
+                      f"{report.summary.unchanged} unchanged)")
+        lines.append("")
+
+        # Overview
+        lines.append("## Overview")
+        lines.append("")
+        lines.append("| | Baseline | Target | Delta |")
+        lines.append("|---|---|---|---|")
+        lines.append(
+            f"| Requests | {report.baseline_requests} "
+            f"| {report.target_requests} "
+            f"| {report.target_requests - report.baseline_requests:+d} |"
+        )
+        lines.append(self._md_diff_row("QPS", report.qps_diff))
+        lines.append("")
+
+        # Latency
+        lines.append("## Latency Comparison")
+        for section in report.latency_diffs:
+            lines.append("")
+            lines.append(f"### {section.metric}")
+            lines.append("")
+            lines.append("| Percentile | Baseline (ms) | Target (ms) | Delta | Change |")
+            lines.append("|---|---|---|---|---|")
+            for label, diff in [("P50", section.p50), ("P95", section.p95), ("P99", section.p99)]:
+                icon = self._direction_icon(diff.direction)
+                rel = (
+                    f"{diff.relative_delta_pct:+.1f}%"
+                    if diff.relative_delta_pct is not None
+                    else "N/A"
+                )
+                lines.append(
+                    f"| {label} | {diff.baseline_value:.2f} "
+                    f"| {diff.target_value:.2f} "
+                    f"| {rel} | {icon} {diff.direction.value} |"
+                )
+        lines.append("")
+
+        # Tokens
+        lines.append("## Token Distribution")
+        lines.append("")
+        lines.append("| Metric | Baseline | Target | Delta |")
+        lines.append("|---|---|---|---|")
+        for diff in report.token_diffs:
+            rel = (
+                f"{diff.relative_delta_pct:+.1f}%"
+                if diff.relative_delta_pct is not None
+                else "N/A"
+            )
+            lines.append(
+                f"| {diff.metric_name} | {diff.baseline_value:.1f} "
+                f"| {diff.target_value:.1f} | {rel} |"
+            )
+        lines.append("")
+
+        return "\n".join(lines)
+
+    def _make_diff(
+        self,
+        name: str,
+        baseline: float,
+        target: float,
+        higher_is_better: Optional[bool],
+    ) -> MetricDiff:
+        absolute = target - baseline
+        if baseline != 0:
+            relative = (absolute / abs(baseline)) * 100.0
+        else:
+            relative = None
+
+        if higher_is_better is None:
+            direction = ChangeDirection.UNCHANGED
+        elif relative is None:
+            direction = ChangeDirection.UNCHANGED
+        elif abs(relative) <= self._threshold:
+            direction = ChangeDirection.UNCHANGED
+        elif higher_is_better:
+            direction = (
+                ChangeDirection.IMPROVED if absolute > 0 else ChangeDirection.REGRESSED
+            )
+        else:
+            direction = (
+                ChangeDirection.IMPROVED if absolute < 0 else ChangeDirection.REGRESSED
+            )
+
+        return MetricDiff(
+            metric_name=name,
+            baseline_value=baseline,
+            target_value=target,
+            absolute_delta=absolute,
+            relative_delta_pct=relative,
+            direction=direction,
+        )
+
+    @staticmethod
+    def _direction_icon(direction: ChangeDirection) -> str:
+        return {
+            ChangeDirection.IMPROVED: "✅",
+            ChangeDirection.REGRESSED: "❌",
+            ChangeDirection.UNCHANGED: "➖",
+        }[direction]
+
+    @staticmethod
+    def _md_diff_row(label: str, diff: MetricDiff) -> str:
+        rel = (
+            f"{diff.relative_delta_pct:+.1f}%"
+            if diff.relative_delta_pct is not None
+            else "N/A"
+        )
+        icon = DiffReporter._direction_icon(diff.direction)
+        return (
+            f"| {label} | {diff.baseline_value:.2f} "
+            f"| {diff.target_value:.2f} "
+            f"| {rel} {icon} |"
+        )
+
+
+def generate_diff_report(
+    baseline: BenchmarkData,
+    target: BenchmarkData,
+    baseline_name: str = "baseline",
+    target_name: str = "target",
+    regression_threshold_pct: float = 5.0,
+) -> dict:
+    """Programmatic API for benchmark diff report.
+
+    Args:
+        baseline: Reference benchmark data.
+        target: Benchmark to compare against baseline.
+        baseline_name: Label for baseline.
+        target_name: Label for target.
+        regression_threshold_pct: Threshold for regression detection.
+
+    Returns:
+        Dictionary representation of DiffReport.
+    """
+    reporter = DiffReporter(regression_threshold_pct=regression_threshold_pct)
+    report = reporter.compare(baseline, target, baseline_name, target_name)
+    return report.model_dump()

--- a/tests/test_diff_report.py
+++ b/tests/test_diff_report.py
@@ -1,0 +1,329 @@
+"""Tests for benchmark diff report (M85)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from xpyd_plan.benchmark_models import (
+    BenchmarkData,
+    BenchmarkMetadata,
+    BenchmarkRequest,
+)
+from xpyd_plan.diff_report import (
+    ChangeDirection,
+    DiffReport,
+    DiffReporter,
+    DiffSummary,
+    generate_diff_report,
+)
+
+
+def _make_requests(
+    n: int = 100,
+    ttft_base: float = 50.0,
+    tpot_base: float = 20.0,
+    total_base: float = 200.0,
+    prompt_tokens: int = 100,
+    output_tokens: int = 50,
+    timestamp_start: float = 1000.0,
+) -> list[BenchmarkRequest]:
+    """Generate N benchmark requests with slight variation."""
+    import random
+
+    rng = random.Random(42)
+    reqs = []
+    for i in range(n):
+        reqs.append(
+            BenchmarkRequest(
+                request_id=f"req-{i}",
+                prompt_tokens=prompt_tokens + rng.randint(-10, 10),
+                output_tokens=output_tokens + rng.randint(-5, 5),
+                ttft_ms=ttft_base + rng.uniform(-5, 5),
+                tpot_ms=tpot_base + rng.uniform(-2, 2),
+                total_latency_ms=total_base + rng.uniform(-20, 20),
+                timestamp=timestamp_start + i * 0.1,
+            )
+        )
+    return reqs
+
+
+def _make_benchmark(
+    requests: list[BenchmarkRequest],
+    qps: float = 10.0,
+    prefill: int = 2,
+    decode: int = 6,
+) -> BenchmarkData:
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=prefill,
+            num_decode_instances=decode,
+            total_instances=prefill + decode,
+            measured_qps=qps,
+        ),
+        requests=requests,
+    )
+
+
+@pytest.fixture
+def baseline() -> BenchmarkData:
+    reqs = _make_requests(
+        n=100, ttft_base=50, tpot_base=20, total_base=200
+    )
+    return _make_benchmark(reqs, qps=10.0)
+
+
+@pytest.fixture
+def improved_target() -> BenchmarkData:
+    return _make_benchmark(
+        _make_requests(
+            n=100, ttft_base=40, tpot_base=15, total_base=160
+        ),
+        qps=12.0,
+    )
+
+
+@pytest.fixture
+def regressed_target() -> BenchmarkData:
+    return _make_benchmark(
+        _make_requests(
+            n=100, ttft_base=70, tpot_base=30, total_base=300
+        ),
+        qps=8.0,
+    )
+
+
+@pytest.fixture
+def equivalent_target() -> BenchmarkData:
+    return _make_benchmark(
+        _make_requests(
+            n=100, ttft_base=50.5, tpot_base=20.2, total_base=201
+        ),
+        qps=10.1,
+    )
+
+
+class TestDiffReporterInit:
+    def test_default_threshold(self):
+        reporter = DiffReporter()
+        assert reporter._threshold == 5.0
+
+    def test_custom_threshold(self):
+        reporter = DiffReporter(regression_threshold_pct=10.0)
+        assert reporter._threshold == 10.0
+
+    def test_negative_threshold_raises(self):
+        with pytest.raises(
+            ValueError, match="regression_threshold_pct must be >= 0"
+        ):
+            DiffReporter(regression_threshold_pct=-1.0)
+
+    def test_zero_threshold(self):
+        reporter = DiffReporter(regression_threshold_pct=0.0)
+        assert reporter._threshold == 0.0
+
+
+class TestDiffReporterCompare:
+    def test_report_structure(self, baseline):
+        reporter = DiffReporter()
+        report = reporter.compare(baseline, baseline, "b", "t")
+        assert isinstance(report, DiffReport)
+        assert report.baseline_file == "b"
+        assert report.target_file == "t"
+        assert len(report.latency_diffs) == 3
+        assert len(report.token_diffs) == 2
+        assert isinstance(report.summary, DiffSummary)
+
+    def test_improved_verdict(self, baseline, improved_target):
+        reporter = DiffReporter()
+        report = reporter.compare(baseline, improved_target)
+        assert report.summary.verdict == "BETTER"
+        assert report.summary.regressions == 0
+        assert report.summary.improvements > 0
+
+    def test_regressed_verdict(self, baseline, regressed_target):
+        reporter = DiffReporter()
+        report = reporter.compare(baseline, regressed_target)
+        assert report.summary.verdict == "WORSE"
+        assert report.summary.improvements == 0
+        assert report.summary.regressions > 0
+
+    def test_equivalent_verdict(self, baseline, equivalent_target):
+        reporter = DiffReporter()
+        report = reporter.compare(baseline, equivalent_target)
+        assert report.summary.verdict == "EQUIVALENT"
+
+    def test_mixed_verdict(self, baseline):
+        mixed_reqs = _make_requests(
+            n=100, ttft_base=60, tpot_base=25, total_base=250
+        )
+        mixed = _make_benchmark(mixed_reqs, qps=15.0)
+        reporter = DiffReporter()
+        report = reporter.compare(baseline, mixed)
+        assert report.summary.verdict == "MIXED"
+
+    def test_qps_higher_is_better(self, baseline):
+        better_qps = _make_benchmark(
+            _make_requests(
+                n=100, ttft_base=50, tpot_base=20, total_base=200
+            ),
+            qps=20.0,
+        )
+        reporter = DiffReporter()
+        report = reporter.compare(baseline, better_qps)
+        assert report.qps_diff.direction == ChangeDirection.IMPROVED
+
+    def test_qps_lower_is_regression(self, baseline):
+        worse_qps = _make_benchmark(
+            _make_requests(
+                n=100, ttft_base=50, tpot_base=20, total_base=200
+            ),
+            qps=5.0,
+        )
+        reporter = DiffReporter()
+        report = reporter.compare(baseline, worse_qps)
+        assert report.qps_diff.direction == ChangeDirection.REGRESSED
+
+    def test_latency_lower_is_better(self, baseline, improved_target):
+        reporter = DiffReporter()
+        report = reporter.compare(baseline, improved_target)
+        for section in report.latency_diffs:
+            assert section.p50.direction == ChangeDirection.IMPROVED
+            assert section.p95.direction == ChangeDirection.IMPROVED
+
+    def test_request_counts(self, baseline, improved_target):
+        reporter = DiffReporter()
+        report = reporter.compare(baseline, improved_target)
+        assert report.baseline_requests == 100
+        assert report.target_requests == 100
+
+
+class TestMetricDiff:
+    def test_relative_delta(self, baseline, improved_target):
+        reporter = DiffReporter()
+        report = reporter.compare(baseline, improved_target)
+        qd = report.qps_diff
+        assert qd.relative_delta_pct is not None
+        assert qd.absolute_delta == pytest.approx(2.0)
+
+    def test_zero_baseline_relative_is_none(self):
+        reporter = DiffReporter()
+        diff = reporter._make_diff(
+            "test", 0.0, 10.0, higher_is_better=True
+        )
+        assert diff.relative_delta_pct is None
+        assert diff.direction == ChangeDirection.UNCHANGED
+
+
+class TestToMarkdown:
+    def test_markdown_contains_sections(
+        self, baseline, improved_target
+    ):
+        reporter = DiffReporter()
+        report = reporter.compare(
+            baseline, improved_target, "a.json", "b.json"
+        )
+        md = reporter.to_markdown(report)
+        assert "# Benchmark Diff:" in md
+        assert "## Overview" in md
+        assert "## Latency Comparison" in md
+        assert "## Token Distribution" in md
+        assert "BETTER" in md
+
+    def test_markdown_has_tables(self, baseline, improved_target):
+        reporter = DiffReporter()
+        report = reporter.compare(baseline, improved_target)
+        md = reporter.to_markdown(report)
+        assert "|" in md
+        assert "P50" in md
+        assert "P95" in md
+        assert "P99" in md
+
+
+class TestProgrammaticAPI:
+    def test_returns_dict(self, baseline, improved_target):
+        result = generate_diff_report(baseline, improved_target)
+        assert isinstance(result, dict)
+        assert "summary" in result
+        assert result["summary"]["verdict"] == "BETTER"
+
+    def test_custom_names(self, baseline, improved_target):
+        result = generate_diff_report(
+            baseline,
+            improved_target,
+            baseline_name="run1",
+            target_name="run2",
+        )
+        assert result["baseline_file"] == "run1"
+        assert result["target_file"] == "run2"
+
+    def test_custom_threshold(self, baseline, equivalent_target):
+        result = generate_diff_report(
+            baseline,
+            equivalent_target,
+            regression_threshold_pct=0.01,
+        )
+        assert result["summary"]["verdict"] != "EQUIVALENT"
+
+
+class TestThresholdSensitivity:
+    def test_strict_detects_more(self, baseline, equivalent_target):
+        strict = DiffReporter(regression_threshold_pct=0.01)
+        lenient = DiffReporter(regression_threshold_pct=20.0)
+        r_strict = strict.compare(baseline, equivalent_target)
+        r_lenient = lenient.compare(baseline, equivalent_target)
+        assert (
+            r_strict.summary.unchanged
+            <= r_lenient.summary.unchanged
+        )
+
+    def test_zero_threshold(self, baseline):
+        same = _make_benchmark(
+            _make_requests(
+                n=100, ttft_base=50, tpot_base=20, total_base=200
+            ),
+            qps=10.0,
+        )
+        reporter = DiffReporter(regression_threshold_pct=0.0)
+        report = reporter.compare(baseline, same)
+        assert report.summary.verdict == "EQUIVALENT"
+
+
+class TestEdgeCases:
+    def test_single_request(self):
+        reqs = [
+            BenchmarkRequest(
+                request_id="r1",
+                prompt_tokens=100,
+                output_tokens=50,
+                ttft_ms=50.0,
+                tpot_ms=20.0,
+                total_latency_ms=200.0,
+                timestamp=1000.0,
+            )
+        ]
+        b = _make_benchmark(reqs, qps=1.0)
+        t = _make_benchmark(reqs, qps=1.0)
+        reporter = DiffReporter()
+        report = reporter.compare(b, t)
+        assert report.summary.verdict == "EQUIVALENT"
+
+    def test_different_request_counts(self, baseline):
+        small = _make_benchmark(
+            _make_requests(
+                n=10, ttft_base=50, tpot_base=20, total_base=200
+            ),
+            qps=10.0,
+        )
+        reporter = DiffReporter()
+        report = reporter.compare(baseline, small)
+        assert report.baseline_requests == 100
+        assert report.target_requests == 10
+
+    def test_report_serializable(self, baseline, improved_target):
+        reporter = DiffReporter()
+        report = reporter.compare(baseline, improved_target)
+        data = report.model_dump()
+        json_str = json.dumps(data, default=str)
+        assert json_str


### PR DESCRIPTION
## Summary

Comprehensive side-by-side benchmark diff report with regression/improvement annotations.

### Changes
- `DiffReporter` class in `diff_report.py`
- `DiffReport`, `MetricDiff`, `LatencyDiffSection`, `DiffSummary`, `ChangeDirection` Pydantic models
- Side-by-side latency percentile comparison (P50/P95/P99) for TTFT, TPOT, total_latency
- QPS comparison with higher-is-better semantics
- Token distribution comparison (mean prompt/output tokens)
- Configurable regression threshold (default 5%)
- Automatic verdict: BETTER, WORSE, MIXED, EQUIVALENT
- Markdown report generation with tables and change icons
- CLI `diff-report` subcommand with `--baseline`, `--target`, `--regression-threshold`, table + JSON + markdown output
- Programmatic `generate_diff_report()` API
- 25 new tests (1912 total)

Closes #189