### PR TITLE
feat: add auto-scaling policy generator (M95)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1259,7 +1259,9 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Programmatic `fit_qps_curve()` API
 - 25 new tests (2063 total)
 
-### M94 — Prediction Cross-Validation
+### M94 ✅ Prediction Cross-Validation
+
+*Completed — PR #209*
 
 - `CrossValidator` class in `cross_validation.py`
 - `ErrorMetric`, `CrossValidationReport`, `ModelAccuracy` Pydantic models
@@ -1270,3 +1272,19 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `cross-validate` subcommand with `--benchmark` (3+), `--method`, table + JSON output
 - Programmatic `cross_validate()` API
 - 19 new tests
+
+### M95 ✅ Auto-Scaling Policy Generator
+
+*Completed — PR #TBD*
+
+- `ScalingPolicyGenerator` class in `scaling_policy.py`
+- `ScalingPolicy`, `ScalingRule`, `ScalingTrigger`, `ScalingAction`, `ScalingDirection`, `PolicyFormat` Pydantic models
+- Analyze benchmark data at multiple QPS levels to derive scaling thresholds
+- Scale-up rules: trigger when latency P95 approaches SLA (80% warning, 90% critical)
+- TTFT-based rules scale prefill instances, TPOT-based rules scale decode instances
+- Scale-down rules: trigger when latency is well below SLA (40% threshold) for sustained period
+- Cooldown period and evaluation interval recommendations
+- Instance count bounds (min/max per type)
+- CLI `scaling-policy` subcommand with `--benchmark`, `--sla-ttft`, `--sla-tpot`, `--sla-total`, `--min-instances`, `--max-instances`, table + JSON output
+- Programmatic `generate_scaling_policy()` API
+- 21 new tests

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -324,6 +324,16 @@ from xpyd_plan.scaling import (
     ScalingReport,
     analyze_scaling,
 )
+from xpyd_plan.scaling_policy import (
+    PolicyFormat,
+    ScalingAction,
+    ScalingDirection,
+    ScalingPolicy,
+    ScalingPolicyGenerator,
+    ScalingRule,
+    ScalingTrigger,
+    generate_scaling_policy,
+)
 from xpyd_plan.scorecard import (
     ConfigScorecard,
     DimensionScore,
@@ -463,6 +473,14 @@ __all__ = [
     "ErrorMetric",
     "ModelAccuracy",
     "cross_validate",
+    "ScalingPolicy",
+    "ScalingPolicyGenerator",
+    "ScalingRule",
+    "ScalingTrigger",
+    "ScalingAction",
+    "ScalingDirection",
+    "PolicyFormat",
+    "generate_scaling_policy",
     "LoadProfileClassifier",
     "LoadProfile",
     "LoadProfileReport",

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -68,6 +68,7 @@ from xpyd_plan.cli._root_cause import _cmd_root_cause, add_root_cause_parser
 from xpyd_plan.cli._sample import add_sample_parser
 from xpyd_plan.cli._saturation import _cmd_saturation, add_saturation_parser
 from xpyd_plan.cli._scaling import _cmd_scaling, add_scaling_parser
+from xpyd_plan.cli._scaling_policy import add_scaling_policy_parser
 from xpyd_plan.cli._scorecard import _cmd_scorecard, add_scorecard_parser
 from xpyd_plan.cli._size_distribution import _cmd_size_distribution, add_size_distribution_parser
 from xpyd_plan.cli._sla_tier import add_sla_tier_parser
@@ -951,6 +952,7 @@ def main(argv: list[str] | None = None) -> None:
     add_token_budget_parser(subparsers)
     add_normalize_parser(subparsers)
     add_cross_validate_parser(subparsers)
+    add_scaling_policy_parser(subparsers)
     add_parquet_parser(subparsers)
     add_qps_curve_parser(subparsers)
     add_retry_optimize_parser(subparsers)
@@ -1158,6 +1160,9 @@ def main(argv: list[str] | None = None) -> None:
     elif args.command == "qps-curve":
         from xpyd_plan.cli._qps_curve import _cmd_qps_curve
         _cmd_qps_curve(args)
+    elif args.command == "scaling-policy":
+        from xpyd_plan.cli._scaling_policy import _cmd_scaling_policy
+        _cmd_scaling_policy(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/cli/_scaling_policy.py
+++ b/src/xpyd_plan/cli/_scaling_policy.py
@@ -1,0 +1,97 @@
+"""CLI handler for the scaling-policy subcommand."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.scaling_policy import ScalingPolicyGenerator
+
+
+def _cmd_scaling_policy(args: argparse.Namespace) -> None:
+    """Execute scaling-policy subcommand."""
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+    data = [load_benchmark_auto(p) for p in args.benchmark]
+
+    gen = ScalingPolicyGenerator(
+        data,
+        sla_ttft_ms=args.sla_ttft,
+        sla_tpot_ms=args.sla_tpot,
+        sla_total_ms=args.sla_total,
+        min_instances=args.min_instances,
+        max_instances=args.max_instances,
+    )
+    policy = gen.generate()
+
+    if args.output_format == "json":
+        json.dump(policy.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Table output
+    table = Table(title="Auto-Scaling Policy Rules")
+    table.add_column("Priority", justify="right")
+    table.add_column("Name")
+    table.add_column("Trigger")
+    table.add_column("Direction")
+    table.add_column("Action")
+    table.add_column("Reason")
+
+    for rule in policy.rules:
+        trigger_str = (
+            f"{rule.trigger.metric} {rule.trigger.comparator} "
+            f"{rule.trigger.threshold} for {rule.trigger.sustained_seconds}s"
+        )
+        action_str = f"P:{rule.action.prefill_delta:+d} D:{rule.action.decode_delta:+d}"
+        table.add_row(
+            str(rule.priority),
+            rule.name,
+            trigger_str,
+            rule.action.direction.value,
+            action_str,
+            rule.action.reason,
+        )
+
+    console.print(table)
+    console.print(f"\nCooldown: {policy.cooldown_seconds}s")
+    p_min = policy.min_prefill_instances
+    p_max = policy.max_prefill_instances
+    d_min = policy.min_decode_instances
+    d_max = policy.max_decode_instances
+    console.print(
+        f"Instance bounds: prefill [{p_min}-{p_max}], "
+        f"decode [{d_min}-{d_max}]"
+    )
+
+    if policy.notes:
+        console.print("\n[bold]Notes:[/bold]")
+        for note in policy.notes:
+            console.print(f"  • {note}")
+
+
+def add_scaling_policy_parser(
+    subparsers: argparse._SubParsersAction,
+) -> None:
+    """Add scaling-policy subcommand parser."""
+    parser = subparsers.add_parser(
+        "scaling-policy",
+        help="Generate auto-scaling policy rules from benchmark data",
+    )
+    parser.add_argument(
+        "--benchmark", "-b", nargs="+", required=True,
+        help="Benchmark JSON files (multiple QPS levels recommended)",
+    )
+    parser.add_argument("--sla-ttft", type=float, default=500.0, help="TTFT SLA (ms)")
+    parser.add_argument("--sla-tpot", type=float, default=100.0, help="TPOT SLA (ms)")
+    parser.add_argument("--sla-total", type=float, default=5000.0, help="Total latency SLA (ms)")
+    parser.add_argument("--min-instances", type=int, default=1, help="Min instances per type")
+    parser.add_argument("--max-instances", type=int, default=16, help="Max instances per type")
+    parser.add_argument(
+        "--output-format", "-o", choices=["table", "json"], default="table",
+        help="Output format",
+    )

--- a/src/xpyd_plan/scaling_policy.py
+++ b/src/xpyd_plan/scaling_policy.py
@@ -1,0 +1,328 @@
+"""Auto-scaling policy generator for P:D disaggregated inference clusters.
+
+Analyzes benchmark data at multiple QPS levels and generates scaling rules
+that map observed metrics (latency, utilization) to instance scaling actions.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.benchmark_models import BenchmarkData
+
+
+class PolicyFormat(str, Enum):
+    """Output format for scaling policies."""
+
+    JSON = "json"
+    YAML = "yaml"
+    TABLE = "table"
+
+
+class ScalingDirection(str, Enum):
+    """Direction of a scaling action."""
+
+    SCALE_UP = "scale_up"
+    SCALE_DOWN = "scale_down"
+
+
+class ScalingTrigger(BaseModel):
+    """Condition that triggers a scaling action."""
+
+    metric: str = Field(..., description="Metric name (e.g., ttft_p95_ms, tpot_p95_ms, qps)")
+    threshold: float = Field(..., description="Threshold value")
+    comparator: str = Field(..., description="Comparison operator (gt, lt, gte, lte)")
+    sustained_seconds: int = Field(
+        60, ge=0, description="Seconds the condition must hold before triggering"
+    )
+
+
+class ScalingAction(BaseModel):
+    """Action to take when a trigger fires."""
+
+    direction: ScalingDirection
+    prefill_delta: int = Field(0, description="Change in prefill instances")
+    decode_delta: int = Field(0, description="Change in decode instances")
+    reason: str = Field("", description="Human-readable reason for this action")
+
+
+class ScalingRule(BaseModel):
+    """A single scaling rule: trigger → action."""
+
+    name: str
+    trigger: ScalingTrigger
+    action: ScalingAction
+    priority: int = Field(1, ge=1, description="Higher priority rules evaluated first")
+
+
+class ScalingPolicy(BaseModel):
+    """Complete auto-scaling policy for a P:D cluster."""
+
+    rules: list[ScalingRule] = Field(default_factory=list)
+    cooldown_seconds: int = Field(
+        300, ge=0, description="Minimum seconds between scaling actions"
+    )
+    min_prefill_instances: int = Field(1, ge=1)
+    min_decode_instances: int = Field(1, ge=1)
+    max_prefill_instances: int = Field(16, ge=1)
+    max_decode_instances: int = Field(16, ge=1)
+    evaluation_interval_seconds: int = Field(
+        30, ge=1, description="How often to evaluate scaling rules"
+    )
+    notes: list[str] = Field(default_factory=list)
+
+
+def _compute_p95(values: list[float]) -> float:
+    """Compute P95 of a list of values."""
+    if not values:
+        return 0.0
+    return float(np.percentile(values, 95))
+
+
+def _compute_p50(values: list[float]) -> float:
+    """Compute P50 of a list of values."""
+    if not values:
+        return 0.0
+    return float(np.percentile(values, 50))
+
+
+class ScalingPolicyGenerator:
+    """Generate auto-scaling policies from benchmark data.
+
+    Analyzes benchmark data at multiple QPS levels to determine when to
+    scale prefill/decode instances up or down based on SLA thresholds.
+    """
+
+    def __init__(
+        self,
+        benchmark_data: list[BenchmarkData],
+        *,
+        sla_ttft_ms: float = 500.0,
+        sla_tpot_ms: float = 100.0,
+        sla_total_ms: float = 5000.0,
+        min_instances: int = 1,
+        max_instances: int = 16,
+    ) -> None:
+        if not benchmark_data:
+            msg = "At least one benchmark file is required"
+            raise ValueError(msg)
+        self._data = sorted(benchmark_data, key=lambda d: d.metadata.measured_qps)
+        self._sla_ttft = sla_ttft_ms
+        self._sla_tpot = sla_tpot_ms
+        self._sla_total = sla_total_ms
+        self._min_instances = min_instances
+        self._max_instances = max_instances
+
+    def generate(self) -> ScalingPolicy:
+        """Generate a scaling policy from benchmark data."""
+        rules: list[ScalingRule] = []
+        notes: list[str] = []
+
+        # Analyze each benchmark to understand latency at different loads
+        profiles = []
+        for bm in self._data:
+            reqs = bm.requests
+            if not reqs:
+                continue
+            ttft_p95 = _compute_p95([r.ttft_ms for r in reqs])
+            tpot_p95 = _compute_p95([r.tpot_ms for r in reqs])
+            total_p95 = _compute_p95([r.total_latency_ms for r in reqs])
+            qps = bm.metadata.measured_qps
+            prefill = bm.metadata.num_prefill_instances
+            decode = bm.metadata.num_decode_instances
+            profiles.append({
+                "qps": qps,
+                "ttft_p95": ttft_p95,
+                "tpot_p95": tpot_p95,
+                "total_p95": total_p95,
+                "prefill": prefill,
+                "decode": decode,
+            })
+
+        if not profiles:
+            msg = "No valid benchmark data with requests found"
+            raise ValueError(msg)
+
+        # Scale-up rules: trigger when latency approaches SLA
+        # Use 80% of SLA as warning threshold
+        warning_factor = 0.8
+
+        ttft_warning = self._sla_ttft * warning_factor
+        tpot_warning = self._sla_tpot * warning_factor
+
+        rules.append(ScalingRule(
+            name="scale-up-ttft-warning",
+            trigger=ScalingTrigger(
+                metric="ttft_p95_ms",
+                threshold=round(ttft_warning, 1),
+                comparator="gte",
+                sustained_seconds=60,
+            ),
+            action=ScalingAction(
+                direction=ScalingDirection.SCALE_UP,
+                prefill_delta=1,
+                decode_delta=0,
+                reason=f"TTFT P95 approaching SLA ({self._sla_ttft}ms), add prefill capacity",
+            ),
+            priority=2,
+        ))
+
+        rules.append(ScalingRule(
+            name="scale-up-tpot-warning",
+            trigger=ScalingTrigger(
+                metric="tpot_p95_ms",
+                threshold=round(tpot_warning, 1),
+                comparator="gte",
+                sustained_seconds=60,
+            ),
+            action=ScalingAction(
+                direction=ScalingDirection.SCALE_UP,
+                prefill_delta=0,
+                decode_delta=1,
+                reason=f"TPOT P95 approaching SLA ({self._sla_tpot}ms), add decode capacity",
+            ),
+            priority=2,
+        ))
+
+        rules.append(ScalingRule(
+            name="scale-up-total-critical",
+            trigger=ScalingTrigger(
+                metric="total_latency_p95_ms",
+                threshold=round(self._sla_total * 0.9, 1),
+                comparator="gte",
+                sustained_seconds=30,
+            ),
+            action=ScalingAction(
+                direction=ScalingDirection.SCALE_UP,
+                prefill_delta=1,
+                decode_delta=1,
+                reason=f"Total latency P95 near SLA ({self._sla_total}ms), add both instance types",
+            ),
+            priority=3,
+        ))
+
+        # Scale-down rules: based on low utilization
+        # Find the lowest QPS profile that still meets SLA
+        sla_meeting_profiles = [
+            p for p in profiles
+            if p["ttft_p95"] <= self._sla_ttft
+            and p["tpot_p95"] <= self._sla_tpot
+            and p["total_p95"] <= self._sla_total
+        ]
+
+        if sla_meeting_profiles:
+            # Use the lowest-QPS SLA-meeting profile for scale-down thresholds
+            low_profile = sla_meeting_profiles[0]
+            # Scale down when TTFT is well below warning (< 50% of SLA)
+            scale_down_ttft = self._sla_ttft * 0.4
+            scale_down_tpot = self._sla_tpot * 0.4
+
+            rules.append(ScalingRule(
+                name="scale-down-ttft-idle",
+                trigger=ScalingTrigger(
+                    metric="ttft_p95_ms",
+                    threshold=round(scale_down_ttft, 1),
+                    comparator="lte",
+                    sustained_seconds=300,
+                ),
+                action=ScalingAction(
+                    direction=ScalingDirection.SCALE_DOWN,
+                    prefill_delta=-1,
+                    decode_delta=0,
+                    reason="TTFT P95 well below SLA, reduce prefill capacity to save cost",
+                ),
+                priority=1,
+            ))
+
+            rules.append(ScalingRule(
+                name="scale-down-tpot-idle",
+                trigger=ScalingTrigger(
+                    metric="tpot_p95_ms",
+                    threshold=round(scale_down_tpot, 1),
+                    comparator="lte",
+                    sustained_seconds=300,
+                ),
+                action=ScalingAction(
+                    direction=ScalingDirection.SCALE_DOWN,
+                    prefill_delta=0,
+                    decode_delta=-1,
+                    reason="TPOT P95 well below SLA, reduce decode capacity to save cost",
+                ),
+                priority=1,
+            ))
+
+            notes.append(
+                f"Scale-down thresholds derived from lowest SLA-meeting benchmark "
+                f"(QPS={low_profile['qps']:.1f})."
+            )
+        else:
+            notes.append(
+                "No benchmark meets all SLA constraints. Scale-down rules not generated. "
+                "Consider relaxing SLA or adding capacity."
+            )
+
+        # Estimate cooldown from data: use the spread of QPS levels
+        if len(profiles) >= 2:
+            cooldown = 300  # default 5 minutes
+            notes.append(
+                f"Cooldown set to {cooldown}s. Adjust based on observed instance startup time."
+            )
+        else:
+            cooldown = 300
+            notes.append(
+                "Single benchmark provided. Policy thresholds may be less accurate. "
+                "More QPS levels recommended."
+            )
+
+        # Sort rules by priority (highest first)
+        rules.sort(key=lambda r: r.priority, reverse=True)
+
+        return ScalingPolicy(
+            rules=rules,
+            cooldown_seconds=cooldown,
+            min_prefill_instances=self._min_instances,
+            min_decode_instances=self._min_instances,
+            max_prefill_instances=self._max_instances,
+            max_decode_instances=self._max_instances,
+            evaluation_interval_seconds=30,
+            notes=notes,
+        )
+
+
+def generate_scaling_policy(
+    benchmark_paths: list[str],
+    *,
+    sla_ttft_ms: float = 500.0,
+    sla_tpot_ms: float = 100.0,
+    sla_total_ms: float = 5000.0,
+    min_instances: int = 1,
+    max_instances: int = 16,
+) -> dict:
+    """Programmatic API for scaling policy generation.
+
+    Args:
+        benchmark_paths: Paths to benchmark JSON files.
+        sla_ttft_ms: TTFT SLA threshold in milliseconds.
+        sla_tpot_ms: TPOT SLA threshold in milliseconds.
+        sla_total_ms: Total latency SLA threshold in milliseconds.
+        min_instances: Minimum instances per type.
+        max_instances: Maximum instances per type.
+
+    Returns:
+        Dictionary representation of ScalingPolicy.
+    """
+    data = [load_benchmark_auto(p) for p in benchmark_paths]
+    gen = ScalingPolicyGenerator(
+        data,
+        sla_ttft_ms=sla_ttft_ms,
+        sla_tpot_ms=sla_tpot_ms,
+        sla_total_ms=sla_total_ms,
+        min_instances=min_instances,
+        max_instances=max_instances,
+    )
+    policy = gen.generate()
+    return policy.model_dump()

--- a/tests/test_scaling_policy.py
+++ b/tests/test_scaling_policy.py
@@ -1,0 +1,286 @@
+"""Tests for scaling_policy module (M95)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from xpyd_plan.benchmark_models import (
+    BenchmarkData,
+    BenchmarkMetadata,
+    BenchmarkRequest,
+)
+from xpyd_plan.scaling_policy import (
+    ScalingAction,
+    ScalingDirection,
+    ScalingPolicy,
+    ScalingPolicyGenerator,
+    ScalingRule,
+    ScalingTrigger,
+    generate_scaling_policy,
+)
+
+UP = ScalingDirection.SCALE_UP
+DOWN = ScalingDirection.SCALE_DOWN
+
+
+def _make_benchmark(
+    qps: float,
+    num_prefill: int,
+    num_decode: int,
+    ttft_base: float = 50.0,
+    tpot_base: float = 10.0,
+    n_requests: int = 100,
+) -> BenchmarkData:
+    """Create a synthetic benchmark dataset."""
+    import random
+
+    random.seed(42)
+    requests = []
+    for i in range(n_requests):
+        ttft = ttft_base + random.gauss(0, ttft_base * 0.1)
+        tpot = tpot_base + random.gauss(0, tpot_base * 0.1)
+        total = ttft + tpot * 50
+        requests.append(
+            BenchmarkRequest(
+                request_id=f"req-{i}",
+                prompt_tokens=100 + random.randint(0, 200),
+                output_tokens=50 + random.randint(0, 100),
+                ttft_ms=max(1.0, ttft),
+                tpot_ms=max(0.1, tpot),
+                total_latency_ms=max(1.0, total),
+                timestamp=1700000000.0 + i,
+            )
+        )
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=num_prefill,
+            num_decode_instances=num_decode,
+            total_instances=num_prefill + num_decode,
+            measured_qps=qps,
+        ),
+        requests=requests,
+    )
+
+
+def _make_high_latency_benchmark(
+    qps: float,
+    num_prefill: int,
+    num_decode: int,
+) -> BenchmarkData:
+    """Create a benchmark with latency near/above typical SLA."""
+    return _make_benchmark(
+        qps=qps,
+        num_prefill=num_prefill,
+        num_decode=num_decode,
+        ttft_base=450.0,
+        tpot_base=90.0,
+    )
+
+
+class TestScalingPolicyGenerator:
+    """Tests for ScalingPolicyGenerator."""
+
+    def test_basic_generation(self) -> None:
+        data = [_make_benchmark(qps=10.0, num_prefill=2, num_decode=2)]
+        gen = ScalingPolicyGenerator(data)
+        policy = gen.generate()
+        assert isinstance(policy, ScalingPolicy)
+        assert len(policy.rules) > 0
+
+    def test_has_scale_up_rules(self) -> None:
+        data = [_make_benchmark(qps=10.0, num_prefill=2, num_decode=2)]
+        gen = ScalingPolicyGenerator(data)
+        policy = gen.generate()
+        up_rules = [
+            r for r in policy.rules if r.action.direction == UP
+        ]
+        assert len(up_rules) >= 2
+
+    def test_has_scale_down_rules_when_sla_met(self) -> None:
+        data = [_make_benchmark(qps=10.0, num_prefill=2, num_decode=2)]
+        gen = ScalingPolicyGenerator(
+            data, sla_ttft_ms=500.0, sla_tpot_ms=100.0,
+            sla_total_ms=5000.0,
+        )
+        policy = gen.generate()
+        down_rules = [
+            r for r in policy.rules if r.action.direction == DOWN
+        ]
+        assert len(down_rules) >= 1
+
+    def test_no_scale_down_when_sla_violated(self) -> None:
+        data = [_make_high_latency_benchmark(
+            qps=100.0, num_prefill=1, num_decode=1,
+        )]
+        gen = ScalingPolicyGenerator(
+            data, sla_ttft_ms=10.0, sla_tpot_ms=1.0,
+            sla_total_ms=50.0,
+        )
+        policy = gen.generate()
+        down_rules = [
+            r for r in policy.rules if r.action.direction == DOWN
+        ]
+        assert len(down_rules) == 0
+
+    def test_cooldown_set(self) -> None:
+        data = [_make_benchmark(qps=10.0, num_prefill=2, num_decode=2)]
+        gen = ScalingPolicyGenerator(data)
+        policy = gen.generate()
+        assert policy.cooldown_seconds > 0
+
+    def test_instance_bounds(self) -> None:
+        data = [_make_benchmark(qps=10.0, num_prefill=2, num_decode=2)]
+        gen = ScalingPolicyGenerator(
+            data, min_instances=2, max_instances=32,
+        )
+        policy = gen.generate()
+        assert policy.min_prefill_instances == 2
+        assert policy.max_prefill_instances == 32
+
+    def test_multiple_benchmarks(self) -> None:
+        data = [
+            _make_benchmark(qps=10.0, num_prefill=2, num_decode=2),
+            _make_benchmark(
+                qps=50.0, num_prefill=4, num_decode=4,
+                ttft_base=100.0,
+            ),
+            _make_benchmark(
+                qps=100.0, num_prefill=8, num_decode=8,
+                ttft_base=200.0,
+            ),
+        ]
+        gen = ScalingPolicyGenerator(data)
+        policy = gen.generate()
+        assert len(policy.rules) >= 3
+
+    def test_rules_sorted_by_priority(self) -> None:
+        data = [_make_benchmark(qps=10.0, num_prefill=2, num_decode=2)]
+        gen = ScalingPolicyGenerator(data)
+        policy = gen.generate()
+        priorities = [r.priority for r in policy.rules]
+        assert priorities == sorted(priorities, reverse=True)
+
+    def test_empty_data_raises(self) -> None:
+        with pytest.raises(ValueError, match="At least one"):
+            ScalingPolicyGenerator([])
+
+    def test_ttft_scale_up_targets_prefill(self) -> None:
+        data = [_make_benchmark(qps=10.0, num_prefill=2, num_decode=2)]
+        gen = ScalingPolicyGenerator(data)
+        policy = gen.generate()
+        ttft_up = [
+            r for r in policy.rules
+            if "ttft" in r.name and r.action.direction == UP
+        ]
+        for rule in ttft_up:
+            assert rule.action.prefill_delta > 0
+
+    def test_tpot_scale_up_targets_decode(self) -> None:
+        data = [_make_benchmark(qps=10.0, num_prefill=2, num_decode=2)]
+        gen = ScalingPolicyGenerator(data)
+        policy = gen.generate()
+        tpot_up = [
+            r for r in policy.rules
+            if "tpot" in r.name and r.action.direction == UP
+        ]
+        for rule in tpot_up:
+            assert rule.action.decode_delta > 0
+
+    def test_notes_present(self) -> None:
+        data = [_make_benchmark(qps=10.0, num_prefill=2, num_decode=2)]
+        gen = ScalingPolicyGenerator(data)
+        policy = gen.generate()
+        assert len(policy.notes) > 0
+
+    def test_custom_sla_thresholds(self) -> None:
+        data = [_make_benchmark(qps=10.0, num_prefill=2, num_decode=2)]
+        gen = ScalingPolicyGenerator(
+            data, sla_ttft_ms=200.0, sla_tpot_ms=50.0,
+        )
+        policy = gen.generate()
+        ttft_up = [
+            r for r in policy.rules
+            if "ttft" in r.name and r.action.direction == UP
+        ]
+        for rule in ttft_up:
+            assert rule.trigger.threshold == 160.0
+
+    def test_evaluation_interval(self) -> None:
+        data = [_make_benchmark(qps=10.0, num_prefill=2, num_decode=2)]
+        gen = ScalingPolicyGenerator(data)
+        policy = gen.generate()
+        assert policy.evaluation_interval_seconds == 30
+
+    def test_total_critical_rule_adds_both(self) -> None:
+        data = [_make_benchmark(qps=10.0, num_prefill=2, num_decode=2)]
+        gen = ScalingPolicyGenerator(data)
+        policy = gen.generate()
+        total_rules = [r for r in policy.rules if "total" in r.name]
+        for rule in total_rules:
+            if rule.action.direction == UP:
+                assert rule.action.prefill_delta > 0
+                assert rule.action.decode_delta > 0
+
+
+class TestScalingModels:
+    """Tests for Pydantic models."""
+
+    def test_scaling_trigger_model(self) -> None:
+        trigger = ScalingTrigger(
+            metric="ttft_p95_ms", threshold=400.0,
+            comparator="gte",
+        )
+        assert trigger.sustained_seconds == 60
+
+    def test_scaling_action_model(self) -> None:
+        action = ScalingAction(
+            direction=ScalingDirection.SCALE_UP, prefill_delta=1,
+        )
+        assert action.decode_delta == 0
+
+    def test_scaling_rule_model(self) -> None:
+        rule = ScalingRule(
+            name="test",
+            trigger=ScalingTrigger(
+                metric="ttft_p95_ms", threshold=400.0,
+                comparator="gte",
+            ),
+            action=ScalingAction(
+                direction=ScalingDirection.SCALE_UP,
+                prefill_delta=1,
+            ),
+        )
+        assert rule.priority == 1
+
+    def test_policy_serialization(self) -> None:
+        data = [_make_benchmark(qps=10.0, num_prefill=2, num_decode=2)]
+        gen = ScalingPolicyGenerator(data)
+        policy = gen.generate()
+        d = policy.model_dump()
+        assert "rules" in d
+        assert "cooldown_seconds" in d
+        policy2 = ScalingPolicy.model_validate(d)
+        assert len(policy2.rules) == len(policy.rules)
+
+
+class TestGenerateScalingPolicyAPI:
+    """Tests for programmatic API."""
+
+    def test_api_returns_dict(self, tmp_path: Path) -> None:
+        bm = _make_benchmark(qps=10.0, num_prefill=2, num_decode=2)
+        f = tmp_path / "bench.json"
+        f.write_text(bm.model_dump_json())
+        result = generate_scaling_policy([str(f)])
+        assert isinstance(result, dict)
+        assert "rules" in result
+
+    def test_api_with_custom_sla(self, tmp_path: Path) -> None:
+        bm = _make_benchmark(qps=10.0, num_prefill=2, num_decode=2)
+        f = tmp_path / "bench.json"
+        f.write_text(bm.model_dump_json())
+        result = generate_scaling_policy(
+            [str(f)], sla_ttft_ms=200.0,
+        )
+        assert isinstance(result, dict)


### PR DESCRIPTION
## Summary

Implement M95: Auto-Scaling Policy Generator — generates scaling rules from benchmark data that map observed latency metrics to prefill/decode instance scaling actions.

Closes #210

## Changes

- `ScalingPolicyGenerator` class in `scaling_policy.py`
- Pydantic models: `ScalingPolicy`, `ScalingRule`, `ScalingTrigger`, `ScalingAction`, `ScalingDirection`, `PolicyFormat`
- Scale-up rules: TTFT→add prefill (80% SLA warning), TPOT→add decode, total→add both (90% critical)
- Scale-down rules: when latency ≤40% of SLA for sustained period
- Cooldown period and evaluation interval recommendations
- CLI `scaling-policy` subcommand with table + JSON output
- Programmatic `generate_scaling_policy()` API
- 21 new tests
- Mark M94 as complete in ROADMAP.md