### PR TITLE
feat: M99 Latency Variance Decomposition

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1313,7 +1313,9 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Programmatic `fingerprint_benchmark()` API
 - 18 new tests
 
-### M98 — Latency Budget Tracker
+### M98 ✅ Latency Budget Tracker
+
+*Completed — PR #217*
 
 - `LatencyBudgetTracker` class in `budget_tracker.py`
 - `BudgetReport`, `RequestBudget`, `BudgetDistribution`, `BudgetAlert`, `BudgetStatus` Pydantic models
@@ -1325,3 +1327,19 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `budget-tracker` subcommand with `--benchmark`, `--sla-ttft`, `--sla-tpot`, `--sla-total`, `--near-miss-threshold`, `--top-n`, table + JSON output
 - Programmatic `track_latency_budget()` API
 - 22 new tests
+
+### M99 — Latency Variance Decomposition
+
+- `VarianceDecomposer` class in `variance_decomp.py`
+- `VarianceReport`, `MetricDecomposition`, `VarianceComponent`, `ComponentSignificance` Pydantic models
+- Sequential OLS regression to attribute total latency variance to:
+  - prompt_tokens: variance explained by prompt size
+  - output_tokens: variance explained by output size
+  - temporal: variance explained by request timing
+  - residual: unexplained variance
+- Per-component contribution percentage and significance classification (DOMINANT/SIGNIFICANT/MINOR/NEGLIGIBLE)
+- R² of full model per metric
+- Dominant factor identification
+- CLI `variance` subcommand with `--benchmark`, `--temporal-bins`, table + JSON output
+- Programmatic `decompose_variance()` API
+- 21 new tests

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -1266,3 +1266,21 @@ __all__ += [
     "RequestBudget",
     "track_latency_budget",
 ]
+
+from xpyd_plan.variance_decomp import (  # noqa: E402
+    ComponentSignificance,
+    MetricDecomposition,
+    VarianceComponent,
+    VarianceDecomposer,
+    VarianceReport,
+    decompose_variance,
+)
+
+__all__ += [
+    "ComponentSignificance",
+    "MetricDecomposition",
+    "VarianceComponent",
+    "VarianceDecomposer",
+    "VarianceReport",
+    "decompose_variance",
+]

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -87,6 +87,7 @@ from xpyd_plan.cli._token_budget import add_token_budget_parser
 from xpyd_plan.cli._token_efficiency import add_token_efficiency_parser, handle_token_efficiency
 from xpyd_plan.cli._trend import _cmd_trend
 from xpyd_plan.cli._validate import _cmd_validate
+from xpyd_plan.cli._variance import _cmd_variance, add_variance_parser
 from xpyd_plan.cli._warmup_filter import _cmd_warmup_filter, add_warmup_filter_parser
 from xpyd_plan.cli._weighted_goodput import register as _register_weighted_goodput
 from xpyd_plan.cli._whatif import _cmd_what_if
@@ -917,6 +918,9 @@ def main(argv: list[str] | None = None) -> None:
 
     # --- correlation subcommand ---
     add_correlation_parser(subparsers)
+
+    # --- variance subcommand ---
+    add_variance_parser(subparsers)
     add_jitter_parser(subparsers)
     add_cold_start_parser(subparsers)
     add_dedup_parser(subparsers)
@@ -1258,6 +1262,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_fingerprint(args)
     elif args.command == "budget-tracker":
         _cmd_budget_tracker(args)
+    elif args.command == "variance":
+        _cmd_variance(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/cli/_variance.py
+++ b/src/xpyd_plan/cli/_variance.py
@@ -1,0 +1,89 @@
+"""CLI variance command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.bench_adapter import load_benchmark_auto
+from xpyd_plan.variance_decomp import ComponentSignificance, VarianceDecomposer
+
+
+def _cmd_variance(args: argparse.Namespace) -> None:
+    """Handle the 'variance' subcommand."""
+    console = Console()
+
+    data = load_benchmark_auto(args.benchmark)
+    decomposer = VarianceDecomposer(n_temporal_bins=getattr(args, "temporal_bins", 10))
+    report = decomposer.decompose(data)
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(report.model_dump(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+
+    # Table output
+    for metric_decomp in report.metrics:
+        table = Table(title=f"Variance Decomposition — {metric_decomp.metric}")
+        table.add_column("Component", justify="left")
+        table.add_column("Sum of Squares", justify="right")
+        table.add_column("Contribution %", justify="right")
+        table.add_column("Significance", justify="center")
+
+        for comp in metric_decomp.components:
+            style = {
+                ComponentSignificance.DOMINANT: "bold red",
+                ComponentSignificance.SIGNIFICANT: "yellow",
+                ComponentSignificance.MINOR: "dim",
+                ComponentSignificance.NEGLIGIBLE: "dim",
+            }[comp.significance]
+
+            table.add_row(
+                comp.name,
+                f"{comp.sum_of_squares:,.2f}",
+                f"[{style}]{comp.contribution_pct:.1f}%[/{style}]",
+                f"[{style}]{comp.significance.value}[/{style}]",
+            )
+
+        console.print(table)
+        if metric_decomp.dominant_factor:
+            console.print(
+                f"  Dominant factor: [bold]{metric_decomp.dominant_factor}[/bold]  "
+                f"R² = {metric_decomp.r_squared:.4f}"
+            )
+        else:
+            console.print(f"  No dominant factor  R² = {metric_decomp.r_squared:.4f}")
+        console.print()
+
+    console.print(f"[bold]{report.recommendation}[/bold]")
+
+
+def add_variance_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the variance subcommand parser."""
+    parser = subparsers.add_parser(
+        "variance",
+        help="Decompose latency variance into prompt, output, temporal, and residual components",
+    )
+    parser.add_argument(
+        "--benchmark",
+        required=True,
+        help="Path to benchmark JSON file",
+    )
+    parser.add_argument(
+        "--temporal-bins",
+        type=int,
+        default=10,
+        help="Number of temporal bins (default: 10)",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_variance)

--- a/src/xpyd_plan/variance_decomp.py
+++ b/src/xpyd_plan/variance_decomp.py
@@ -1,0 +1,317 @@
+"""Latency variance decomposition.
+
+Attribute variance to prompt size, output size, temporal, and residual.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData
+
+
+class ComponentSignificance(str, Enum):
+    """Significance classification based on contribution percentage."""
+
+    DOMINANT = "dominant"      # >= 40%
+    SIGNIFICANT = "significant"  # 15% <= x < 40%
+    MINOR = "minor"            # 5% <= x < 15%
+    NEGLIGIBLE = "negligible"  # < 5%
+
+
+class VarianceComponent(BaseModel):
+    """A single variance component."""
+
+    name: str = Field(..., description="Component name")
+    sum_of_squares: float = Field(..., ge=0, description="Type III sum of squares")
+    contribution_pct: float = Field(..., ge=0, le=100, description="Percentage of total variance")
+    significance: ComponentSignificance = Field(..., description="Significance classification")
+
+
+class MetricDecomposition(BaseModel):
+    """Variance decomposition for a single latency metric."""
+
+    metric: str = Field(..., description="Latency metric name")
+    total_variance: float = Field(..., ge=0, description="Total variance (sum of squares)")
+    components: list[VarianceComponent] = Field(..., description="Decomposed components")
+    dominant_factor: str | None = Field(None, description="Name of the dominant component")
+    r_squared: float = Field(..., ge=0, le=1, description="R² of the full model")
+
+
+class VarianceReport(BaseModel):
+    """Complete variance decomposition report."""
+
+    metrics: list[MetricDecomposition] = Field(..., description="Per-metric decomposition")
+    sample_size: int = Field(..., ge=1, description="Number of requests analyzed")
+    recommendation: str = Field(..., description="Actionable recommendation")
+
+
+def _classify_significance(pct: float) -> ComponentSignificance:
+    """Classify component significance from contribution percentage."""
+    if pct >= 40:
+        return ComponentSignificance.DOMINANT
+    if pct >= 15:
+        return ComponentSignificance.SIGNIFICANT
+    if pct >= 5:
+        return ComponentSignificance.MINOR
+    return ComponentSignificance.NEGLIGIBLE
+
+
+def _mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs)
+
+
+def _ss_total(ys: list[float]) -> float:
+    """Total sum of squares."""
+    m = _mean(ys)
+    return sum((y - m) ** 2 for y in ys)
+
+
+def _sequential_ss(
+    y: list[float],
+    predictors: list[tuple[str, list[float]]],
+    n_temporal_bins: int = 10,
+) -> list[tuple[str, float]]:
+    """Compute sequential (Type I) SS via manual OLS residuals.
+
+    Each predictor is added sequentially; the SS attributed to it is the
+    reduction in residual SS when it is added.
+
+    For simplicity we use univariate OLS at each step on residuals.
+    """
+    n = len(y)
+    residuals = list(y)  # start with raw values
+
+    results: list[tuple[str, float]] = []
+    for name, x in predictors:
+        # Fit simple OLS: residuals ~ x
+        mean_x = _mean(x)
+        mean_r = _mean(residuals)
+
+        cov = sum((xi - mean_x) * (ri - mean_r) for xi, ri in zip(x, residuals))
+        var_x = sum((xi - mean_x) ** 2 for xi in x)
+
+        if var_x == 0:
+            results.append((name, 0.0))
+            continue
+
+        slope = cov / var_x
+        intercept = mean_r - slope * mean_x
+
+        # Compute SS explained = SS_before - SS_after
+        ss_before = sum(r**2 for r in residuals) - n * mean_r**2
+        if ss_before < 0:
+            ss_before = sum((r - mean_r) ** 2 for r in residuals)
+
+        new_residuals = [r - (slope * xi + intercept) for r, xi in zip(residuals, x)]
+        mean_new = _mean(new_residuals)
+        ss_after = sum((r - mean_new) ** 2 for r in new_residuals)
+
+        ss_explained = max(0.0, ss_before - ss_after)
+        results.append((name, ss_explained))
+
+        residuals = new_residuals
+
+    return results
+
+
+def _build_temporal_feature(timestamps: list[float], n_bins: int = 10) -> list[float]:
+    """Convert timestamps to temporal bin indices (as floats for regression)."""
+    if not timestamps:
+        return []
+    t_min = min(timestamps)
+    t_max = max(timestamps)
+    t_range = t_max - t_min
+    if t_range == 0:
+        return [0.0] * len(timestamps)
+    return [((t - t_min) / t_range) * n_bins for t in timestamps]
+
+
+_LATENCY_METRICS = ["ttft_ms", "tpot_ms", "total_latency_ms"]
+
+
+class VarianceDecomposer:
+    """Decompose latency variance into prompt, output, temporal, and residual components."""
+
+    def __init__(self, n_temporal_bins: int = 10):
+        self._n_temporal_bins = n_temporal_bins
+
+    def decompose(self, data: BenchmarkData) -> VarianceReport:
+        """Decompose variance for all latency metrics.
+
+        Args:
+            data: Benchmark data with at least 3 requests.
+
+        Returns:
+            VarianceReport with per-metric decomposition.
+
+        Raises:
+            ValueError: If fewer than 3 requests.
+        """
+        if len(data.requests) < 3:
+            raise ValueError("Need at least 3 requests for variance decomposition")
+
+        n = len(data.requests)
+
+        # Extract vectors
+        prompt_tokens = [float(r.prompt_tokens) for r in data.requests]
+        output_tokens = [float(r.output_tokens) for r in data.requests]
+        timestamps = [r.timestamp for r in data.requests]
+        temporal = _build_temporal_feature(timestamps, self._n_temporal_bins)
+
+        latency_vectors = {
+            "ttft_ms": [r.ttft_ms for r in data.requests],
+            "tpot_ms": [r.tpot_ms for r in data.requests],
+            "total_latency_ms": [r.total_latency_ms for r in data.requests],
+        }
+
+        predictors = [
+            ("prompt_tokens", prompt_tokens),
+            ("output_tokens", output_tokens),
+            ("temporal", temporal),
+        ]
+
+        metrics: list[MetricDecomposition] = []
+        dominant_factors: list[str | None] = []
+
+        for metric_name in _LATENCY_METRICS:
+            y = latency_vectors[metric_name]
+            ss_tot = _ss_total(y)
+
+            if ss_tot == 0:
+                # Zero variance — all values identical
+                components = [
+                    VarianceComponent(
+                        name=name,
+                        sum_of_squares=0.0,
+                        contribution_pct=0.0,
+                        significance=ComponentSignificance.NEGLIGIBLE,
+                    )
+                    for name, _ in predictors
+                ]
+                components.append(
+                    VarianceComponent(
+                        name="residual",
+                        sum_of_squares=0.0,
+                        contribution_pct=0.0,
+                        significance=ComponentSignificance.NEGLIGIBLE,
+                    )
+                )
+                metrics.append(
+                    MetricDecomposition(
+                        metric=metric_name,
+                        total_variance=0.0,
+                        components=components,
+                        dominant_factor=None,
+                        r_squared=0.0,
+                    )
+                )
+                dominant_factors.append(None)
+                continue
+
+            seq_ss = _sequential_ss(y, predictors, self._n_temporal_bins)
+
+            explained_total = sum(ss for _, ss in seq_ss)
+            residual_ss = max(0.0, ss_tot - explained_total)
+
+            components: list[VarianceComponent] = []
+            for name, ss in seq_ss:
+                pct = (ss / ss_tot * 100) if ss_tot > 0 else 0.0
+                components.append(
+                    VarianceComponent(
+                        name=name,
+                        sum_of_squares=round(ss, 4),
+                        contribution_pct=round(pct, 2),
+                        significance=_classify_significance(pct),
+                    )
+                )
+
+            residual_pct = (residual_ss / ss_tot * 100) if ss_tot > 0 else 0.0
+            components.append(
+                VarianceComponent(
+                    name="residual",
+                    sum_of_squares=round(residual_ss, 4),
+                    contribution_pct=round(residual_pct, 2),
+                    significance=_classify_significance(residual_pct),
+                )
+            )
+
+            r_squared = explained_total / ss_tot if ss_tot > 0 else 0.0
+            r_squared = min(1.0, max(0.0, r_squared))
+
+            # Find dominant factor (excluding residual)
+            non_residual = [c for c in components if c.name != "residual"]
+            dominant = max(non_residual, key=lambda c: c.contribution_pct) if non_residual else None
+            dominant_name = dominant.name if dominant and dominant.contribution_pct >= 15 else None
+
+            metrics.append(
+                MetricDecomposition(
+                    metric=metric_name,
+                    total_variance=round(ss_tot, 4),
+                    components=components,
+                    dominant_factor=dominant_name,
+                    r_squared=round(r_squared, 4),
+                )
+            )
+            dominant_factors.append(dominant_name)
+
+        # Build recommendation
+        recommendation = _build_recommendation(metrics)
+
+        return VarianceReport(
+            metrics=metrics,
+            sample_size=n,
+            recommendation=recommendation,
+        )
+
+
+def _build_recommendation(metrics: list[MetricDecomposition]) -> str:
+    """Generate actionable recommendation from decomposition results."""
+    # Collect dominant factors across metrics
+    dominant_set: set[str] = set()
+    for m in metrics:
+        if m.dominant_factor:
+            dominant_set.add(m.dominant_factor)
+
+    if not dominant_set:
+        return (
+            "No single factor dominates latency variance. "
+            "Variance is spread across multiple factors or driven by residual noise. "
+            "Consider collecting more data or investigating system-level factors."
+        )
+
+    parts: list[str] = []
+    if "prompt_tokens" in dominant_set:
+        parts.append(
+            "Prompt size is a dominant variance source — consider grouping "
+            "similar-length prompts or optimizing prefill for long prompts."
+        )
+    if "output_tokens" in dominant_set:
+        parts.append(
+            "Output size is a dominant variance source — consider output length "
+            "prediction or decode-instance scaling for long-generation workloads."
+        )
+    if "temporal" in dominant_set:
+        parts.append(
+            "Temporal patterns explain significant variance — investigate "
+            "time-of-day load patterns, warmup effects, or resource contention."
+        )
+
+    return " ".join(parts)
+
+
+def decompose_variance(data: BenchmarkData, *, n_temporal_bins: int = 10) -> dict:
+    """Programmatic API for variance decomposition.
+
+    Args:
+        data: Benchmark data to analyze.
+        n_temporal_bins: Number of bins for temporal feature.
+
+    Returns:
+        Dictionary representation of the VarianceReport.
+    """
+    decomposer = VarianceDecomposer(n_temporal_bins=n_temporal_bins)
+    report = decomposer.decompose(data)
+    return report.model_dump()

--- a/tests/test_variance_decomp.py
+++ b/tests/test_variance_decomp.py
@@ -1,0 +1,263 @@
+"""Tests for variance decomposition analysis."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+
+import pytest
+
+from xpyd_plan.benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+from xpyd_plan.variance_decomp import (
+    ComponentSignificance,
+    VarianceDecomposer,
+    VarianceReport,
+    decompose_variance,
+)
+
+
+def _make_data(requests: list[dict]) -> BenchmarkData:
+    """Build BenchmarkData from simplified request dicts."""
+    reqs = [
+        BenchmarkRequest(
+            request_id=f"req-{i}",
+            prompt_tokens=r["prompt_tokens"],
+            output_tokens=r["output_tokens"],
+            ttft_ms=r["ttft_ms"],
+            tpot_ms=r["tpot_ms"],
+            total_latency_ms=r["total_latency_ms"],
+            timestamp=r.get("timestamp", 1000.0 + i),
+        )
+        for i, r in enumerate(requests)
+    ]
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=2,
+            num_decode_instances=2,
+            total_instances=4,
+            measured_qps=10.0,
+        ),
+        requests=reqs,
+    )
+
+
+def _make_simple_data(n: int = 50) -> BenchmarkData:
+    """Generate data where prompt_tokens strongly drives ttft_ms."""
+    requests = []
+    for i in range(n):
+        pt = 100 + i * 20
+        ot = 50 + (i % 10) * 5
+        requests.append({
+            "prompt_tokens": pt,
+            "output_tokens": ot,
+            "ttft_ms": pt * 0.5 + 10,  # strongly correlated with prompt
+            "tpot_ms": ot * 0.3 + 5,   # correlated with output
+            "total_latency_ms": pt * 0.5 + ot * 0.3 + 15,
+            "timestamp": 1000.0 + i * 2.0,
+        })
+    return _make_data(requests)
+
+
+class TestVarianceDecomposer:
+    """Tests for VarianceDecomposer."""
+
+    def test_basic_decomposition(self):
+        data = _make_simple_data()
+        decomposer = VarianceDecomposer()
+        report = decomposer.decompose(data)
+
+        assert isinstance(report, VarianceReport)
+        assert report.sample_size == 50
+        assert len(report.metrics) == 3  # ttft, tpot, total
+
+    def test_metric_names(self):
+        data = _make_simple_data()
+        report = VarianceDecomposer().decompose(data)
+        metric_names = [m.metric for m in report.metrics]
+        assert metric_names == ["ttft_ms", "tpot_ms", "total_latency_ms"]
+
+    def test_components_per_metric(self):
+        data = _make_simple_data()
+        report = VarianceDecomposer().decompose(data)
+        for m in report.metrics:
+            names = [c.name for c in m.components]
+            assert "prompt_tokens" in names
+            assert "output_tokens" in names
+            assert "temporal" in names
+            assert "residual" in names
+            assert len(m.components) == 4
+
+    def test_contributions_sum_roughly_100(self):
+        data = _make_simple_data()
+        report = VarianceDecomposer().decompose(data)
+        for m in report.metrics:
+            total_pct = sum(c.contribution_pct for c in m.components)
+            assert 99.0 <= total_pct <= 101.0, f"{m.metric}: {total_pct}"
+
+    def test_prompt_dominant_for_ttft(self):
+        """TTFT is driven by prompt_tokens, so it should be dominant or significant."""
+        data = _make_simple_data()
+        report = VarianceDecomposer().decompose(data)
+        ttft = report.metrics[0]
+        assert ttft.metric == "ttft_ms"
+        prompt_comp = next(c for c in ttft.components if c.name == "prompt_tokens")
+        assert prompt_comp.contribution_pct > 30  # should be high
+
+    def test_r_squared_range(self):
+        data = _make_simple_data()
+        report = VarianceDecomposer().decompose(data)
+        for m in report.metrics:
+            assert 0 <= m.r_squared <= 1
+
+    def test_minimum_requests_raises(self):
+        data = _make_data([
+            {"prompt_tokens": 100, "output_tokens": 50,
+             "ttft_ms": 50, "tpot_ms": 15, "total_latency_ms": 65},
+            {"prompt_tokens": 200, "output_tokens": 60,
+             "ttft_ms": 100, "tpot_ms": 18, "total_latency_ms": 118},
+        ])
+        with pytest.raises(ValueError, match="at least 3"):
+            VarianceDecomposer().decompose(data)
+
+    def test_three_requests_works(self):
+        data = _make_data([
+            {"prompt_tokens": 100, "output_tokens": 50,
+             "ttft_ms": 50, "tpot_ms": 15, "total_latency_ms": 65},
+            {"prompt_tokens": 200, "output_tokens": 60,
+             "ttft_ms": 100, "tpot_ms": 18, "total_latency_ms": 118},
+            {"prompt_tokens": 300, "output_tokens": 70,
+             "ttft_ms": 150, "tpot_ms": 21, "total_latency_ms": 171},
+        ])
+        report = VarianceDecomposer().decompose(data)
+        assert report.sample_size == 3
+
+    def test_identical_values_zero_variance(self):
+        """All same latency values should yield zero variance."""
+        data = _make_data([
+            {
+                "prompt_tokens": 100 + i, "output_tokens": 50,
+                "ttft_ms": 50, "tpot_ms": 15, "total_latency_ms": 65,
+            }
+            for i in range(10)
+        ])
+        report = VarianceDecomposer().decompose(data)
+        tpot = next(m for m in report.metrics if m.metric == "tpot_ms")
+        assert tpot.total_variance == 0.0
+
+    def test_significance_classification(self):
+        data = _make_simple_data()
+        report = VarianceDecomposer().decompose(data)
+        for m in report.metrics:
+            for c in m.components:
+                assert isinstance(c.significance, ComponentSignificance)
+
+    def test_dominant_factor_set_when_significant(self):
+        data = _make_simple_data()
+        report = VarianceDecomposer().decompose(data)
+        # At least one metric should have a dominant factor
+        has_dominant = any(m.dominant_factor is not None for m in report.metrics)
+        assert has_dominant
+
+    def test_recommendation_not_empty(self):
+        data = _make_simple_data()
+        report = VarianceDecomposer().decompose(data)
+        assert len(report.recommendation) > 0
+
+    def test_temporal_bins_parameter(self):
+        data = _make_simple_data()
+        report5 = VarianceDecomposer(n_temporal_bins=5).decompose(data)
+        report20 = VarianceDecomposer(n_temporal_bins=20).decompose(data)
+        # Both should produce valid reports
+        assert report5.sample_size == report20.sample_size == 50
+
+    def test_sum_of_squares_non_negative(self):
+        data = _make_simple_data()
+        report = VarianceDecomposer().decompose(data)
+        for m in report.metrics:
+            for c in m.components:
+                assert c.sum_of_squares >= 0
+
+    def test_total_variance_non_negative(self):
+        data = _make_simple_data()
+        report = VarianceDecomposer().decompose(data)
+        for m in report.metrics:
+            assert m.total_variance >= 0
+
+    def test_temporal_dominant_with_time_pattern(self):
+        """When latency increases with time, temporal should explain variance."""
+        requests = []
+        for i in range(50):
+            # Latency grows purely with time, not tokens
+            requests.append({
+                "prompt_tokens": 100,
+                "output_tokens": 50,
+                "ttft_ms": 50 + i * 5,
+                "tpot_ms": 15 + i * 2,
+                "total_latency_ms": 65 + i * 7,
+                "timestamp": 1000.0 + i * 10.0,
+            })
+        data = _make_data(requests)
+        report = VarianceDecomposer().decompose(data)
+        ttft = report.metrics[0]
+        temporal = next(c for c in ttft.components if c.name == "temporal")
+        # Temporal should have meaningful contribution since latency grows with time
+        assert temporal.contribution_pct > 10
+
+
+class TestDecomposeVarianceAPI:
+    """Tests for the programmatic decompose_variance() API."""
+
+    def test_returns_dict(self):
+        data = _make_simple_data()
+        result = decompose_variance(data)
+        assert isinstance(result, dict)
+        assert "metrics" in result
+        assert "sample_size" in result
+        assert "recommendation" in result
+
+    def test_n_temporal_bins_kwarg(self):
+        data = _make_simple_data()
+        result = decompose_variance(data, n_temporal_bins=5)
+        assert result["sample_size"] == 50
+
+    def test_json_serializable(self):
+        data = _make_simple_data()
+        result = decompose_variance(data)
+        # Should not raise
+        json.dumps(result)
+
+
+class TestVarianceCLI:
+    """Tests for the CLI variance subcommand."""
+
+    def _write_benchmark(self, tmp_dir: str, data: BenchmarkData) -> str:
+        import os
+        path = os.path.join(tmp_dir, "bench.json")
+        with open(path, "w") as f:
+            json.dump(data.model_dump(), f)
+        return path
+
+    def test_cli_json_output(self):
+        data = _make_simple_data()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write_benchmark(tmp, data)
+            result = subprocess.run(
+                ["xpyd-plan", "variance", "--benchmark", path, "--output-format", "json"],
+                capture_output=True, text=True,
+            )
+            assert result.returncode == 0
+            output = json.loads(result.stdout)
+            assert "metrics" in output
+            assert len(output["metrics"]) == 3
+
+    def test_cli_table_output(self):
+        data = _make_simple_data()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write_benchmark(tmp, data)
+            result = subprocess.run(
+                ["xpyd-plan", "variance", "--benchmark", path],
+                capture_output=True, text=True,
+            )
+            assert result.returncode == 0
+            assert "Variance Decomposition" in result.stdout


### PR DESCRIPTION
## Summary

Implement variance decomposition using sequential OLS regression to attribute total latency variance to prompt size, output size, temporal effects, and residual noise.

## Changes

- `VarianceDecomposer` class in `variance_decomp.py`
- `VarianceReport`, `MetricDecomposition`, `VarianceComponent`, `ComponentSignificance` Pydantic models
- Sequential OLS for TTFT, TPOT, total_latency
- Per-component contribution %, significance classification (DOMINANT/SIGNIFICANT/MINOR/NEGLIGIBLE)
- R² of full model per metric, dominant factor identification
- CLI `variance` subcommand with `--benchmark`, `--temporal-bins`, table + JSON output
- Programmatic `decompose_variance()` API
- Mark M98 as completed in ROADMAP.md
- 21 new tests (2212 total, all passing)

Closes #218