### PR TITLE
feat: M91 — Retry Policy Optimizer

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1215,3 +1215,17 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `retry-sim` subcommand with `--benchmark`, `--max-retries`, `--retry-threshold-ttft`, `--retry-threshold-tpot`, `--retry-threshold-total`, `--backoff-ms`, `--backoff-type`, table + JSON output
 - Programmatic `simulate_retries()` API
 - 21 new tests (1995 total)
+
+### M91 ✅ Retry Policy Optimizer
+
+*Completed — PR #TBD*
+
+- `RetryOptimizer` class in `retry_optimizer.py`
+- `RetryOptimizerConfig`, `OptimalRetryPolicy`, `RetryOptimizerReport`, `PolicyCandidate` Pydantic models
+- Grid search over retry parameters: max_retries, threshold percentiles, backoff strategies, backoff delays
+- Objective: maximize effective goodput subject to max amplification factor constraint (default 2.0x)
+- Pareto frontier of goodput vs amplification tradeoffs
+- Uses `RetrySimulator` internally for each candidate evaluation
+- CLI `retry-optimize` subcommand with `--benchmark`, `--max-amplification`, `--sla-ttft`, `--sla-tpot`, `--sla-total`, table + JSON output
+- Programmatic `optimize_retry_policy()` API
+- 20 new tests (2015 total)

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -1106,3 +1106,21 @@ __all__ += [
     "RetrySimulator",
     "simulate_retries",
 ]
+
+from xpyd_plan.retry_optimizer import (  # noqa: E402
+    OptimalRetryPolicy,
+    PolicyCandidate,
+    RetryOptimizer,
+    RetryOptimizerConfig,
+    RetryOptimizerReport,
+    optimize_retry_policy,
+)
+
+__all__ += [
+    "OptimalRetryPolicy",
+    "PolicyCandidate",
+    "RetryOptimizer",
+    "RetryOptimizerConfig",
+    "RetryOptimizerReport",
+    "optimize_retry_policy",
+]

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -57,6 +57,7 @@ from xpyd_plan.cli._recommend import _cmd_recommend
 from xpyd_plan.cli._regression import _cmd_regression, add_regression_parser
 from xpyd_plan.cli._replay import add_replay_parser
 from xpyd_plan.cli._reproducibility import _cmd_reproducibility, add_reproducibility_parser
+from xpyd_plan.cli._retry_optimize import add_retry_optimize_parser
 from xpyd_plan.cli._retry_sim import add_retry_sim_parser
 from xpyd_plan.cli._roi import add_roi_parser
 from xpyd_plan.cli._root_cause import _cmd_root_cause, add_root_cause_parser
@@ -944,6 +945,7 @@ def main(argv: list[str] | None = None) -> None:
     add_sample_parser(subparsers)
     add_size_distribution_parser(subparsers)
     add_token_budget_parser(subparsers)
+    add_retry_optimize_parser(subparsers)
     add_retry_sim_parser(subparsers)
     add_token_efficiency_parser(subparsers)
     add_timeline_parser(subparsers)

--- a/src/xpyd_plan/cli/_retry_optimize.py
+++ b/src/xpyd_plan/cli/_retry_optimize.py
@@ -1,0 +1,112 @@
+"""CLI retry-optimize command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.retry_optimizer import RetryOptimizer, RetryOptimizerConfig
+
+
+def _cmd_retry_optimize(args: argparse.Namespace) -> None:
+    """Handle the 'retry-optimize' subcommand."""
+    console = Console()
+
+    data = load_benchmark_auto(args.benchmark)
+    config = RetryOptimizerConfig(
+        max_amplification=args.max_amplification,
+        sla_ttft_ms=args.sla_ttft,
+        sla_tpot_ms=args.sla_tpot,
+        sla_total_ms=args.sla_total,
+    )
+    optimizer = RetryOptimizer(config)
+    report = optimizer.optimize(data)
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Summary
+    table = Table(title="Retry Policy Optimization")
+    table.add_column("Metric", justify="left")
+    table.add_column("Value", justify="right")
+    table.add_row("Candidates Evaluated", str(report.candidates_evaluated))
+    table.add_row("Within Budget", str(report.candidates_within_budget))
+    table.add_row("Pareto-Optimal", str(len(report.pareto_frontier)))
+    console.print(table)
+
+    # Best policy
+    if report.best_policy:
+        bp = report.best_policy
+        bc = bp.config
+        best_table = Table(title="Best Policy")
+        best_table.add_column("Parameter", justify="left")
+        best_table.add_column("Value", justify="right")
+        best_table.add_row("Max Retries", str(bc.max_retries))
+        best_table.add_row("Backoff", f"{bc.backoff_ms:.0f}ms ({bc.backoff_type.value})")
+        if bc.retry_threshold_ttft_ms is not None:
+            best_table.add_row("TTFT Threshold", f"{bc.retry_threshold_ttft_ms:.1f}ms")
+        if bc.retry_threshold_tpot_ms is not None:
+            best_table.add_row("TPOT Threshold", f"{bc.retry_threshold_tpot_ms:.1f}ms")
+        if bc.retry_threshold_total_ms is not None:
+            best_table.add_row("Total Threshold", f"{bc.retry_threshold_total_ms:.1f}ms")
+        best_table.add_row("Effective Goodput", f"{bp.effective_goodput:.1%}")
+        best_table.add_row("Improvement", f"+{bp.goodput_improvement:.1%}")
+        best_table.add_row("Amplification", f"{bp.amplification_factor:.2f}x")
+        console.print()
+        console.print(best_table)
+
+    # Pareto frontier
+    if report.pareto_frontier:
+        pareto_table = Table(title="Pareto Frontier")
+        pareto_table.add_column("Max Retries", justify="right")
+        pareto_table.add_column("Backoff", justify="left")
+        pareto_table.add_column("Goodput", justify="right")
+        pareto_table.add_column("Improvement", justify="right")
+        pareto_table.add_column("Amplification", justify="right")
+        pareto_table.add_column("Within Budget", justify="center")
+        for c in report.pareto_frontier:
+            pareto_table.add_row(
+                str(c.config.max_retries),
+                f"{c.config.backoff_ms:.0f}ms ({c.config.backoff_type.value})",
+                f"{c.effective_goodput:.1%}",
+                f"+{c.goodput_improvement:.1%}",
+                f"{c.amplification_factor:.2f}x",
+                "✓" if c.within_budget else "✗",
+            )
+        console.print()
+        console.print(pareto_table)
+
+    console.print()
+    console.print(f"[bold]{report.recommendation}[/bold]")
+
+
+def add_retry_optimize_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the retry-optimize subcommand parser."""
+    parser = subparsers.add_parser(
+        "retry-optimize",
+        help="Find optimal retry policy for benchmark data",
+    )
+    parser.add_argument("--benchmark", required=True, help="Benchmark JSON file")
+    parser.add_argument(
+        "--max-amplification", type=float, default=2.0,
+        help="Maximum allowed load amplification factor (default: 2.0)",
+    )
+    parser.add_argument("--sla-ttft", type=float, default=None, help="SLA TTFT threshold (ms)")
+    parser.add_argument("--sla-tpot", type=float, default=None, help="SLA TPOT threshold (ms)")
+    parser.add_argument(
+        "--sla-total", type=float, default=None,
+        help="SLA total latency threshold (ms)",
+    )
+    parser.add_argument(
+        "--output-format", choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_retry_optimize)

--- a/src/xpyd_plan/retry_optimizer.py
+++ b/src/xpyd_plan/retry_optimizer.py
@@ -1,0 +1,300 @@
+"""Retry policy optimizer.
+
+Sweeps retry parameters (max retries, thresholds, backoff strategies)
+to find the configuration that maximizes effective goodput while keeping
+load amplification within a specified budget.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData
+from .retry_sim import BackoffType, RetryConfig, RetrySimulator
+
+
+class RetryOptimizerConfig(BaseModel):
+    """Configuration for retry policy optimization."""
+
+    max_amplification: float = Field(
+        2.0, gt=1.0, description="Maximum allowed load amplification factor"
+    )
+    max_retries_range: list[int] = Field(
+        default_factory=lambda: [1, 2, 3, 5],
+        description="Max retries values to search",
+    )
+    threshold_percentiles: list[float] = Field(
+        default_factory=lambda: [90.0, 95.0, 99.0],
+        description="Percentiles of latency distributions to use as retry thresholds",
+    )
+    backoff_types: list[BackoffType] = Field(
+        default_factory=lambda: [BackoffType.CONSTANT, BackoffType.EXPONENTIAL],
+        description="Backoff strategies to evaluate",
+    )
+    backoff_ms_values: list[float] = Field(
+        default_factory=lambda: [50.0, 100.0, 200.0],
+        description="Backoff base delay values to search (ms)",
+    )
+    sla_ttft_ms: float | None = Field(None, ge=0, description="SLA TTFT threshold (ms)")
+    sla_tpot_ms: float | None = Field(None, ge=0, description="SLA TPOT threshold (ms)")
+    sla_total_ms: float | None = Field(None, ge=0, description="SLA total latency threshold (ms)")
+
+
+class PolicyCandidate(BaseModel):
+    """A single retry policy candidate with measured outcomes."""
+
+    config: RetryConfig
+    effective_goodput: float = Field(..., ge=0, le=1)
+    original_goodput: float = Field(..., ge=0, le=1)
+    goodput_improvement: float = Field(..., description="Effective - original goodput")
+    amplification_factor: float = Field(..., ge=1.0)
+    retry_rate: float = Field(..., ge=0, le=1)
+    within_budget: bool = Field(..., description="Whether amplification is within budget")
+
+
+class OptimalRetryPolicy(BaseModel):
+    """The recommended optimal retry policy."""
+
+    config: RetryConfig
+    effective_goodput: float = Field(..., ge=0, le=1)
+    goodput_improvement: float
+    amplification_factor: float = Field(..., ge=1.0)
+
+
+class RetryOptimizerReport(BaseModel):
+    """Complete retry optimization report."""
+
+    optimizer_config: RetryOptimizerConfig
+    candidates_evaluated: int = Field(..., ge=0)
+    candidates_within_budget: int = Field(..., ge=0)
+    best_policy: OptimalRetryPolicy | None = Field(
+        None, description="Best policy within amplification budget (None if none qualify)"
+    )
+    pareto_frontier: list[PolicyCandidate] = Field(
+        default_factory=list,
+        description="Pareto-optimal candidates (goodput vs amplification tradeoff)",
+    )
+    all_candidates: list[PolicyCandidate] = Field(default_factory=list)
+    recommendation: str
+
+
+class RetryOptimizer:
+    """Find optimal retry policy via grid search over parameters."""
+
+    def __init__(self, config: RetryOptimizerConfig) -> None:
+        if (
+            config.sla_ttft_ms is None
+            and config.sla_tpot_ms is None
+            and config.sla_total_ms is None
+        ):
+            raise ValueError(
+                "At least one SLA threshold must be specified "
+                "(sla_ttft_ms, sla_tpot_ms, or sla_total_ms)"
+            )
+        self._config = config
+
+    def optimize(self, data: BenchmarkData) -> RetryOptimizerReport:
+        """Run grid search and return optimization report."""
+        import numpy as np
+
+        cfg = self._config
+        requests = data.requests
+
+        if len(requests) == 0:
+            return RetryOptimizerReport(
+                optimizer_config=cfg,
+                candidates_evaluated=0,
+                candidates_within_budget=0,
+                best_policy=None,
+                pareto_frontier=[],
+                all_candidates=[],
+                recommendation="No requests to analyze.",
+            )
+
+        # Compute latency percentiles for threshold generation
+        ttft_vals = np.array([r.ttft_ms for r in requests])
+        tpot_vals = np.array([r.tpot_ms for r in requests])
+        total_vals = np.array([r.total_latency_ms for r in requests])
+
+        ttft_thresholds: list[float | None] = [None]
+        tpot_thresholds: list[float | None] = [None]
+        total_thresholds: list[float | None] = [None]
+
+        if cfg.sla_ttft_ms is not None:
+            ttft_thresholds = [
+                float(np.percentile(ttft_vals, p)) for p in cfg.threshold_percentiles
+            ]
+        if cfg.sla_tpot_ms is not None:
+            tpot_thresholds = [
+                float(np.percentile(tpot_vals, p)) for p in cfg.threshold_percentiles
+            ]
+        if cfg.sla_total_ms is not None:
+            total_thresholds = [
+                float(np.percentile(total_vals, p)) for p in cfg.threshold_percentiles
+            ]
+
+        candidates: list[PolicyCandidate] = []
+
+        for max_retries in cfg.max_retries_range:
+            for backoff_type in cfg.backoff_types:
+                for backoff_ms in cfg.backoff_ms_values:
+                    for ttft_th in ttft_thresholds:
+                        for tpot_th in tpot_thresholds:
+                            for total_th in total_thresholds:
+                                # Skip if no threshold set
+                                if (
+                                    ttft_th is None
+                                    and tpot_th is None
+                                    and total_th is None
+                                ):
+                                    continue
+
+                                retry_cfg = RetryConfig(
+                                    max_retries=max_retries,
+                                    retry_threshold_ttft_ms=ttft_th,
+                                    retry_threshold_tpot_ms=tpot_th,
+                                    retry_threshold_total_ms=total_th,
+                                    backoff_ms=backoff_ms,
+                                    backoff_type=backoff_type,
+                                )
+
+                                try:
+                                    simulator = RetrySimulator(retry_cfg)
+                                    report = simulator.simulate(data)
+                                except (ValueError, Exception):
+                                    continue
+
+                                la = report.load_amplification
+                                within = la.amplification_factor <= cfg.max_amplification
+
+                                candidates.append(PolicyCandidate(
+                                    config=retry_cfg,
+                                    effective_goodput=report.effective_goodput,
+                                    original_goodput=report.original_goodput,
+                                    goodput_improvement=(
+                                        report.effective_goodput - report.original_goodput
+                                    ),
+                                    amplification_factor=la.amplification_factor,
+                                    retry_rate=la.retry_rate,
+                                    within_budget=within,
+                                ))
+
+        within_budget = [c for c in candidates if c.within_budget]
+
+        # Best policy: highest effective goodput within budget
+        best: OptimalRetryPolicy | None = None
+        if within_budget:
+            best_candidate = max(
+                within_budget,
+                key=lambda c: (c.effective_goodput, -c.amplification_factor),
+            )
+            best = OptimalRetryPolicy(
+                config=best_candidate.config,
+                effective_goodput=best_candidate.effective_goodput,
+                goodput_improvement=best_candidate.goodput_improvement,
+                amplification_factor=best_candidate.amplification_factor,
+            )
+
+        # Pareto frontier: non-dominated in (goodput↑, amplification↓)
+        pareto = _compute_pareto(candidates)
+
+        # Recommendation
+        if not candidates:
+            rec = "No valid retry configurations found."
+        elif best is None:
+            rec = (
+                f"No retry policy achieves goodput improvement within "
+                f"{cfg.max_amplification:.1f}x amplification budget. "
+                f"Consider increasing the budget or improving baseline performance."
+            )
+        elif best.goodput_improvement < 0.01:
+            rec = (
+                f"Best policy provides minimal goodput improvement "
+                f"(+{best.goodput_improvement:.1%}). "
+                f"Retries may not be worthwhile for this workload."
+            )
+        else:
+            bc = best.config
+            rec = (
+                f"Recommended: max_retries={bc.max_retries}, "
+                f"backoff={bc.backoff_ms:.0f}ms ({bc.backoff_type.value}). "
+                f"Achieves {best.effective_goodput:.1%} goodput "
+                f"(+{best.goodput_improvement:.1%}) at "
+                f"{best.amplification_factor:.2f}x amplification."
+            )
+
+        return RetryOptimizerReport(
+            optimizer_config=cfg,
+            candidates_evaluated=len(candidates),
+            candidates_within_budget=len(within_budget),
+            best_policy=best,
+            pareto_frontier=pareto,
+            all_candidates=candidates,
+            recommendation=rec,
+        )
+
+
+def _compute_pareto(candidates: list[PolicyCandidate]) -> list[PolicyCandidate]:
+    """Find Pareto-optimal candidates (maximize goodput, minimize amplification)."""
+    if not candidates:
+        return []
+
+    pareto: list[PolicyCandidate] = []
+    for c in candidates:
+        dominated = False
+        for other in candidates:
+            if (
+                other.effective_goodput >= c.effective_goodput
+                and other.amplification_factor <= c.amplification_factor
+                and (
+                    other.effective_goodput > c.effective_goodput
+                    or other.amplification_factor < c.amplification_factor
+                )
+            ):
+                dominated = True
+                break
+        if not dominated:
+            pareto.append(c)
+
+    # Sort by amplification ascending
+    pareto.sort(key=lambda c: c.amplification_factor)
+    return pareto
+
+
+def optimize_retry_policy(
+    benchmark_path: str,
+    max_amplification: float = 2.0,
+    sla_ttft_ms: float | None = None,
+    sla_tpot_ms: float | None = None,
+    sla_total_ms: float | None = None,
+    max_retries_range: list[int] | None = None,
+) -> dict:
+    """Programmatic API for retry policy optimization.
+
+    Args:
+        benchmark_path: Path to benchmark JSON file.
+        max_amplification: Maximum allowed load amplification factor.
+        sla_ttft_ms: SLA TTFT threshold (ms).
+        sla_tpot_ms: SLA TPOT threshold (ms).
+        sla_total_ms: SLA total latency threshold (ms).
+        max_retries_range: List of max_retries values to search.
+
+    Returns:
+        dict: RetryOptimizerReport as a dictionary.
+    """
+    from .bench_adapter import load_benchmark_auto
+
+    data = load_benchmark_auto(benchmark_path)
+    kwargs: dict = {
+        "max_amplification": max_amplification,
+        "sla_ttft_ms": sla_ttft_ms,
+        "sla_tpot_ms": sla_tpot_ms,
+        "sla_total_ms": sla_total_ms,
+    }
+    if max_retries_range is not None:
+        kwargs["max_retries_range"] = max_retries_range
+
+    config = RetryOptimizerConfig(**kwargs)
+    optimizer = RetryOptimizer(config)
+    report = optimizer.optimize(data)
+    return report.model_dump()

--- a/tests/test_retry_optimizer.py
+++ b/tests/test_retry_optimizer.py
@@ -1,0 +1,310 @@
+"""Tests for retry policy optimizer."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.retry_optimizer import (
+    PolicyCandidate,
+    RetryOptimizer,
+    RetryOptimizerConfig,
+    _compute_pareto,
+    optimize_retry_policy,
+)
+from xpyd_plan.retry_sim import RetryConfig
+
+
+def _make_request(
+    request_id: str = "r1",
+    prompt_tokens: int = 100,
+    output_tokens: int = 50,
+    ttft_ms: float = 50.0,
+    tpot_ms: float = 20.0,
+    total_latency_ms: float = 200.0,
+    timestamp: float = 1000.0,
+) -> BenchmarkRequest:
+    return BenchmarkRequest(
+        request_id=request_id,
+        prompt_tokens=prompt_tokens,
+        output_tokens=output_tokens,
+        ttft_ms=ttft_ms,
+        tpot_ms=tpot_ms,
+        total_latency_ms=total_latency_ms,
+        timestamp=timestamp,
+    )
+
+
+def _make_data(requests: list[BenchmarkRequest], qps: float = 10.0) -> BenchmarkData:
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=4,
+            total_instances=6,
+            measured_qps=qps,
+        ),
+        requests=requests,
+    )
+
+
+class TestRetryOptimizerInit:
+    def test_no_sla_raises(self):
+        with pytest.raises(ValueError, match="At least one SLA threshold"):
+            RetryOptimizer(RetryOptimizerConfig(
+                sla_ttft_ms=None, sla_tpot_ms=None, sla_total_ms=None,
+            ))
+
+    def test_valid_config(self):
+        opt = RetryOptimizer(RetryOptimizerConfig(sla_total_ms=300.0))
+        assert opt is not None
+
+
+class TestRetryOptimizerOptimize:
+    def test_single_request_passing(self):
+        requests = [_make_request(total_latency_ms=50.0)]
+        opt = RetryOptimizer(RetryOptimizerConfig(sla_total_ms=300.0))
+        report = opt.optimize(_make_data(requests))
+        assert report.candidates_evaluated > 0
+
+    def test_all_passing_no_improvement(self):
+        requests = [
+            _make_request(request_id=f"r{i}", total_latency_ms=50.0, timestamp=1000.0 + i)
+            for i in range(20)
+        ]
+        opt = RetryOptimizer(RetryOptimizerConfig(sla_total_ms=300.0))
+        report = opt.optimize(_make_data(requests))
+        assert report.candidates_evaluated > 0
+        # All requests already pass, so goodput improvement should be minimal
+        if report.best_policy:
+            assert report.best_policy.effective_goodput >= 0.99
+
+    def test_some_failing_finds_improvement(self):
+        requests = [
+            _make_request(request_id=f"r{i}", total_latency_ms=50.0, timestamp=1000.0 + i)
+            for i in range(15)
+        ] + [
+            _make_request(request_id=f"r{i+15}", total_latency_ms=400.0, timestamp=1000.0 + i + 15)
+            for i in range(5)
+        ]
+        opt = RetryOptimizer(RetryOptimizerConfig(sla_total_ms=300.0))
+        report = opt.optimize(_make_data(requests))
+        assert report.candidates_evaluated > 0
+        assert report.candidates_within_budget > 0
+        assert report.best_policy is not None
+        assert report.best_policy.effective_goodput >= 0.75
+
+    def test_amplification_budget_respected(self):
+        requests = [
+            _make_request(request_id=f"r{i}", total_latency_ms=500.0, timestamp=1000.0 + i)
+            for i in range(20)
+        ]
+        opt = RetryOptimizer(RetryOptimizerConfig(
+            sla_total_ms=100.0,
+            max_amplification=1.5,
+        ))
+        report = opt.optimize(_make_data(requests))
+        for c in report.all_candidates:
+            if c.within_budget:
+                assert c.amplification_factor <= 1.5
+
+    def test_pareto_frontier_non_empty(self):
+        requests = [
+            _make_request(request_id=f"r{i}", total_latency_ms=50.0 + i * 20, timestamp=1000.0 + i)
+            for i in range(20)
+        ]
+        opt = RetryOptimizer(RetryOptimizerConfig(sla_total_ms=200.0))
+        report = opt.optimize(_make_data(requests))
+        assert len(report.pareto_frontier) > 0
+
+    def test_pareto_sorted_by_amplification(self):
+        requests = [
+            _make_request(request_id=f"r{i}", total_latency_ms=50.0 + i * 20, timestamp=1000.0 + i)
+            for i in range(20)
+        ]
+        opt = RetryOptimizer(RetryOptimizerConfig(sla_total_ms=200.0))
+        report = opt.optimize(_make_data(requests))
+        for i in range(len(report.pareto_frontier) - 1):
+            assert (
+                report.pareto_frontier[i].amplification_factor
+                <= report.pareto_frontier[i + 1].amplification_factor
+            )
+
+    def test_report_serializable(self):
+        requests = [
+            _make_request(request_id=f"r{i}", total_latency_ms=300.0, timestamp=1000.0 + i)
+            for i in range(10)
+        ]
+        opt = RetryOptimizer(RetryOptimizerConfig(sla_total_ms=200.0))
+        report = opt.optimize(_make_data(requests))
+        d = report.model_dump()
+        assert isinstance(d, dict)
+        json_str = json.dumps(d)
+        assert "candidates_evaluated" in json_str
+
+    def test_recommendation_text(self):
+        requests = [
+            _make_request(request_id=f"r{i}", total_latency_ms=50.0, timestamp=1000.0 + i)
+            for i in range(10)
+        ] + [
+            _make_request(request_id=f"r{i+10}", total_latency_ms=400.0, timestamp=1000.0 + i + 10)
+            for i in range(10)
+        ]
+        opt = RetryOptimizer(RetryOptimizerConfig(sla_total_ms=300.0))
+        report = opt.optimize(_make_data(requests))
+        assert len(report.recommendation) > 0
+
+    def test_no_budget_feasible(self):
+        # Very tight budget, all requests fail
+        requests = [
+            _make_request(request_id=f"r{i}", total_latency_ms=5000.0, timestamp=1000.0 + i)
+            for i in range(20)
+        ]
+        opt = RetryOptimizer(RetryOptimizerConfig(
+            sla_total_ms=1.0,
+            max_amplification=1.01,
+        ))
+        report = opt.optimize(_make_data(requests))
+        # Might have no candidates within budget
+        assert report.candidates_evaluated > 0
+
+    def test_multiple_sla_metrics(self):
+        requests = [
+            _make_request(
+                request_id=f"r{i}",
+                ttft_ms=50.0 + i * 5,
+                tpot_ms=10.0 + i * 2,
+                total_latency_ms=100.0 + i * 20,
+                timestamp=1000.0 + i,
+            )
+            for i in range(20)
+        ]
+        opt = RetryOptimizer(RetryOptimizerConfig(
+            sla_ttft_ms=150.0,
+            sla_tpot_ms=50.0,
+            sla_total_ms=300.0,
+        ))
+        report = opt.optimize(_make_data(requests))
+        assert report.candidates_evaluated > 0
+
+    def test_best_policy_has_highest_goodput_in_budget(self):
+        requests = [
+            _make_request(request_id=f"r{i}", total_latency_ms=50.0 + i * 30, timestamp=1000.0 + i)
+            for i in range(20)
+        ]
+        opt = RetryOptimizer(RetryOptimizerConfig(sla_total_ms=300.0))
+        report = opt.optimize(_make_data(requests))
+        if report.best_policy:
+            within = [c for c in report.all_candidates if c.within_budget]
+            max_goodput = max(c.effective_goodput for c in within)
+            assert report.best_policy.effective_goodput == max_goodput
+
+
+class TestComputePareto:
+    def test_empty(self):
+        assert _compute_pareto([]) == []
+
+    def test_single_candidate(self):
+        c = PolicyCandidate(
+            config=RetryConfig(retry_threshold_total_ms=100.0),
+            effective_goodput=0.9,
+            original_goodput=0.8,
+            goodput_improvement=0.1,
+            amplification_factor=1.5,
+            retry_rate=0.2,
+            within_budget=True,
+        )
+        result = _compute_pareto([c])
+        assert len(result) == 1
+
+    def test_dominated_removed(self):
+        c1 = PolicyCandidate(
+            config=RetryConfig(retry_threshold_total_ms=100.0),
+            effective_goodput=0.9,
+            original_goodput=0.8,
+            goodput_improvement=0.1,
+            amplification_factor=1.5,
+            retry_rate=0.2,
+            within_budget=True,
+        )
+        c2 = PolicyCandidate(
+            config=RetryConfig(retry_threshold_total_ms=200.0),
+            effective_goodput=0.8,
+            original_goodput=0.8,
+            goodput_improvement=0.0,
+            amplification_factor=1.8,
+            retry_rate=0.3,
+            within_budget=True,
+        )
+        # c2 is dominated by c1 (worse goodput and worse amplification)
+        result = _compute_pareto([c1, c2])
+        assert len(result) == 1
+        assert result[0].effective_goodput == 0.9
+
+    def test_non_dominated_kept(self):
+        c1 = PolicyCandidate(
+            config=RetryConfig(retry_threshold_total_ms=100.0),
+            effective_goodput=0.9,
+            original_goodput=0.8,
+            goodput_improvement=0.1,
+            amplification_factor=2.0,
+            retry_rate=0.2,
+            within_budget=True,
+        )
+        c2 = PolicyCandidate(
+            config=RetryConfig(retry_threshold_total_ms=200.0),
+            effective_goodput=0.85,
+            original_goodput=0.8,
+            goodput_improvement=0.05,
+            amplification_factor=1.3,
+            retry_rate=0.1,
+            within_budget=True,
+        )
+        # Neither dominates the other
+        result = _compute_pareto([c1, c2])
+        assert len(result) == 2
+
+
+class TestOptimizeRetryPolicyAPI:
+    def test_api_function(self, tmp_path):
+        data = _make_data([
+            _make_request(request_id=f"r{i}", total_latency_ms=50.0 + i * 30, timestamp=1000.0 + i)
+            for i in range(20)
+        ])
+        path = tmp_path / "bench.json"
+        path.write_text(json.dumps(data.model_dump()))
+
+        result = optimize_retry_policy(
+            str(path),
+            sla_total_ms=300.0,
+            max_amplification=2.0,
+        )
+        assert isinstance(result, dict)
+        assert "candidates_evaluated" in result
+        assert "best_policy" in result
+
+    def test_api_custom_retries_range(self, tmp_path):
+        data = _make_data([
+            _make_request(request_id=f"r{i}", total_latency_ms=50.0 + i * 30, timestamp=1000.0 + i)
+            for i in range(20)
+        ])
+        path = tmp_path / "bench.json"
+        path.write_text(json.dumps(data.model_dump()))
+
+        result = optimize_retry_policy(
+            str(path),
+            sla_total_ms=300.0,
+            max_retries_range=[1, 2],
+        )
+        assert isinstance(result, dict)
+
+
+class TestRetryOptimizerConfig:
+    def test_defaults(self):
+        cfg = RetryOptimizerConfig(sla_total_ms=100.0)
+        assert cfg.max_amplification == 2.0
+        assert cfg.max_retries_range == [1, 2, 3, 5]
+        assert len(cfg.threshold_percentiles) == 3
+        assert len(cfg.backoff_types) == 2
+        assert len(cfg.backoff_ms_values) == 3


### PR DESCRIPTION
## Summary

Implements M91: Retry Policy Optimizer.

### Changes
- `RetryOptimizer` class in `retry_optimizer.py`
- `RetryOptimizerConfig`, `OptimalRetryPolicy`, `RetryOptimizerReport`, `PolicyCandidate` Pydantic models
- Grid search over retry parameters: max_retries, threshold percentiles, backoff strategies, backoff delays
- Objective: maximize effective goodput subject to max amplification factor constraint (default 2.0x)
- Pareto frontier of goodput vs amplification tradeoffs
- Uses `RetrySimulator` internally for each candidate evaluation
- CLI `retry-optimize` subcommand with `--benchmark`, `--max-amplification`, `--sla-*`, table + JSON output
- Programmatic `optimize_retry_policy()` API
- 20 new tests (2015 total, all passing)

Closes #201