### PR TITLE
feat: M92 — Benchmark Normalization

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1229,3 +1229,18 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `retry-optimize` subcommand with `--benchmark`, `--max-amplification`, `--sla-ttft`, `--sla-tpot`, `--sla-total`, table + JSON output
 - Programmatic `optimize_retry_policy()` API
 - 20 new tests (2015 total)
+
+### M92 ✅ Benchmark Normalization
+
+*Completed — PR #TBD*
+
+- `BenchmarkNormalizer` class in `normalizer.py`
+- `NormalizationConfig`, `NormalizationReport`, `NormalizedStats`, `GPUPerformanceFactor`, `GPUType` Pydantic models
+- GPU performance factor registry: A100-80G (1.0), H100-80G (1.8), H200-141G (2.2), A10G-24G (0.45), L40S-48G (0.7)
+- Latency scaling preserves relative distributions (percentile ordering unchanged)
+- QPS scaled inversely to latency factor
+- `normalize_data()` returns new BenchmarkData with normalized values
+- Custom GPU factors via `custom_factors` parameter
+- CLI `normalize` subcommand with `--benchmark`, `--source-gpu`, `--target-gpu`, `--output`, table + JSON output
+- Programmatic `normalize_benchmark()` API
+- ~23 new tests

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -1124,3 +1124,23 @@ __all__ += [
     "RetryOptimizerReport",
     "optimize_retry_policy",
 ]
+
+from xpyd_plan.normalizer import (  # noqa: E402
+    BenchmarkNormalizer,
+    GPUPerformanceFactor,
+    GPUType,
+    NormalizationConfig,
+    NormalizationReport,
+    NormalizedStats,
+    normalize_benchmark,
+)
+
+__all__ += [
+    "BenchmarkNormalizer",
+    "GPUPerformanceFactor",
+    "GPUType",
+    "NormalizationConfig",
+    "NormalizationReport",
+    "NormalizedStats",
+    "normalize_benchmark",
+]

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -44,6 +44,7 @@ from xpyd_plan.cli._merge import _cmd_merge
 from xpyd_plan.cli._metrics import _cmd_metrics, add_metrics_parser
 from xpyd_plan.cli._migrate import add_migrate_parser
 from xpyd_plan.cli._model_compare import _cmd_model_compare
+from xpyd_plan.cli._normalize import add_normalize_parser
 from xpyd_plan.cli._outlier_impact import (
     add_outlier_impact_parser,
 )
@@ -945,6 +946,7 @@ def main(argv: list[str] | None = None) -> None:
     add_sample_parser(subparsers)
     add_size_distribution_parser(subparsers)
     add_token_budget_parser(subparsers)
+    add_normalize_parser(subparsers)
     add_retry_optimize_parser(subparsers)
     add_retry_sim_parser(subparsers)
     add_token_efficiency_parser(subparsers)

--- a/src/xpyd_plan/cli/_normalize.py
+++ b/src/xpyd_plan/cli/_normalize.py
@@ -1,0 +1,116 @@
+"""CLI normalize command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.normalizer import BenchmarkNormalizer, NormalizationConfig
+
+
+def _cmd_normalize(args: argparse.Namespace) -> None:
+    """Handle the 'normalize' subcommand."""
+    console = Console()
+
+    data = load_benchmark_auto(args.benchmark)
+    config = NormalizationConfig(
+        source_gpu=args.source_gpu,
+        target_gpu=args.target_gpu,
+    )
+    normalizer = BenchmarkNormalizer(config)
+    report = normalizer.normalize(data)
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Summary table
+    summary = Table(title="Benchmark Normalization")
+    summary.add_column("Metric", justify="left")
+    summary.add_column("Value", justify="right")
+    summary.add_row("Source GPU", config.source_gpu)
+    summary.add_row("Target GPU", config.target_gpu)
+    summary.add_row("Source Factor", f"{report.source_factor:.2f}")
+    summary.add_row("Target Factor", f"{report.target_factor:.2f}")
+    summary.add_row("Scaling Factor", f"{report.scaling_factor:.4f}")
+    summary.add_row("Requests", str(report.request_count))
+    summary.add_row("Original QPS", f"{report.original_qps:.2f}")
+    summary.add_row("Normalized QPS", f"{report.normalized_qps:.2f}")
+    console.print(summary)
+
+    # Latency comparison
+    lat_table = Table(title="Latency Comparison")
+    lat_table.add_column("Metric", justify="left")
+    lat_table.add_column("Orig P50", justify="right")
+    lat_table.add_column("Orig P95", justify="right")
+    lat_table.add_column("Orig P99", justify="right")
+    lat_table.add_column("Norm P50", justify="right")
+    lat_table.add_column("Norm P95", justify="right")
+    lat_table.add_column("Norm P99", justify="right")
+
+    for name, stats in [
+        ("TTFT", report.ttft_stats),
+        ("TPOT", report.tpot_stats),
+        ("Total", report.total_latency_stats),
+    ]:
+        lat_table.add_row(
+            name,
+            f"{stats.original_p50:.1f}ms",
+            f"{stats.original_p95:.1f}ms",
+            f"{stats.original_p99:.1f}ms",
+            f"{stats.normalized_p50:.1f}ms",
+            f"{stats.normalized_p95:.1f}ms",
+            f"{stats.normalized_p99:.1f}ms",
+        )
+    console.print()
+    console.print(lat_table)
+
+    # Known GPUs
+    gpu_table = Table(title="Known GPU Performance Factors")
+    gpu_table.add_column("GPU Type", justify="left")
+    gpu_table.add_column("Factor", justify="right")
+    for gpu in report.known_gpus:
+        marker = " ←" if gpu.gpu_type in (config.source_gpu, config.target_gpu) else ""
+        gpu_table.add_row(gpu.gpu_type, f"{gpu.factor:.2f}{marker}")
+    console.print()
+    console.print(gpu_table)
+
+    # Output normalized data if requested
+    if args.output:
+        norm_data = normalizer.normalize_data(data)
+        with open(args.output, "w") as f:
+            json.dump(norm_data.model_dump(), f, indent=2)
+        console.print(f"\n[green]Normalized benchmark written to {args.output}[/green]")
+
+
+def add_normalize_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the normalize subcommand parser."""
+    parser = subparsers.add_parser(
+        "normalize",
+        help="Normalize benchmark latencies across GPU types",
+    )
+    parser.add_argument("--benchmark", required=True, help="Benchmark JSON file")
+    parser.add_argument(
+        "--source-gpu", required=True,
+        help="GPU type the benchmark was run on (e.g., H100-80G)",
+    )
+    parser.add_argument(
+        "--target-gpu", default="A100-80G",
+        help="GPU type to normalize to (default: A100-80G)",
+    )
+    parser.add_argument(
+        "--output", default=None,
+        help="Write normalized benchmark data to file",
+    )
+    parser.add_argument(
+        "--output-format", choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_normalize)

--- a/src/xpyd_plan/normalizer.py
+++ b/src/xpyd_plan/normalizer.py
@@ -1,0 +1,206 @@
+"""Benchmark normalization across GPU types.
+
+Scales latency values using GPU-relative performance factors to enable
+fair cross-hardware comparison.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData, BenchmarkRequest
+
+
+class GPUType(str, Enum):
+    """Known GPU types."""
+
+    A100_80G = "A100-80G"
+    H100_80G = "H100-80G"
+    H200_141G = "H200-141G"
+    A10G_24G = "A10G-24G"
+    L40S_48G = "L40S-48G"
+
+
+# Performance factors relative to A100-80G = 1.0.
+# Higher means faster (lower latency). Based on public FP16 throughput ratios.
+_DEFAULT_FACTORS: dict[GPUType, float] = {
+    GPUType.A100_80G: 1.0,
+    GPUType.H100_80G: 1.8,
+    GPUType.H200_141G: 2.2,
+    GPUType.A10G_24G: 0.45,
+    GPUType.L40S_48G: 0.7,
+}
+
+
+class GPUPerformanceFactor(BaseModel):
+    """Performance factor for a GPU type relative to reference."""
+
+    gpu_type: str
+    factor: float = Field(..., gt=0, description="Performance factor (higher = faster)")
+
+
+class NormalizationConfig(BaseModel):
+    """Configuration for benchmark normalization."""
+
+    source_gpu: str = Field(..., description="GPU type the benchmark was run on")
+    target_gpu: str = Field(
+        "A100-80G", description="GPU type to normalize to (reference)"
+    )
+    custom_factors: dict[str, float] | None = Field(
+        None, description="Custom GPU performance factors (overrides defaults)"
+    )
+
+
+class NormalizedStats(BaseModel):
+    """Statistics before and after normalization."""
+
+    original_p50: float
+    original_p95: float
+    original_p99: float
+    normalized_p50: float
+    normalized_p95: float
+    normalized_p99: float
+    scaling_factor: float
+
+
+class NormalizationReport(BaseModel):
+    """Complete normalization report."""
+
+    config: NormalizationConfig
+    source_factor: float
+    target_factor: float
+    scaling_factor: float = Field(
+        ..., description="Multiplier applied to latencies (source_factor / target_factor)"
+    )
+    request_count: int
+    ttft_stats: NormalizedStats
+    tpot_stats: NormalizedStats
+    total_latency_stats: NormalizedStats
+    original_qps: float
+    normalized_qps: float
+    known_gpus: list[GPUPerformanceFactor]
+
+
+class BenchmarkNormalizer:
+    """Normalize benchmark latencies across GPU types."""
+
+    def __init__(self, config: NormalizationConfig) -> None:
+        self._config = config
+        self._factors = self._build_factors()
+
+    def _build_factors(self) -> dict[str, float]:
+        factors: dict[str, float] = {g.value: f for g, f in _DEFAULT_FACTORS.items()}
+        if self._config.custom_factors:
+            factors.update(self._config.custom_factors)
+        return factors
+
+    def _get_factor(self, gpu: str) -> float:
+        if gpu in self._factors:
+            return self._factors[gpu]
+        raise ValueError(
+            f"Unknown GPU type '{gpu}'. Known types: {sorted(self._factors.keys())}"
+        )
+
+    def normalize(self, data: BenchmarkData) -> NormalizationReport:
+        """Normalize benchmark data and return report."""
+        import numpy as np
+
+        cfg = self._config
+        source_factor = self._get_factor(cfg.source_gpu)
+        target_factor = self._get_factor(cfg.target_gpu)
+        # If source is faster than target, latencies should increase (scale up)
+        scaling = source_factor / target_factor
+
+        requests = data.requests
+        if not requests:
+            raise ValueError("Benchmark contains no requests")
+
+        ttft = np.array([r.ttft_ms for r in requests])
+        tpot = np.array([r.tpot_ms for r in requests])
+        total = np.array([r.total_latency_ms for r in requests])
+
+        def _stats(orig: np.ndarray, scaled: np.ndarray) -> NormalizedStats:
+            return NormalizedStats(
+                original_p50=float(np.percentile(orig, 50)),
+                original_p95=float(np.percentile(orig, 95)),
+                original_p99=float(np.percentile(orig, 99)),
+                normalized_p50=float(np.percentile(scaled, 50)),
+                normalized_p95=float(np.percentile(scaled, 95)),
+                normalized_p99=float(np.percentile(scaled, 99)),
+                scaling_factor=scaling,
+            )
+
+        ttft_scaled = ttft * scaling
+        tpot_scaled = tpot * scaling
+        total_scaled = total * scaling
+
+        original_qps = data.metadata.measured_qps
+        # Faster GPU → higher QPS, so normalized QPS scales inversely
+        normalized_qps = original_qps / scaling if scaling > 0 else 0.0
+
+        known = [
+            GPUPerformanceFactor(gpu_type=k, factor=v)
+            for k, v in sorted(self._factors.items())
+        ]
+
+        return NormalizationReport(
+            config=cfg,
+            source_factor=source_factor,
+            target_factor=target_factor,
+            scaling_factor=scaling,
+            request_count=len(requests),
+            ttft_stats=_stats(ttft, ttft_scaled),
+            tpot_stats=_stats(tpot, tpot_scaled),
+            total_latency_stats=_stats(total, total_scaled),
+            original_qps=original_qps,
+            normalized_qps=normalized_qps,
+            known_gpus=known,
+        )
+
+    def normalize_data(self, data: BenchmarkData) -> BenchmarkData:
+        """Return a new BenchmarkData with normalized latencies."""
+        cfg = self._config
+        source_factor = self._get_factor(cfg.source_gpu)
+        target_factor = self._get_factor(cfg.target_gpu)
+        scaling = source_factor / target_factor
+
+        new_requests = [
+            BenchmarkRequest(
+                request_id=r.request_id,
+                prompt_tokens=r.prompt_tokens,
+                output_tokens=r.output_tokens,
+                ttft_ms=r.ttft_ms * scaling,
+                tpot_ms=r.tpot_ms * scaling,
+                total_latency_ms=r.total_latency_ms * scaling,
+                timestamp=r.timestamp,
+            )
+            for r in data.requests
+        ]
+
+        from .benchmark_models import BenchmarkMetadata
+
+        new_cluster = BenchmarkMetadata(
+            num_prefill_instances=data.metadata.num_prefill_instances,
+            num_decode_instances=data.metadata.num_decode_instances,
+            total_instances=data.metadata.total_instances,
+            measured_qps=data.metadata.measured_qps / scaling if scaling > 0 else 0.0,
+        )
+
+        return BenchmarkData(requests=new_requests, metadata=new_cluster)
+
+
+def normalize_benchmark(
+    data: BenchmarkData,
+    source_gpu: str,
+    target_gpu: str = "A100-80G",
+    custom_factors: dict[str, float] | None = None,
+) -> NormalizationReport:
+    """Programmatic API for benchmark normalization."""
+    config = NormalizationConfig(
+        source_gpu=source_gpu,
+        target_gpu=target_gpu,
+        custom_factors=custom_factors,
+    )
+    return BenchmarkNormalizer(config).normalize(data)

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -1,0 +1,278 @@
+"""Tests for benchmark normalization."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.normalizer import (
+    BenchmarkNormalizer,
+    GPUType,
+    NormalizationConfig,
+    normalize_benchmark,
+)
+
+
+def _make_data(
+    n: int = 100,
+    ttft_base: float = 50.0,
+    tpot_base: float = 30.0,
+    total_base: float = 200.0,
+    qps: float = 10.0,
+) -> BenchmarkData:
+    """Create synthetic benchmark data."""
+    import random
+
+    random.seed(42)
+    requests = []
+    for i in range(n):
+        noise = 1 + random.gauss(0, 0.1)
+        requests.append(
+            BenchmarkRequest(
+                request_id=f"req-{i}",
+                prompt_tokens=100 + random.randint(0, 200),
+                output_tokens=50 + random.randint(0, 100),
+                ttft_ms=ttft_base * max(0.1, noise),
+                tpot_ms=tpot_base * max(0.1, noise),
+                total_latency_ms=total_base * max(0.1, noise),
+                timestamp=1000.0 + i * 0.1,
+            )
+        )
+    return BenchmarkData(
+        requests=requests,
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=2,
+            total_instances=4,
+            measured_qps=qps,
+        ),
+    )
+
+
+class TestBenchmarkNormalizer:
+    """Tests for BenchmarkNormalizer."""
+
+    def test_same_gpu_no_change(self) -> None:
+        data = _make_data()
+        config = NormalizationConfig(source_gpu="A100-80G", target_gpu="A100-80G")
+        report = BenchmarkNormalizer(config).normalize(data)
+        assert report.scaling_factor == pytest.approx(1.0)
+        assert report.ttft_stats.original_p50 == pytest.approx(report.ttft_stats.normalized_p50)
+        assert report.normalized_qps == pytest.approx(report.original_qps)
+
+    def test_h100_to_a100_scales_up(self) -> None:
+        """H100 is faster, so normalizing to A100 should increase latencies."""
+        data = _make_data()
+        report = normalize_benchmark(data, source_gpu="H100-80G", target_gpu="A100-80G")
+        # H100 factor=1.8, A100 factor=1.0, scaling=1.8
+        assert report.scaling_factor == pytest.approx(1.8)
+        assert report.ttft_stats.normalized_p50 > report.ttft_stats.original_p50
+        assert report.normalized_qps < report.original_qps
+
+    def test_a100_to_h100_scales_down(self) -> None:
+        """A100 is slower, so normalizing to H100 should decrease latencies."""
+        data = _make_data()
+        report = normalize_benchmark(data, source_gpu="A100-80G", target_gpu="H100-80G")
+        assert report.scaling_factor == pytest.approx(1.0 / 1.8, rel=1e-3)
+        assert report.ttft_stats.normalized_p50 < report.ttft_stats.original_p50
+        assert report.normalized_qps > report.original_qps
+
+    def test_scaling_preserves_percentile_order(self) -> None:
+        data = _make_data()
+        report = normalize_benchmark(data, source_gpu="H100-80G")
+        assert report.ttft_stats.normalized_p50 <= report.ttft_stats.normalized_p95
+        assert report.ttft_stats.normalized_p95 <= report.ttft_stats.normalized_p99
+
+    def test_unknown_gpu_raises(self) -> None:
+        data = _make_data()
+        with pytest.raises(ValueError, match="Unknown GPU type"):
+            normalize_benchmark(data, source_gpu="UNKNOWN-GPU")
+
+    def test_custom_factors(self) -> None:
+        data = _make_data()
+        report = normalize_benchmark(
+            data,
+            source_gpu="MY-GPU",
+            target_gpu="A100-80G",
+            custom_factors={"MY-GPU": 2.5},
+        )
+        assert report.scaling_factor == pytest.approx(2.5)
+
+    def test_normalize_data_returns_benchmark(self) -> None:
+        data = _make_data(n=10)
+        config = NormalizationConfig(source_gpu="H100-80G", target_gpu="A100-80G")
+        normalizer = BenchmarkNormalizer(config)
+        result = normalizer.normalize_data(data)
+        assert isinstance(result, BenchmarkData)
+        assert len(result.requests) == 10
+        # Latencies should be scaled
+        scaling = 1.8
+        for orig, norm in zip(data.requests, result.requests):
+            assert norm.ttft_ms == pytest.approx(orig.ttft_ms * scaling, rel=1e-6)
+            assert norm.tpot_ms == pytest.approx(orig.tpot_ms * scaling, rel=1e-6)
+
+    def test_normalize_data_preserves_tokens(self) -> None:
+        data = _make_data(n=5)
+        config = NormalizationConfig(source_gpu="H100-80G", target_gpu="A100-80G")
+        result = BenchmarkNormalizer(config).normalize_data(data)
+        for orig, norm in zip(data.requests, result.requests):
+            assert norm.prompt_tokens == orig.prompt_tokens
+            assert norm.output_tokens == orig.output_tokens
+
+    def test_empty_data_raises(self) -> None:
+        """BenchmarkData enforces min_length=1, so empty data can't be created."""
+        with pytest.raises(Exception):
+            BenchmarkData(
+                requests=[],
+                metadata=BenchmarkMetadata(
+                    num_prefill_instances=1,
+                    num_decode_instances=1,
+                    total_instances=2,
+                    measured_qps=1.0,
+                ),
+            )
+
+    def test_all_known_gpus_in_report(self) -> None:
+        data = _make_data()
+        report = normalize_benchmark(data, source_gpu="A100-80G")
+        gpu_names = {g.gpu_type for g in report.known_gpus}
+        assert "A100-80G" in gpu_names
+        assert "H100-80G" in gpu_names
+        assert "H200-141G" in gpu_names
+
+    def test_gpu_type_enum(self) -> None:
+        assert GPUType.A100_80G.value == "A100-80G"
+        assert GPUType.H100_80G.value == "H100-80G"
+
+    def test_report_request_count(self) -> None:
+        data = _make_data(n=50)
+        report = normalize_benchmark(data, source_gpu="A100-80G")
+        assert report.request_count == 50
+
+    def test_a10g_to_a100(self) -> None:
+        """A10G is slower, normalizing to A100 should decrease latencies."""
+        data = _make_data()
+        report = normalize_benchmark(data, source_gpu="A10G-24G", target_gpu="A100-80G")
+        assert report.scaling_factor == pytest.approx(0.45)
+        assert report.ttft_stats.normalized_p50 < report.ttft_stats.original_p50
+
+    def test_bidirectional_consistency(self) -> None:
+        """Normalizing A→B then B→A should return to original."""
+        data = _make_data(n=20)
+        config_ab = NormalizationConfig(source_gpu="A100-80G", target_gpu="H100-80G")
+        norm_ab = BenchmarkNormalizer(config_ab)
+        data_ab = norm_ab.normalize_data(data)
+
+        config_ba = NormalizationConfig(source_gpu="H100-80G", target_gpu="A100-80G")
+        norm_ba = BenchmarkNormalizer(config_ba)
+        data_round = norm_ba.normalize_data(data_ab)
+
+        for orig, rnd in zip(data.requests, data_round.requests):
+            assert rnd.ttft_ms == pytest.approx(orig.ttft_ms, rel=1e-6)
+
+    def test_qps_scaling(self) -> None:
+        data = _make_data(qps=100.0)
+        report = normalize_benchmark(data, source_gpu="H100-80G", target_gpu="A100-80G")
+        # H100→A100: scaling=1.8, QPS should decrease
+        assert report.normalized_qps == pytest.approx(100.0 / 1.8, rel=1e-3)
+
+    def test_normalize_data_qps(self) -> None:
+        data = _make_data(qps=50.0)
+        config = NormalizationConfig(source_gpu="H100-80G", target_gpu="A100-80G")
+        result = BenchmarkNormalizer(config).normalize_data(data)
+        assert result.metadata.measured_qps == pytest.approx(50.0 / 1.8, rel=1e-3)
+
+    def test_custom_factors_override_defaults(self) -> None:
+        data = _make_data()
+        # Override A100 factor
+        report = normalize_benchmark(
+            data,
+            source_gpu="A100-80G",
+            target_gpu="A100-80G",
+            custom_factors={"A100-80G": 3.0},
+        )
+        assert report.scaling_factor == pytest.approx(1.0)
+
+    def test_tpot_and_total_stats(self) -> None:
+        data = _make_data()
+        report = normalize_benchmark(data, source_gpu="H100-80G")
+        assert report.tpot_stats.scaling_factor == pytest.approx(1.8)
+        assert report.total_latency_stats.scaling_factor == pytest.approx(1.8)
+
+    def test_h200_to_a100(self) -> None:
+        data = _make_data()
+        report = normalize_benchmark(data, source_gpu="H200-141G", target_gpu="A100-80G")
+        assert report.scaling_factor == pytest.approx(2.2)
+
+    def test_l40s_factor(self) -> None:
+        data = _make_data()
+        report = normalize_benchmark(data, source_gpu="L40S-48G", target_gpu="A100-80G")
+        assert report.scaling_factor == pytest.approx(0.7)
+
+
+class TestCLI:
+    """Tests for normalize CLI subcommand."""
+
+    def test_cli_table_output(self, tmp_path) -> None:
+        from xpyd_plan.cli._normalize import _cmd_normalize
+
+        data = _make_data(n=50)
+        bench_file = tmp_path / "bench.json"
+        bench_file.write_text(json.dumps(data.model_dump()))
+
+        import argparse
+
+        args = argparse.Namespace(
+            benchmark=str(bench_file),
+            source_gpu="H100-80G",
+            target_gpu="A100-80G",
+            output=None,
+            output_format="table",
+        )
+        # Should not raise
+        _cmd_normalize(args)
+
+    def test_cli_json_output(self, tmp_path, capsys) -> None:
+        from xpyd_plan.cli._normalize import _cmd_normalize
+
+        data = _make_data(n=50)
+        bench_file = tmp_path / "bench.json"
+        bench_file.write_text(json.dumps(data.model_dump()))
+
+        import argparse
+
+        args = argparse.Namespace(
+            benchmark=str(bench_file),
+            source_gpu="H100-80G",
+            target_gpu="A100-80G",
+            output=None,
+            output_format="json",
+        )
+        _cmd_normalize(args)
+        captured = capsys.readouterr()
+        result = json.loads(captured.out)
+        assert result["scaling_factor"] == pytest.approx(1.8)
+
+    def test_cli_output_file(self, tmp_path) -> None:
+        from xpyd_plan.cli._normalize import _cmd_normalize
+
+        data = _make_data(n=20)
+        bench_file = tmp_path / "bench.json"
+        bench_file.write_text(json.dumps(data.model_dump()))
+        out_file = tmp_path / "normalized.json"
+
+        import argparse
+
+        args = argparse.Namespace(
+            benchmark=str(bench_file),
+            source_gpu="H100-80G",
+            target_gpu="A100-80G",
+            output=str(out_file),
+            output_format="table",
+        )
+        _cmd_normalize(args)
+        assert out_file.exists()
+        result = json.loads(out_file.read_text())
+        assert "requests" in result


### PR DESCRIPTION
## Summary

Implements M92: Benchmark Normalization.

### Changes
- `BenchmarkNormalizer` class in `normalizer.py`
- `NormalizationConfig`, `NormalizationReport`, `NormalizedStats`, `GPUPerformanceFactor`, `GPUType` Pydantic models
- GPU performance factor registry: A100-80G (1.0), H100-80G (1.8), H200-141G (2.2), A10G-24G (0.45), L40S-48G (0.7)
- Latency scaling preserves relative distributions (percentile ordering unchanged)
- QPS scaled inversely to latency factor
- `normalize_data()` returns new BenchmarkData with normalized values
- Custom GPU factors via `custom_factors` parameter
- CLI `normalize` subcommand with `--benchmark`, `--source-gpu`, `--target-gpu`, `--output`, table + JSON output
- Programmatic `normalize_benchmark()` API
- 23 new tests

Closes #203