### PR TITLE
feat: M96 Benchmark Session Manager

### DIFF
--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -1212,3 +1212,19 @@ __all__ += [
     "ParquetExportResult",
     "export_parquet",
 ]
+
+from xpyd_plan.session import (  # noqa: E402
+    Session,
+    SessionEntry,
+    SessionManager,
+    SessionReport,
+    manage_session,
+)
+
+__all__ += [
+    "Session",
+    "SessionEntry",
+    "SessionManager",
+    "SessionReport",
+    "manage_session",
+]

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -70,6 +70,7 @@ from xpyd_plan.cli._saturation import _cmd_saturation, add_saturation_parser
 from xpyd_plan.cli._scaling import _cmd_scaling, add_scaling_parser
 from xpyd_plan.cli._scaling_policy import add_scaling_policy_parser
 from xpyd_plan.cli._scorecard import _cmd_scorecard, add_scorecard_parser
+from xpyd_plan.cli._session import _cmd_session
 from xpyd_plan.cli._size_distribution import _cmd_size_distribution, add_size_distribution_parser
 from xpyd_plan.cli._sla_tier import add_sla_tier_parser
 from xpyd_plan.cli._spike import add_spike_parser
@@ -1004,6 +1005,40 @@ def main(argv: list[str] | None = None) -> None:
     add_plugins_subcommand(subparsers)
 
     # Let plugins register their own CLI subcommands
+        # --- session subcommand ---
+    session_parser = subparsers.add_parser(
+        "session",
+        help="Manage benchmark sessions (group related benchmark files)",
+    )
+    session_parser.add_argument(
+        "session_action", choices=["create", "add", "list", "show", "delete", "remove"],
+        help="Session action",
+    )
+    session_parser.add_argument(
+        "--name", type=str, default=None,
+        help="Session name",
+    )
+    session_parser.add_argument(
+        "--description", type=str, default=None,
+        help="Session description (for 'create')",
+    )
+    session_parser.add_argument(
+        "--tags", type=str, default=None,
+        help="Comma-separated tags (for 'create')",
+    )
+    session_parser.add_argument(
+        "--benchmark", type=str, default=None,
+        help="Path to benchmark JSON file (for 'add' and 'remove')",
+    )
+    session_parser.add_argument(
+        "--db", type=str, default=None,
+        help="Path to session SQLite database (default: xpyd-plan-sessions.db)",
+    )
+    session_parser.add_argument(
+        "--output-format", type=str, choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
+
     from xpyd_plan.plugin import get_registry
 
     get_registry().register_all_cli(subparsers)
@@ -1163,6 +1198,8 @@ def main(argv: list[str] | None = None) -> None:
     elif args.command == "scaling-policy":
         from xpyd_plan.cli._scaling_policy import _cmd_scaling_policy
         _cmd_scaling_policy(args)
+    elif args.command == "session":
+        _cmd_session(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/cli/_session.py
+++ b/src/xpyd_plan/cli/_session.py
@@ -1,0 +1,153 @@
+"""CLI session command."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+
+def _cmd_session(args: argparse.Namespace) -> None:
+    """Handle the 'session' subcommand."""
+    from xpyd_plan.session import SessionManager
+
+    console = Console()
+    db_path = args.db or "xpyd-plan-sessions.db"
+    mgr = SessionManager(db_path=db_path)
+
+    try:
+        if args.session_action == "create":
+            if not args.name:
+                console.print("[red]Error: --name is required for 'create'[/red]")
+                sys.exit(1)
+            tags = [t.strip() for t in args.tags.split(",")] if args.tags else []
+            session = mgr.create(
+                name=args.name,
+                description=args.description or "",
+                tags=tags,
+            )
+            if args.output_format == "json":
+                print(session.model_dump_json(indent=2))
+            else:
+                console.print(
+                    f"[green]✅ Created session #{session.id}:[/green] {session.name}"
+                )
+
+        elif args.session_action == "add":
+            if not args.name or not args.benchmark:
+                console.print("[red]Error: --name and --benchmark required for 'add'[/red]")
+                sys.exit(1)
+            entry = mgr.add(session_name=args.name, benchmark_path=args.benchmark)
+            if args.output_format == "json":
+                print(entry.model_dump_json(indent=2))
+            else:
+                console.print(
+                    f"[green]✅ Added to '{args.name}':[/green] "
+                    f"{entry.benchmark_path} ({entry.num_requests} requests, "
+                    f"QPS={entry.measured_qps:.1f})"
+                )
+
+        elif args.session_action == "list":
+            sessions = mgr.list_sessions()
+            if args.output_format == "json":
+                import json
+
+                print(json.dumps([s.model_dump() for s in sessions], indent=2))
+                return
+
+            if not sessions:
+                console.print("[dim]No sessions found.[/dim]")
+                return
+
+            table = Table(title="Benchmark Sessions")
+            table.add_column("ID", justify="right")
+            table.add_column("Name", style="cyan")
+            table.add_column("Description")
+            table.add_column("Tags", style="green")
+            table.add_column("Files", justify="right")
+            table.add_column("Total Requests", justify="right")
+
+            for s in sessions:
+                total_reqs = sum(e.num_requests for e in s.entries)
+                table.add_row(
+                    str(s.id),
+                    s.name,
+                    s.description or "-",
+                    ", ".join(s.tags) if s.tags else "-",
+                    str(len(s.entries)),
+                    str(total_reqs),
+                )
+            console.print(table)
+
+        elif args.session_action == "show":
+            if not args.name:
+                console.print("[red]Error: --name is required for 'show'[/red]")
+                sys.exit(1)
+            session = mgr.show(args.name)
+            if args.output_format == "json":
+                print(session.model_dump_json(indent=2))
+                return
+
+            console.print(f"\n[bold]📋 Session: {session.name}[/bold]")
+            if session.description:
+                console.print(f"  Description: {session.description}")
+            if session.tags:
+                console.print(f"  Tags: {', '.join(session.tags)}")
+            console.print(f"  Files: {len(session.entries)}")
+
+            if session.entries:
+                table = Table(title="Benchmark Files")
+                table.add_column("ID", justify="right")
+                table.add_column("Path", style="cyan")
+                table.add_column("Requests", justify="right")
+                table.add_column("QPS", justify="right")
+                table.add_column("Config", style="green")
+
+                for e in session.entries:
+                    table.add_row(
+                        str(e.id),
+                        e.benchmark_path,
+                        str(e.num_requests),
+                        f"{e.measured_qps:.1f}",
+                        f"{e.num_prefill}P:{e.num_decode}D",
+                    )
+                console.print(table)
+
+        elif args.session_action == "delete":
+            if not args.name:
+                console.print("[red]Error: --name is required for 'delete'[/red]")
+                sys.exit(1)
+            mgr.delete(args.name)
+            if args.output_format == "json":
+                import json
+
+                print(json.dumps({"deleted": args.name}))
+            else:
+                console.print(f"[green]✅ Deleted session '{args.name}'[/green]")
+
+        elif args.session_action == "remove":
+            if not args.name or not args.benchmark:
+                console.print(
+                    "[red]Error: --name and --benchmark required for 'remove'[/red]"
+                )
+                sys.exit(1)
+            mgr.remove(session_name=args.name, benchmark_path=args.benchmark)
+            if args.output_format == "json":
+                import json
+
+                print(json.dumps({"removed": args.benchmark, "session": args.name}))
+            else:
+                console.print(
+                    f"[green]✅ Removed '{args.benchmark}' from '{args.name}'[/green]"
+                )
+
+        else:
+            console.print(
+                "[red]Error: specify 'create', 'add', 'list',"
+                " 'show', 'delete', or 'remove'[/red]"
+            )
+            sys.exit(1)
+    finally:
+        mgr.close()

--- a/src/xpyd_plan/session.py
+++ b/src/xpyd_plan/session.py
@@ -1,0 +1,358 @@
+"""Benchmark session manager with SQLite-backed storage.
+
+Organize benchmark files into named sessions with metadata,
+enabling logical grouping of related experiments.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+
+
+class SessionEntry(BaseModel):
+    """A benchmark file within a session."""
+
+    id: int | None = Field(None, description="Auto-assigned row ID")
+    session_id: int = Field(..., description="Parent session ID")
+    benchmark_path: str = Field(..., description="Path to benchmark JSON file")
+    added_at: float = Field(..., description="Unix timestamp when added")
+    num_requests: int = Field(..., ge=0, description="Number of requests in benchmark")
+    measured_qps: float = Field(..., ge=0, description="Measured QPS")
+    num_prefill: int = Field(..., ge=1, description="Prefill instance count")
+    num_decode: int = Field(..., ge=1, description="Decode instance count")
+
+
+class Session(BaseModel):
+    """A named benchmark session."""
+
+    id: int | None = Field(None, description="Auto-assigned session ID")
+    name: str = Field(..., description="Session name")
+    description: str = Field("", description="Optional description")
+    tags: list[str] = Field(default_factory=list, description="Tags for filtering")
+    created_at: float = Field(..., description="Unix timestamp when created")
+    entries: list[SessionEntry] = Field(default_factory=list, description="Benchmark entries")
+
+
+class SessionReport(BaseModel):
+    """Summary report of sessions."""
+
+    sessions: list[Session] = Field(default_factory=list)
+    total_sessions: int = Field(0, description="Total number of sessions")
+    total_benchmarks: int = Field(0, description="Total benchmark files across all sessions")
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL DEFAULT '',
+    tags TEXT NOT NULL DEFAULT '[]',
+    created_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS session_entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    benchmark_path TEXT NOT NULL,
+    added_at REAL NOT NULL,
+    num_requests INTEGER NOT NULL,
+    measured_qps REAL NOT NULL,
+    num_prefill INTEGER NOT NULL,
+    num_decode INTEGER NOT NULL
+);
+"""
+
+
+class SessionManager:
+    """Manage benchmark sessions with SQLite storage."""
+
+    def __init__(self, db_path: str | Path = "xpyd-plan-sessions.db") -> None:
+        self._db_path = str(db_path)
+        self._conn = sqlite3.connect(self._db_path)
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self._conn.close()
+
+    def create(
+        self,
+        name: str,
+        description: str = "",
+        tags: list[str] | None = None,
+    ) -> Session:
+        """Create a new session.
+
+        Args:
+            name: Unique session name.
+            description: Optional description.
+            tags: Optional tags for filtering.
+
+        Returns:
+            The created Session.
+
+        Raises:
+            ValueError: If a session with the same name already exists.
+        """
+        tags = tags or []
+        now = time.time()
+        try:
+            cur = self._conn.execute(
+                "INSERT INTO sessions (name, description, tags, created_at) VALUES (?, ?, ?, ?)",
+                (name, description, json.dumps(tags), now),
+            )
+            self._conn.commit()
+        except sqlite3.IntegrityError:
+            raise ValueError(f"Session '{name}' already exists")
+        return Session(
+            id=cur.lastrowid,
+            name=name,
+            description=description,
+            tags=tags,
+            created_at=now,
+        )
+
+    def add(self, session_name: str, benchmark_path: str | Path) -> SessionEntry:
+        """Add a benchmark file to a session.
+
+        Args:
+            session_name: Name of the session.
+            benchmark_path: Path to benchmark JSON file.
+
+        Returns:
+            The created SessionEntry.
+
+        Raises:
+            ValueError: If session not found or file already in session.
+        """
+        session_id = self._get_session_id(session_name)
+        path_str = str(Path(benchmark_path).resolve())
+
+        # Check for duplicate
+        row = self._conn.execute(
+            "SELECT id FROM session_entries WHERE session_id = ? AND benchmark_path = ?",
+            (session_id, path_str),
+        ).fetchone()
+        if row is not None:
+            raise ValueError(f"Benchmark '{path_str}' already in session '{session_name}'")
+
+        # Load and extract metadata
+        data = load_benchmark_auto(path_str)
+        now = time.time()
+        cur = self._conn.execute(
+            "INSERT INTO session_entries "
+            "(session_id, benchmark_path, added_at, num_requests, measured_qps, "
+            "num_prefill, num_decode) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                session_id,
+                path_str,
+                now,
+                len(data.requests),
+                data.metadata.measured_qps,
+                data.metadata.num_prefill_instances,
+                data.metadata.num_decode_instances,
+            ),
+        )
+        self._conn.commit()
+        return SessionEntry(
+            id=cur.lastrowid,
+            session_id=session_id,
+            benchmark_path=path_str,
+            added_at=now,
+            num_requests=len(data.requests),
+            measured_qps=data.metadata.measured_qps,
+            num_prefill=data.metadata.num_prefill_instances,
+            num_decode=data.metadata.num_decode_instances,
+        )
+
+    def remove(self, session_name: str, benchmark_path: str | Path) -> None:
+        """Remove a benchmark file from a session.
+
+        Args:
+            session_name: Name of the session.
+            benchmark_path: Path to benchmark JSON file.
+
+        Raises:
+            ValueError: If session or entry not found.
+        """
+        session_id = self._get_session_id(session_name)
+        path_str = str(Path(benchmark_path).resolve())
+        cur = self._conn.execute(
+            "DELETE FROM session_entries WHERE session_id = ? AND benchmark_path = ?",
+            (session_id, path_str),
+        )
+        self._conn.commit()
+        if cur.rowcount == 0:
+            raise ValueError(f"Benchmark '{path_str}' not found in session '{session_name}'")
+
+    def list_sessions(self) -> list[Session]:
+        """List all sessions with their entries.
+
+        Returns:
+            List of Session objects.
+        """
+        rows = self._conn.execute(
+            "SELECT id, name, description, tags, created_at FROM sessions ORDER BY created_at"
+        ).fetchall()
+        sessions = []
+        for row in rows:
+            session_id, name, description, tags_json, created_at = row
+            entries = self._get_entries(session_id)
+            sessions.append(
+                Session(
+                    id=session_id,
+                    name=name,
+                    description=description,
+                    tags=json.loads(tags_json),
+                    created_at=created_at,
+                    entries=entries,
+                )
+            )
+        return sessions
+
+    def show(self, session_name: str) -> Session:
+        """Show a single session with its entries.
+
+        Args:
+            session_name: Name of the session.
+
+        Returns:
+            Session with entries populated.
+
+        Raises:
+            ValueError: If session not found.
+        """
+        session_id = self._get_session_id(session_name)
+        row = self._conn.execute(
+            "SELECT id, name, description, tags, created_at FROM sessions WHERE id = ?",
+            (session_id,),
+        ).fetchone()
+        entries = self._get_entries(session_id)
+        return Session(
+            id=row[0],
+            name=row[1],
+            description=row[2],
+            tags=json.loads(row[3]),
+            created_at=row[4],
+            entries=entries,
+        )
+
+    def delete(self, session_name: str) -> None:
+        """Delete a session and all its entries.
+
+        Args:
+            session_name: Name of the session.
+
+        Raises:
+            ValueError: If session not found.
+        """
+        session_id = self._get_session_id(session_name)
+        self._conn.execute("DELETE FROM session_entries WHERE session_id = ?", (session_id,))
+        self._conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
+        self._conn.commit()
+
+    def _get_session_id(self, name: str) -> int:
+        """Get session ID by name, raise if not found."""
+        row = self._conn.execute(
+            "SELECT id FROM sessions WHERE name = ?", (name,)
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"Session '{name}' not found")
+        return row[0]
+
+    def _get_entries(self, session_id: int) -> list[SessionEntry]:
+        """Get all entries for a session."""
+        rows = self._conn.execute(
+            "SELECT id, session_id, benchmark_path, added_at, num_requests, "
+            "measured_qps, num_prefill, num_decode "
+            "FROM session_entries WHERE session_id = ? ORDER BY added_at",
+            (session_id,),
+        ).fetchall()
+        return [
+            SessionEntry(
+                id=r[0],
+                session_id=r[1],
+                benchmark_path=r[2],
+                added_at=r[3],
+                num_requests=r[4],
+                measured_qps=r[5],
+                num_prefill=r[6],
+                num_decode=r[7],
+            )
+            for r in rows
+        ]
+
+
+def manage_session(
+    action: str,
+    db_path: str | Path = "xpyd-plan-sessions.db",
+    name: str | None = None,
+    description: str = "",
+    tags: list[str] | None = None,
+    benchmark_path: str | Path | None = None,
+) -> Session | list[Session] | SessionReport | None:
+    """Programmatic API for session management.
+
+    Args:
+        action: One of 'create', 'add', 'remove', 'list', 'show', 'delete'.
+        db_path: Path to SQLite database.
+        name: Session name (required for all actions except 'list').
+        description: Session description (for 'create').
+        tags: Session tags (for 'create').
+        benchmark_path: Benchmark file path (for 'add' and 'remove').
+
+    Returns:
+        Depends on action:
+        - create: Session
+        - add: Session (updated)
+        - remove: None
+        - list: SessionReport
+        - show: Session
+        - delete: None
+    """
+    mgr = SessionManager(db_path=db_path)
+    try:
+        if action == "create":
+            if name is None:
+                raise ValueError("name is required for 'create'")
+            return mgr.create(name=name, description=description, tags=tags)
+        elif action == "add":
+            if name is None or benchmark_path is None:
+                raise ValueError("name and benchmark_path are required for 'add'")
+            mgr.add(session_name=name, benchmark_path=benchmark_path)
+            return mgr.show(name)
+        elif action == "remove":
+            if name is None or benchmark_path is None:
+                raise ValueError("name and benchmark_path are required for 'remove'")
+            mgr.remove(session_name=name, benchmark_path=benchmark_path)
+            return None
+        elif action == "list":
+            sessions = mgr.list_sessions()
+            total_benchmarks = sum(len(s.entries) for s in sessions)
+            return SessionReport(
+                sessions=sessions,
+                total_sessions=len(sessions),
+                total_benchmarks=total_benchmarks,
+            )
+        elif action == "show":
+            if name is None:
+                raise ValueError("name is required for 'show'")
+            return mgr.show(name)
+        elif action == "delete":
+            if name is None:
+                raise ValueError("name is required for 'delete'")
+            mgr.delete(name)
+            return None
+        else:
+            raise ValueError(f"Unknown action: {action}")
+    finally:
+        mgr.close()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,274 @@
+"""Tests for benchmark session manager module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.session import Session, SessionEntry, SessionManager, SessionReport, manage_session
+
+
+def _make_benchmark(
+    qps: float = 100.0,
+    num_prefill: int = 2,
+    num_decode: int = 2,
+    num_requests: int = 50,
+) -> BenchmarkData:
+    """Generate synthetic benchmark data."""
+    requests = []
+    for i in range(num_requests):
+        factor = 1.0 + (i % 10) * 0.05
+        requests.append(
+            BenchmarkRequest(
+                request_id=f"req-{i}",
+                prompt_tokens=100 + i,
+                output_tokens=50 + i,
+                ttft_ms=10.0 * factor,
+                tpot_ms=5.0 * factor,
+                total_latency_ms=100.0 * factor,
+                timestamp=1000000.0 + i,
+            )
+        )
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=num_prefill,
+            num_decode_instances=num_decode,
+            total_instances=num_prefill + num_decode,
+            measured_qps=qps,
+        ),
+        requests=requests,
+    )
+
+
+def _write_benchmark(tmp_path: Path, name: str = "bench.json", **kwargs) -> Path:
+    """Write a benchmark file and return its path."""
+    data = _make_benchmark(**kwargs)
+    p = tmp_path / name
+    p.write_text(data.model_dump_json(indent=2))
+    return p
+
+
+class TestSessionManager:
+    """Test SessionManager core functionality."""
+
+    def test_create_session(self) -> None:
+        mgr = SessionManager(":memory:")
+        session = mgr.create("experiment-1", description="First experiment", tags=["h100"])
+        assert session.id is not None
+        assert session.name == "experiment-1"
+        assert session.description == "First experiment"
+        assert session.tags == ["h100"]
+        mgr.close()
+
+    def test_create_duplicate_raises(self) -> None:
+        mgr = SessionManager(":memory:")
+        mgr.create("exp-1")
+        with pytest.raises(ValueError, match="already exists"):
+            mgr.create("exp-1")
+        mgr.close()
+
+    def test_add_benchmark(self, tmp_path: Path) -> None:
+        mgr = SessionManager(":memory:")
+        mgr.create("exp-1")
+        bench_path = _write_benchmark(tmp_path)
+        entry = mgr.add("exp-1", bench_path)
+        assert entry.id is not None
+        assert entry.num_requests == 50
+        assert entry.measured_qps == 100.0
+        assert entry.num_prefill == 2
+        assert entry.num_decode == 2
+        mgr.close()
+
+    def test_add_duplicate_benchmark_raises(self, tmp_path: Path) -> None:
+        mgr = SessionManager(":memory:")
+        mgr.create("exp-1")
+        bench_path = _write_benchmark(tmp_path)
+        mgr.add("exp-1", bench_path)
+        with pytest.raises(ValueError, match="already in session"):
+            mgr.add("exp-1", bench_path)
+        mgr.close()
+
+    def test_add_to_nonexistent_session_raises(self, tmp_path: Path) -> None:
+        mgr = SessionManager(":memory:")
+        bench_path = _write_benchmark(tmp_path)
+        with pytest.raises(ValueError, match="not found"):
+            mgr.add("nonexistent", bench_path)
+        mgr.close()
+
+    def test_remove_benchmark(self, tmp_path: Path) -> None:
+        mgr = SessionManager(":memory:")
+        mgr.create("exp-1")
+        bench_path = _write_benchmark(tmp_path)
+        mgr.add("exp-1", bench_path)
+        mgr.remove("exp-1", bench_path)
+        session = mgr.show("exp-1")
+        assert len(session.entries) == 0
+        mgr.close()
+
+    def test_remove_nonexistent_raises(self, tmp_path: Path) -> None:
+        mgr = SessionManager(":memory:")
+        mgr.create("exp-1")
+        with pytest.raises(ValueError, match="not found"):
+            mgr.remove("exp-1", "/fake/path.json")
+        mgr.close()
+
+    def test_list_sessions(self) -> None:
+        mgr = SessionManager(":memory:")
+        mgr.create("exp-1", tags=["a"])
+        mgr.create("exp-2", tags=["b"])
+        sessions = mgr.list_sessions()
+        assert len(sessions) == 2
+        assert sessions[0].name == "exp-1"
+        assert sessions[1].name == "exp-2"
+        mgr.close()
+
+    def test_list_sessions_empty(self) -> None:
+        mgr = SessionManager(":memory:")
+        sessions = mgr.list_sessions()
+        assert sessions == []
+        mgr.close()
+
+    def test_show_session(self, tmp_path: Path) -> None:
+        mgr = SessionManager(":memory:")
+        mgr.create("exp-1", description="Test")
+        bench1 = _write_benchmark(tmp_path, "b1.json", qps=100)
+        bench2 = _write_benchmark(tmp_path, "b2.json", qps=200)
+        mgr.add("exp-1", bench1)
+        mgr.add("exp-1", bench2)
+        session = mgr.show("exp-1")
+        assert session.name == "exp-1"
+        assert session.description == "Test"
+        assert len(session.entries) == 2
+        mgr.close()
+
+    def test_show_nonexistent_raises(self) -> None:
+        mgr = SessionManager(":memory:")
+        with pytest.raises(ValueError, match="not found"):
+            mgr.show("nope")
+        mgr.close()
+
+    def test_delete_session(self, tmp_path: Path) -> None:
+        mgr = SessionManager(":memory:")
+        mgr.create("exp-1")
+        bench_path = _write_benchmark(tmp_path)
+        mgr.add("exp-1", bench_path)
+        mgr.delete("exp-1")
+        sessions = mgr.list_sessions()
+        assert len(sessions) == 0
+        mgr.close()
+
+    def test_delete_nonexistent_raises(self) -> None:
+        mgr = SessionManager(":memory:")
+        with pytest.raises(ValueError, match="not found"):
+            mgr.delete("nope")
+        mgr.close()
+
+    def test_multiple_benchmarks_in_session(self, tmp_path: Path) -> None:
+        mgr = SessionManager(":memory:")
+        mgr.create("multi")
+        for i in range(5):
+            p = _write_benchmark(tmp_path, f"b{i}.json", qps=100 + i * 10)
+            mgr.add("multi", p)
+        session = mgr.show("multi")
+        assert len(session.entries) == 5
+        mgr.close()
+
+    def test_session_tags_preserved(self) -> None:
+        mgr = SessionManager(":memory:")
+        mgr.create("tagged", tags=["h100", "nightly", "v2.0"])
+        session = mgr.show("tagged")
+        assert session.tags == ["h100", "nightly", "v2.0"]
+        mgr.close()
+
+
+class TestSessionModels:
+    """Test Pydantic model validation."""
+
+    def test_session_entry_model(self) -> None:
+        entry = SessionEntry(
+            session_id=1,
+            benchmark_path="/tmp/bench.json",
+            added_at=1000.0,
+            num_requests=100,
+            measured_qps=50.0,
+            num_prefill=2,
+            num_decode=3,
+        )
+        assert entry.session_id == 1
+        assert entry.num_requests == 100
+
+    def test_session_model(self) -> None:
+        session = Session(
+            name="test",
+            created_at=1000.0,
+            tags=["a", "b"],
+        )
+        assert session.name == "test"
+        assert session.tags == ["a", "b"]
+        assert session.entries == []
+
+    def test_session_report_model(self) -> None:
+        report = SessionReport(total_sessions=2, total_benchmarks=5)
+        assert report.total_sessions == 2
+        assert report.total_benchmarks == 5
+
+    def test_session_json_roundtrip(self) -> None:
+        session = Session(name="rt", created_at=1000.0, description="desc", tags=["x"])
+        dumped = session.model_dump_json()
+        loaded = Session.model_validate_json(dumped)
+        assert loaded.name == "rt"
+        assert loaded.tags == ["x"]
+
+
+class TestManageSessionAPI:
+    """Test the programmatic API."""
+
+    def test_create_via_api(self, tmp_path: Path) -> None:
+        db = tmp_path / "test.db"
+        result = manage_session("create", db_path=db, name="api-test", tags=["tag1"])
+        assert isinstance(result, Session)
+        assert result.name == "api-test"
+
+    def test_list_via_api(self, tmp_path: Path) -> None:
+        db = tmp_path / "test.db"
+        manage_session("create", db_path=db, name="s1")
+        manage_session("create", db_path=db, name="s2")
+        result = manage_session("list", db_path=db)
+        assert isinstance(result, SessionReport)
+        assert result.total_sessions == 2
+
+    def test_add_and_show_via_api(self, tmp_path: Path) -> None:
+        db = tmp_path / "test.db"
+        bench = _write_benchmark(tmp_path, "b.json")
+        manage_session("create", db_path=db, name="s1")
+        result = manage_session("add", db_path=db, name="s1", benchmark_path=bench)
+        assert isinstance(result, Session)
+        assert len(result.entries) == 1
+
+    def test_delete_via_api(self, tmp_path: Path) -> None:
+        db = tmp_path / "test.db"
+        manage_session("create", db_path=db, name="s1")
+        result = manage_session("delete", db_path=db, name="s1")
+        assert result is None
+        report = manage_session("list", db_path=db)
+        assert report.total_sessions == 0
+
+    def test_remove_via_api(self, tmp_path: Path) -> None:
+        db = tmp_path / "test.db"
+        bench = _write_benchmark(tmp_path, "b.json")
+        manage_session("create", db_path=db, name="s1")
+        manage_session("add", db_path=db, name="s1", benchmark_path=bench)
+        result = manage_session("remove", db_path=db, name="s1", benchmark_path=bench)
+        assert result is None
+
+    def test_unknown_action_raises(self, tmp_path: Path) -> None:
+        db = tmp_path / "test.db"
+        with pytest.raises(ValueError, match="Unknown action"):
+            manage_session("invalid", db_path=db)
+
+    def test_create_missing_name_raises(self, tmp_path: Path) -> None:
+        db = tmp_path / "test.db"
+        with pytest.raises(ValueError, match="name is required"):
+            manage_session("create", db_path=db)


### PR DESCRIPTION
## M96: Benchmark Session Manager

### Changes
- `SessionManager` class in `session.py` with SQLite-backed storage (reuses pattern from TrendTracker)
- `Session`, `SessionEntry`, `SessionReport` Pydantic models
- Create/add/remove/list/show/delete session operations
- CLI `session` subcommand with table + JSON output
- Programmatic `manage_session()` API
- 26 new tests (2151 total, all passing)
- Lint clean: `ruff check` + `isort --check` pass

Closes #212