### PR TITLE
feat: M87 Benchmark Coverage Score

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1157,3 +1157,17 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `error-budget` subcommand with `--benchmark`, `--slo-target`, `--sla-*`, `--window-size`, `--warning-burn-rate`, `--critical-burn-rate`, table + JSON output
 - Programmatic `analyze_error_budget()` API
 - 28 new tests
+
+### M87 ✅ Benchmark Coverage Score
+
+*Completed — PR #195*
+
+- `CoverageAnalyzer` class in `coverage.py`
+- `CoverageReport`, `CoverageMetrics`, `CoverageGrade`, `RatioGap` Pydantic models
+- Composite 0-100 coverage score: coverage fraction (40%), boundary (15%), balanced (15%), spread (20%), gap penalty (10%)
+- Gap analysis: identify unexplored P:D ratios sorted by distance to nearest benchmark
+- Spread score: assess evenness of benchmark distribution across ratio space
+- Actionable recommendations for next benchmarks to run
+- CLI `coverage` subcommand with `--benchmark` (multiple), table + JSON output
+- Programmatic `analyze_coverage()` API
+- 22 new tests (1962 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -1058,3 +1058,39 @@ __all__ += [
     "ErrorBudgetReport",
     "analyze_error_budget",
 ]
+
+from xpyd_plan.coverage import (  # noqa: E402
+    CoverageAnalyzer,
+    CoverageGrade,
+    CoverageMetrics,
+    CoverageReport,
+    RatioGap,
+    analyze_coverage,
+)
+
+__all__ += [
+    "CoverageAnalyzer",
+    "CoverageGrade",
+    "CoverageMetrics",
+    "CoverageReport",
+    "RatioGap",
+    "analyze_coverage",
+]
+
+from xpyd_plan.pd_imbalance import (  # noqa: E402
+    ImbalanceClassification,
+    ImbalanceLevel,
+    ImbalanceReport,
+    MetricSensitivity,
+    PDImbalanceDetector,
+    detect_pd_imbalance,
+)
+
+__all__ += [
+    "ImbalanceClassification",
+    "ImbalanceLevel",
+    "ImbalanceReport",
+    "MetricSensitivity",
+    "PDImbalanceDetector",
+    "detect_pd_imbalance",
+]

--- a/src/xpyd_plan/cli/_coverage.py
+++ b/src/xpyd_plan/cli/_coverage.py
@@ -1,0 +1,94 @@
+"""CLI subcommand for benchmark coverage analysis."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.coverage import CoverageAnalyzer
+
+
+def add_coverage_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Register the coverage subcommand."""
+    p = subparsers.add_parser(
+        "coverage",
+        help="Assess P:D ratio space exploration completeness",
+    )
+    p.add_argument(
+        "--benchmark",
+        nargs="+",
+        required=True,
+        help="Benchmark JSON files to analyze",
+    )
+    p.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+
+
+def _cmd_coverage(args: argparse.Namespace) -> None:
+    """Execute the coverage subcommand."""
+    datasets = []
+    for path in args.benchmark:
+        data = load_benchmark_auto(path)
+        datasets.append(data)
+
+    analyzer = CoverageAnalyzer(datasets)
+    report = analyzer.analyze()
+
+    if args.output_format == "json":
+        print(json.dumps(report.model_dump(), indent=2, default=str))
+        return
+
+    console = Console()
+
+    # Summary table
+    t = Table(title="Benchmark Coverage Report")
+    t.add_column("Metric", style="cyan")
+    t.add_column("Value", style="green")
+
+    m = report.metrics
+    t.add_row("Total instances", str(report.total_instances))
+    t.add_row("Possible ratios", str(m.total_possible_ratios))
+    t.add_row("Benchmarked ratios", str(m.benchmarked_ratios))
+    t.add_row("Coverage", f"{m.coverage_fraction:.1%}")
+    t.add_row("Boundaries covered", "✓" if m.has_boundaries else "✗")
+    t.add_row("Balanced covered", "✓" if m.has_balanced else "✗")
+    t.add_row("Max gap size", str(m.max_gap_size))
+    t.add_row("Spread score", f"{m.spread_score:.2f}")
+    t.add_row("Score", f"{report.score}/100")
+    t.add_row("Grade", report.grade.value)
+    console.print(t)
+
+    # Benchmarked ratios
+    if report.benchmarked:
+        bt = Table(title="Benchmarked Ratios")
+        bt.add_column("Prefill", style="cyan")
+        bt.add_column("Decode", style="cyan")
+        bt.add_column("Ratio", style="green")
+        for p, d in report.benchmarked:
+            bt.add_row(str(p), str(d), f"{p}P:{d}D")
+        console.print(bt)
+
+    # Top gaps
+    top_gaps = [g for g in report.gaps if g.priority in ("critical", "high")][:10]
+    if top_gaps:
+        gt = Table(title="Top Gaps (suggested next benchmarks)")
+        gt.add_column("Ratio", style="cyan")
+        gt.add_column("Distance", style="yellow")
+        gt.add_column("Priority", style="red")
+        for g in top_gaps:
+            gt.add_row(g.ratio_str, str(g.distance_to_nearest), g.priority)
+        console.print(gt)
+
+    # Recommendations
+    if report.recommendations:
+        console.print("\n[bold]Recommendations:[/bold]")
+        for rec in report.recommendations:
+            console.print(f"  • {rec}")

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -21,6 +21,7 @@ from xpyd_plan.cli._confidence import _cmd_confidence
 from xpyd_plan.cli._config import _add_config_flag, _apply_config_defaults, _cmd_config
 from xpyd_plan.cli._convergence import add_convergence_parser
 from xpyd_plan.cli._correlation import _cmd_correlation, add_correlation_parser
+from xpyd_plan.cli._coverage import add_coverage_parser
 from xpyd_plan.cli._dashboard import _cmd_dashboard
 from xpyd_plan.cli._decompose import _cmd_decompose, add_decompose_parser
 from xpyd_plan.cli._dedup import add_dedup_parser
@@ -972,6 +973,9 @@ def main(argv: list[str] | None = None) -> None:
     # --- plan-benchmarks subcommand ---
     add_plan_benchmarks_parser(subparsers)
 
+    # --- coverage subcommand ---
+    add_coverage_parser(subparsers)
+
     # --- threshold-advisor subcommand ---
     add_threshold_advisor_parser(subparsers)
 
@@ -1090,6 +1094,9 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_arrival_pattern(args)
     elif args.command == "plan-benchmarks":
         _cmd_plan_benchmarks(args)
+    elif args.command == "coverage":
+        from xpyd_plan.cli._coverage import _cmd_coverage
+        _cmd_coverage(args)
     elif args.command == "threshold-advisor":
         _cmd_threshold_advisor(args)
     elif args.command == "forecast":

--- a/src/xpyd_plan/coverage.py
+++ b/src/xpyd_plan/coverage.py
@@ -1,0 +1,275 @@
+"""Benchmark coverage score — assess P:D ratio space exploration completeness.
+
+Given multiple benchmark files, evaluate how well they cover the possible
+P:D ratio space, identify gaps, and recommend next benchmarks to run.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData
+
+
+class CoverageGrade(str, Enum):
+    """Letter grade for benchmark coverage quality."""
+
+    EXCELLENT = "A"
+    GOOD = "B"
+    FAIR = "C"
+    POOR = "D"
+    MINIMAL = "F"
+
+
+class RatioGap(BaseModel):
+    """An unexplored P:D ratio in the configuration space."""
+
+    num_prefill: int = Field(..., ge=1)
+    num_decode: int = Field(..., ge=1)
+    distance_to_nearest: int = Field(
+        ..., ge=1, description="Min distance to nearest benchmarked ratio"
+    )
+    priority: str = Field(..., description="Suggested benchmark priority")
+
+    @property
+    def ratio_str(self) -> str:
+        return f"{self.num_prefill}P:{self.num_decode}D"
+
+
+class CoverageMetrics(BaseModel):
+    """Quantitative coverage metrics."""
+
+    total_possible_ratios: int = Field(..., ge=1)
+    benchmarked_ratios: int = Field(..., ge=0)
+    coverage_fraction: float = Field(..., ge=0.0, le=1.0)
+    has_boundaries: bool = Field(..., description="Benchmarked extreme P-heavy and D-heavy ratios")
+    has_balanced: bool = Field(..., description="Benchmarked near-balanced ratio")
+    max_gap_size: int = Field(..., ge=0, description="Largest gap between consecutive benchmarked")
+    spread_score: float = Field(
+        ..., ge=0.0, le=1.0, description="How evenly benchmarks are spread"
+    )
+
+
+class CoverageReport(BaseModel):
+    """Full coverage analysis report."""
+
+    total_instances: int = Field(..., ge=2)
+    benchmarked: list[tuple[int, int]] = Field(..., description="(P, D) pairs benchmarked")
+    metrics: CoverageMetrics
+    score: float = Field(..., ge=0.0, le=100.0)
+    grade: CoverageGrade
+    gaps: list[RatioGap] = Field(..., description="Unexplored ratios, sorted by priority")
+    recommendations: list[str] = Field(..., description="Actionable suggestions")
+
+
+class CoverageAnalyzer:
+    """Analyze benchmark coverage of the P:D ratio space."""
+
+    def __init__(self, datasets: list[BenchmarkData]) -> None:
+        if not datasets:
+            raise ValueError("At least one benchmark dataset is required")
+        self._datasets = datasets
+        total_set = set()
+        for ds in datasets:
+            t = ds.metadata.num_prefill_instances + ds.metadata.num_decode_instances
+            total_set.add(t)
+        if len(total_set) != 1:
+            raise ValueError(
+                f"All benchmarks must have the same total instances, got {total_set}"
+            )
+        self._total = total_set.pop()
+
+    def analyze(self) -> CoverageReport:
+        """Run coverage analysis."""
+        benchmarked = sorted(
+            {
+                (ds.metadata.num_prefill_instances, ds.metadata.num_decode_instances)
+                for ds in self._datasets
+            }
+        )
+        all_ratios = [(p, self._total - p) for p in range(1, self._total)]
+        total_possible = len(all_ratios)
+        n_benchmarked = len(benchmarked)
+
+        # Boundary check
+        prefill_vals = [p for p, _ in benchmarked]
+        has_boundaries = (1 in prefill_vals) and (self._total - 1 in prefill_vals)
+
+        # Balanced check
+        mid = self._total / 2
+        has_balanced = any(abs(p - mid) <= 1 for p, _ in benchmarked)
+
+        # Gap analysis
+        benchmarked_p = sorted(p for p, _ in benchmarked)
+        max_gap = 0
+        if benchmarked_p:
+            # Gap from 1 to first benchmarked
+            max_gap = max(max_gap, benchmarked_p[0] - 1)
+            # Gap from last benchmarked to total-1
+            max_gap = max(max_gap, (self._total - 1) - benchmarked_p[-1])
+            for i in range(len(benchmarked_p) - 1):
+                gap = benchmarked_p[i + 1] - benchmarked_p[i] - 1
+                max_gap = max(max_gap, gap)
+
+        # Spread score: ideal is uniform spacing. Use 1 - normalized_std_of_gaps
+        spread_score = self._compute_spread_score(benchmarked_p)
+
+        coverage_fraction = n_benchmarked / total_possible if total_possible > 0 else 0.0
+
+        metrics = CoverageMetrics(
+            total_possible_ratios=total_possible,
+            benchmarked_ratios=n_benchmarked,
+            coverage_fraction=round(coverage_fraction, 4),
+            has_boundaries=has_boundaries,
+            has_balanced=has_balanced,
+            max_gap_size=max_gap,
+            spread_score=round(spread_score, 4),
+        )
+
+        # Score: weighted composite
+        score = self._compute_score(metrics)
+        grade = self._grade(score)
+
+        # Gaps
+        benchmarked_set = set(benchmarked)
+        gaps = self._find_gaps(all_ratios, benchmarked_set)
+
+        # Recommendations
+        recommendations = self._generate_recommendations(metrics, gaps)
+
+        return CoverageReport(
+            total_instances=self._total,
+            benchmarked=benchmarked,
+            metrics=metrics,
+            score=round(score, 1),
+            grade=grade,
+            gaps=gaps,
+            recommendations=recommendations,
+        )
+
+    def _compute_spread_score(self, benchmarked_p: list[int]) -> float:
+        """Compute how evenly benchmarks are spread across the ratio space."""
+        if len(benchmarked_p) <= 1:
+            return 0.0
+
+        gaps = []
+        gaps.append(benchmarked_p[0] - 1)
+        for i in range(len(benchmarked_p) - 1):
+            gaps.append(benchmarked_p[i + 1] - benchmarked_p[i] - 1)
+        gaps.append((self._total - 1) - benchmarked_p[-1])
+
+        if not gaps:
+            return 1.0
+
+        mean_gap = sum(gaps) / len(gaps)
+        if mean_gap == 0:
+            return 1.0
+
+        variance = sum((g - mean_gap) ** 2 for g in gaps) / len(gaps)
+        std = variance**0.5
+        cv = std / mean_gap if mean_gap > 0 else 0.0
+        # CV = 0 means perfectly even → score = 1.0; cap at CV=2
+        return max(0.0, 1.0 - cv / 2.0)
+
+    def _compute_score(self, m: CoverageMetrics) -> float:
+        """Compute composite 0-100 coverage score."""
+        # Coverage fraction: 40 points
+        cov_pts = min(m.coverage_fraction * 100, 100) * 0.4
+
+        # Boundary coverage: 15 points
+        boundary_pts = 15.0 if m.has_boundaries else 0.0
+
+        # Balanced coverage: 15 points
+        balanced_pts = 15.0 if m.has_balanced else 0.0
+
+        # Spread evenness: 20 points
+        spread_pts = m.spread_score * 20.0
+
+        # Gap penalty: up to 10 points off for large gaps
+        total_possible = m.total_possible_ratios
+        if total_possible > 0:
+            gap_ratio = m.max_gap_size / total_possible
+        else:
+            gap_ratio = 0.0
+        gap_pts = max(0.0, 10.0 * (1.0 - gap_ratio * 2))
+
+        return min(100.0, cov_pts + boundary_pts + balanced_pts + spread_pts + gap_pts)
+
+    def _grade(self, score: float) -> CoverageGrade:
+        if score >= 90:
+            return CoverageGrade.EXCELLENT
+        if score >= 75:
+            return CoverageGrade.GOOD
+        if score >= 60:
+            return CoverageGrade.FAIR
+        if score >= 40:
+            return CoverageGrade.POOR
+        return CoverageGrade.MINIMAL
+
+    def _find_gaps(
+        self,
+        all_ratios: list[tuple[int, int]],
+        benchmarked_set: set[tuple[int, int]],
+    ) -> list[RatioGap]:
+        """Find unexplored ratios and compute distance to nearest benchmarked."""
+        benchmarked_p = sorted(p for p, _ in benchmarked_set)
+        if not benchmarked_p:
+            return []
+
+        gaps: list[RatioGap] = []
+        for p, d in all_ratios:
+            if (p, d) in benchmarked_set:
+                continue
+            dist = min(abs(p - bp) for bp in benchmarked_p)
+            if dist >= 3:
+                priority = "critical"
+            elif dist >= 2:
+                priority = "high"
+            else:
+                priority = "medium"
+            gaps.append(
+                RatioGap(
+                    num_prefill=p,
+                    num_decode=d,
+                    distance_to_nearest=dist,
+                    priority=priority,
+                )
+            )
+
+        gaps.sort(key=lambda g: (-g.distance_to_nearest, g.num_prefill))
+        return gaps
+
+    def _generate_recommendations(
+        self, metrics: CoverageMetrics, gaps: list[RatioGap]
+    ) -> list[str]:
+        recs: list[str] = []
+        if not metrics.has_boundaries:
+            recs.append("Benchmark boundary ratios (1P:ND and NP:1D) to establish extremes")
+        if not metrics.has_balanced:
+            recs.append("Benchmark a balanced ratio near the midpoint")
+        if metrics.max_gap_size >= 3:
+            critical = [g for g in gaps if g.priority == "critical"]
+            if critical:
+                top = critical[0]
+                recs.append(
+                    f"Large gap detected — benchmark {top.ratio_str} to fill the largest hole"
+                )
+        if metrics.coverage_fraction < 0.3:
+            recs.append("Coverage below 30% — run more benchmark configurations")
+        if metrics.spread_score < 0.5:
+            recs.append("Benchmarks are clustered — spread them more evenly across ratios")
+        if not recs:
+            recs.append("Coverage is good — consider re-running benchmarks for reproducibility")
+        return recs
+
+
+def analyze_coverage(datasets: list[BenchmarkData]) -> dict:
+    """Programmatic API for benchmark coverage analysis.
+
+    Returns a dict with coverage report details.
+    """
+    analyzer = CoverageAnalyzer(datasets)
+    report = analyzer.analyze()
+    return report.model_dump()

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,272 @@
+"""Tests for benchmark coverage analysis."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.coverage import (
+    CoverageAnalyzer,
+    CoverageGrade,
+    CoverageReport,
+    analyze_coverage,
+)
+
+
+def _make_dataset(num_prefill: int, num_decode: int, n_requests: int = 10) -> BenchmarkData:
+    """Create a minimal benchmark dataset for testing."""
+    requests = [
+        BenchmarkRequest(
+            request_id=f"req-{i}",
+            prompt_tokens=100 + i,
+            output_tokens=50 + i,
+            ttft_ms=20.0 + i,
+            tpot_ms=10.0 + i,
+            total_latency_ms=100.0 + i * 5,
+            timestamp=1000.0 + i,
+        )
+        for i in range(n_requests)
+    ]
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=num_prefill,
+            num_decode_instances=num_decode,
+            total_instances=num_prefill + num_decode,
+            measured_qps=10.0,
+        ),
+        requests=requests,
+    )
+
+
+class TestCoverageAnalyzer:
+    """Tests for CoverageAnalyzer."""
+
+    def test_single_benchmark(self) -> None:
+        """Single benchmark should have low coverage."""
+        datasets = [_make_dataset(3, 3)]
+        analyzer = CoverageAnalyzer(datasets)
+        report = analyzer.analyze()
+
+        assert isinstance(report, CoverageReport)
+        assert report.total_instances == 6
+        assert report.metrics.benchmarked_ratios == 1
+        assert report.metrics.total_possible_ratios == 5  # 1P:5D through 5P:1D
+        assert report.metrics.coverage_fraction == pytest.approx(0.2)
+        assert len(report.gaps) == 4
+
+    def test_full_coverage(self) -> None:
+        """All ratios benchmarked should yield high score."""
+        datasets = [_make_dataset(p, 4 - p) for p in range(1, 4)]
+        analyzer = CoverageAnalyzer(datasets)
+        report = analyzer.analyze()
+
+        assert report.metrics.benchmarked_ratios == 3
+        assert report.metrics.coverage_fraction == 1.0
+        assert report.metrics.has_boundaries is True
+        assert report.metrics.has_balanced is True
+        assert report.metrics.max_gap_size == 0
+        assert report.score >= 90.0
+        assert report.grade == CoverageGrade.EXCELLENT
+        assert len(report.gaps) == 0
+
+    def test_boundary_ratios(self) -> None:
+        """Benchmarking extremes should set has_boundaries."""
+        datasets = [_make_dataset(1, 7), _make_dataset(7, 1)]
+        analyzer = CoverageAnalyzer(datasets)
+        report = analyzer.analyze()
+
+        assert report.metrics.has_boundaries is True
+        assert report.metrics.has_balanced is False
+
+    def test_balanced_ratio(self) -> None:
+        """Benchmarking near-midpoint should set has_balanced."""
+        datasets = [_make_dataset(4, 4)]
+        analyzer = CoverageAnalyzer(datasets)
+        report = analyzer.analyze()
+
+        assert report.metrics.has_balanced is True
+        assert report.metrics.has_boundaries is False
+
+    def test_balanced_detection_odd_total(self) -> None:
+        """Balanced detection works for odd total instances."""
+        datasets = [_make_dataset(3, 4)]  # total=7, mid=3.5
+        analyzer = CoverageAnalyzer(datasets)
+        report = analyzer.analyze()
+        assert report.metrics.has_balanced is True
+
+    def test_gap_detection(self) -> None:
+        """Gaps should be detected between benchmarked ratios."""
+        datasets = [_make_dataset(1, 9), _make_dataset(9, 1)]
+        analyzer = CoverageAnalyzer(datasets)
+        report = analyzer.analyze()
+
+        assert report.metrics.max_gap_size == 7  # gap from P=1 to P=9
+        critical_gaps = [g for g in report.gaps if g.priority == "critical"]
+        assert len(critical_gaps) > 0
+
+    def test_gap_distance(self) -> None:
+        """Gap distance_to_nearest should be correct."""
+        datasets = [_make_dataset(1, 5), _make_dataset(5, 1)]
+        analyzer = CoverageAnalyzer(datasets)
+        report = analyzer.analyze()
+
+        # P=3 is distance 2 from both P=1 and P=5
+        gap_3 = next(g for g in report.gaps if g.num_prefill == 3)
+        assert gap_3.distance_to_nearest == 2
+
+    def test_spread_score_even(self) -> None:
+        """Evenly spread benchmarks should have high spread score."""
+        # Benchmark P=1,3,5,7,9 — evenly spaced
+        datasets = [_make_dataset(p, 10 - p) for p in [1, 3, 5, 7, 9]]
+        analyzer = CoverageAnalyzer(datasets)
+        report = analyzer.analyze()
+
+        assert report.metrics.spread_score > 0.5
+
+    def test_spread_score_clustered(self) -> None:
+        """Clustered benchmarks should have low spread score."""
+        # Benchmark P=4,5,6 — clustered in middle
+        datasets = [_make_dataset(p, 10 - p) for p in [4, 5, 6]]
+        analyzer = CoverageAnalyzer(datasets)
+        report = analyzer.analyze()
+
+        assert report.metrics.spread_score < 0.6
+
+    def test_duplicate_benchmarks_deduplicated(self) -> None:
+        """Duplicate P:D ratios should be counted once."""
+        datasets = [_make_dataset(3, 3), _make_dataset(3, 3)]
+        analyzer = CoverageAnalyzer(datasets)
+        report = analyzer.analyze()
+
+        assert report.metrics.benchmarked_ratios == 1
+
+    def test_mismatched_total_instances_raises(self) -> None:
+        """Datasets with different total instances should raise."""
+        datasets = [_make_dataset(2, 2), _make_dataset(3, 3)]
+        with pytest.raises(ValueError, match="same total instances"):
+            CoverageAnalyzer(datasets)
+
+    def test_empty_datasets_raises(self) -> None:
+        """Empty dataset list should raise."""
+        with pytest.raises(ValueError, match="At least one"):
+            CoverageAnalyzer([])
+
+    def test_recommendations_missing_boundaries(self) -> None:
+        """Should recommend boundary benchmarks when missing."""
+        datasets = [_make_dataset(3, 3)]  # total=6, no boundaries
+        report = CoverageAnalyzer(datasets).analyze()
+
+        boundary_rec = [r for r in report.recommendations if "boundary" in r.lower()]
+        assert len(boundary_rec) > 0
+
+    def test_recommendations_missing_balanced(self) -> None:
+        """Should recommend balanced ratio when missing."""
+        datasets = [_make_dataset(1, 9)]  # total=10, no balanced
+        report = CoverageAnalyzer(datasets).analyze()
+
+        balanced_rec = [r for r in report.recommendations if "balanced" in r.lower()]
+        assert len(balanced_rec) > 0
+
+    def test_score_range(self) -> None:
+        """Score should be between 0 and 100."""
+        datasets = [_make_dataset(1, 5)]
+        report = CoverageAnalyzer(datasets).analyze()
+        assert 0.0 <= report.score <= 100.0
+
+    def test_grade_assignment(self) -> None:
+        """Grade should correspond to score ranges."""
+        # Full coverage
+        datasets = [_make_dataset(p, 4 - p) for p in range(1, 4)]
+        report = CoverageAnalyzer(datasets).analyze()
+        assert report.grade in (CoverageGrade.EXCELLENT, CoverageGrade.GOOD)
+
+    def test_gaps_sorted_by_distance(self) -> None:
+        """Gaps should be sorted by distance descending."""
+        datasets = [_make_dataset(1, 9), _make_dataset(9, 1)]
+        report = CoverageAnalyzer(datasets).analyze()
+
+        distances = [g.distance_to_nearest for g in report.gaps]
+        assert distances == sorted(distances, reverse=True)
+
+    def test_good_coverage_no_critical_recs(self) -> None:
+        """Full coverage should produce benign recommendations."""
+        datasets = [_make_dataset(p, 4 - p) for p in range(1, 4)]
+        report = CoverageAnalyzer(datasets).analyze()
+
+        # Should not recommend boundaries or balanced (already have them)
+        assert not any("boundary" in r.lower() for r in report.recommendations)
+        assert not any("balanced" in r.lower() for r in report.recommendations)
+
+
+class TestAnalyzeCoverageAPI:
+    """Tests for the programmatic API."""
+
+    def test_returns_dict(self) -> None:
+        """analyze_coverage should return a dict."""
+        datasets = [_make_dataset(2, 2)]
+        result = analyze_coverage(datasets)
+        assert isinstance(result, dict)
+        assert "score" in result
+        assert "grade" in result
+        assert "metrics" in result
+        assert "gaps" in result
+
+    def test_dict_values(self) -> None:
+        """Dict values should be correct types."""
+        datasets = [_make_dataset(p, 4 - p) for p in range(1, 4)]
+        result = analyze_coverage(datasets)
+        assert result["metrics"]["coverage_fraction"] == 1.0
+        assert result["metrics"]["benchmarked_ratios"] == 3
+
+
+class TestCoverageCLI:
+    """Test CLI integration for coverage subcommand."""
+
+    def test_cli_json_output(self) -> None:
+        """CLI should produce valid JSON output."""
+        from unittest.mock import MagicMock
+
+        from xpyd_plan.cli._coverage import _cmd_coverage
+
+        data = _make_dataset(3, 3)
+        with tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False) as f:
+            json.dump(data.model_dump(), f, default=str)
+            f.flush()
+
+            args = MagicMock()
+            args.benchmark = [f.name]
+            args.output_format = "json"
+
+            import io
+            import sys
+
+            captured = io.StringIO()
+            old_stdout = sys.stdout
+            sys.stdout = captured
+            try:
+                _cmd_coverage(args)
+            finally:
+                sys.stdout = old_stdout
+
+            output = json.loads(captured.getvalue())
+            assert "score" in output
+            assert "grade" in output
+
+    def test_cli_table_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """CLI table output should not raise."""
+        from unittest.mock import MagicMock
+
+        from xpyd_plan.cli._coverage import _cmd_coverage
+
+        data = _make_dataset(3, 3)
+        with tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False) as f:
+            json.dump(data.model_dump(), f, default=str)
+            f.flush()
+
+            args = MagicMock()
+            args.benchmark = [f.name]
+            args.output_format = "table"
+            _cmd_coverage(args)


### PR DESCRIPTION
## Summary

Add benchmark coverage score analysis — assess how well existing benchmarks explore the P:D ratio space and identify information gaps.

Closes #194

## Changes

- `CoverageAnalyzer` class in `coverage.py`
- `CoverageReport`, `CoverageMetrics`, `CoverageGrade`, `RatioGap` Pydantic models
- Composite 0-100 score combining:
  - Coverage fraction (40%): percentage of possible ratios benchmarked
  - Boundary coverage (15%): extreme ratios benchmarked
  - Balanced coverage (15%): near-midpoint ratio benchmarked
  - Spread score (20%): evenness of benchmark distribution
  - Gap penalty (10%): penalty for large unexplored regions
- Gap analysis: unexplored ratios sorted by distance to nearest benchmark
- Actionable recommendations for next benchmarks to run
- CLI `coverage` subcommand with `--benchmark` (multiple files), table + JSON output
- Programmatic `analyze_coverage()` API
- 22 new tests (all passing)
- Full test suite: 1962 tests passing

## Design Alignment

Follows the 'User-Friendly' design principle: helps users understand which configurations still need benchmarking, minimizing wasted benchmark runs.