### PR TITLE
feat: M104 — Latency Baseline Manager

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1402,3 +1402,20 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `sla-headroom` subcommand with `--benchmark`, `--sla-ttft`, `--sla-tpot`, `--sla-total`, `--percentile`, table + JSON output
 - Programmatic `analyze_sla_headroom()` API
 - 19 new tests
+
+### M104 ✅ Latency Baseline Manager
+
+*Completed — PR #TBD*
+
+- `BaselineManager` class in `baseline.py`
+- `BaselineProfile`, `BaselineComparison`, `BaselineVerdict`, `MetricBaseline`, `MetricDelta` Pydantic models
+- Save golden baseline profile (P50/P95/P99 for TTFT, TPOT, total_latency + QPS + cluster config)
+- Load baseline from JSON file
+- Compare current benchmark against saved baseline with configurable regression threshold (default 10%)
+- Per-metric-percentile delta reporting with PASS/WARN/FAIL verdict
+- Warning threshold at half of regression threshold
+- Overall verdict: worst across all metric-percentile pairs
+- CLI `baseline` subcommand: `baseline save` and `baseline compare`
+- Non-zero exit code on FAIL verdict (CI/CD friendly)
+- Programmatic `save_baseline()` and `compare_baseline()` APIs
+- 19 new tests

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -1368,3 +1368,23 @@ __all__ += [
     "SLAHeadroomCalculator",
     "analyze_sla_headroom",
 ]
+
+from xpyd_plan.baseline import (  # noqa: E402
+    BaselineComparison,
+    BaselineManager,
+    BaselineProfile,
+    BaselineVerdict,
+    MetricBaseline,
+    compare_baseline,
+    save_baseline,
+)
+
+__all__ += [
+    "BaselineComparison",
+    "BaselineManager",
+    "BaselineProfile",
+    "BaselineVerdict",
+    "MetricBaseline",
+    "compare_baseline",
+    "save_baseline",
+]

--- a/src/xpyd_plan/baseline.py
+++ b/src/xpyd_plan/baseline.py
@@ -1,0 +1,229 @@
+"""Latency baseline manager — save, load, and compare golden baselines.
+
+Establish a reference latency profile from a known-good benchmark run,
+persist it as JSON, and compare future runs against it with configurable
+regression thresholds.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from enum import Enum
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData
+
+
+class BaselineVerdict(str, Enum):
+    """Overall comparison verdict."""
+
+    PASS = "pass"
+    WARN = "warn"
+    FAIL = "fail"
+
+
+class MetricBaseline(BaseModel):
+    """Latency percentiles for a single metric."""
+
+    p50_ms: float = Field(..., description="P50 latency in ms")
+    p95_ms: float = Field(..., description="P95 latency in ms")
+    p99_ms: float = Field(..., description="P99 latency in ms")
+
+
+class BaselineProfile(BaseModel):
+    """Saved baseline profile from a golden benchmark run."""
+
+    ttft: MetricBaseline = Field(..., description="TTFT percentiles")
+    tpot: MetricBaseline = Field(..., description="TPOT percentiles")
+    total_latency: MetricBaseline = Field(..., description="Total latency percentiles")
+    qps: float = Field(..., description="Measured QPS")
+    request_count: int = Field(..., description="Number of requests")
+    num_prefill_instances: int = Field(..., description="Prefill instance count")
+    num_decode_instances: int = Field(..., description="Decode instance count")
+
+
+class MetricDelta(BaseModel):
+    """Comparison result for a single metric at a single percentile."""
+
+    metric: str = Field(..., description="Metric name")
+    percentile: str = Field(..., description="Percentile label (p50, p95, p99)")
+    baseline_ms: float = Field(..., description="Baseline value in ms")
+    current_ms: float = Field(..., description="Current value in ms")
+    delta_ms: float = Field(..., description="Absolute delta (current - baseline)")
+    delta_pct: float = Field(..., description="Relative delta as %")
+    verdict: BaselineVerdict = Field(..., description="Pass/warn/fail for this metric")
+
+
+class BaselineComparison(BaseModel):
+    """Full comparison report against a saved baseline."""
+
+    deltas: list[MetricDelta] = Field(..., description="Per-metric-percentile deltas")
+    overall_verdict: BaselineVerdict = Field(..., description="Overall verdict")
+    regression_threshold_pct: float = Field(
+        ..., description="Configured regression threshold %"
+    )
+    warn_threshold_pct: float = Field(
+        ..., description="Warning threshold % (half of regression)"
+    )
+    summary: str = Field(..., description="Human-readable summary")
+
+
+def _percentile_value(values: list[float], pct: float) -> float:
+    """Compute percentile using linear interpolation."""
+    if not values:
+        return 0.0
+    sorted_v = sorted(values)
+    n = len(sorted_v)
+    k = (pct / 100.0) * (n - 1)
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return sorted_v[int(k)]
+    return sorted_v[f] * (c - k) + sorted_v[c] * (k - f)
+
+
+def _extract_metric(data: BenchmarkData, attr: str) -> MetricBaseline:
+    """Extract P50/P95/P99 for a given request attribute."""
+    values = [getattr(r, attr) for r in data.requests]
+    return MetricBaseline(
+        p50_ms=_percentile_value(values, 50.0),
+        p95_ms=_percentile_value(values, 95.0),
+        p99_ms=_percentile_value(values, 99.0),
+    )
+
+
+class BaselineManager:
+    """Save, load, and compare latency baselines."""
+
+    def save(self, data: BenchmarkData) -> BaselineProfile:
+        """Create a baseline profile from benchmark data."""
+        profile = BaselineProfile(
+            ttft=_extract_metric(data, "ttft_ms"),
+            tpot=_extract_metric(data, "tpot_ms"),
+            total_latency=_extract_metric(data, "total_latency_ms"),
+            qps=data.metadata.measured_qps,
+            request_count=len(data.requests),
+            num_prefill_instances=data.metadata.num_prefill_instances,
+            num_decode_instances=data.metadata.num_decode_instances,
+        )
+        return profile
+
+    def save_to_file(self, data: BenchmarkData, path: str | Path) -> BaselineProfile:
+        """Create baseline profile and write to JSON file."""
+        profile = self.save(data)
+        path = Path(path)
+        path.write_text(json.dumps(profile.model_dump(), indent=2) + "\n")
+        return profile
+
+    def load(self, path: str | Path) -> BaselineProfile:
+        """Load a baseline profile from JSON file."""
+        path = Path(path)
+        raw = json.loads(path.read_text())
+        return BaselineProfile.model_validate(raw)
+
+    def compare(
+        self,
+        data: BenchmarkData,
+        baseline: BaselineProfile,
+        regression_threshold_pct: float = 10.0,
+    ) -> BaselineComparison:
+        """Compare benchmark data against a baseline profile.
+
+        Args:
+            data: Current benchmark data.
+            baseline: Saved baseline profile.
+            regression_threshold_pct: Percentage increase that constitutes a
+                regression (default 10%). Warning threshold is half this value.
+
+        Returns:
+            BaselineComparison with per-metric deltas and overall verdict.
+        """
+        warn_threshold = regression_threshold_pct / 2.0
+        current = self.save(data)
+
+        deltas: list[MetricDelta] = []
+        metrics = [
+            ("ttft", current.ttft, baseline.ttft),
+            ("tpot", current.tpot, baseline.tpot),
+            ("total_latency", current.total_latency, baseline.total_latency),
+        ]
+
+        for metric_name, cur_metric, base_metric in metrics:
+            for pct_label, cur_val, base_val in [
+                ("p50", cur_metric.p50_ms, base_metric.p50_ms),
+                ("p95", cur_metric.p95_ms, base_metric.p95_ms),
+                ("p99", cur_metric.p99_ms, base_metric.p99_ms),
+            ]:
+                delta_ms = cur_val - base_val
+                if base_val > 0:
+                    delta_pct = (delta_ms / base_val) * 100.0
+                else:
+                    delta_pct = 0.0 if cur_val == 0 else 100.0
+
+                if delta_pct >= regression_threshold_pct:
+                    verdict = BaselineVerdict.FAIL
+                elif delta_pct >= warn_threshold:
+                    verdict = BaselineVerdict.WARN
+                else:
+                    verdict = BaselineVerdict.PASS
+
+                deltas.append(
+                    MetricDelta(
+                        metric=metric_name,
+                        percentile=pct_label,
+                        baseline_ms=base_val,
+                        current_ms=cur_val,
+                        delta_ms=round(delta_ms, 3),
+                        delta_pct=round(delta_pct, 3),
+                        verdict=verdict,
+                    )
+                )
+
+        # Overall verdict: worst across all deltas
+        if any(d.verdict == BaselineVerdict.FAIL for d in deltas):
+            overall = BaselineVerdict.FAIL
+        elif any(d.verdict == BaselineVerdict.WARN for d in deltas):
+            overall = BaselineVerdict.WARN
+        else:
+            overall = BaselineVerdict.PASS
+
+        fail_count = sum(1 for d in deltas if d.verdict == BaselineVerdict.FAIL)
+        warn_count = sum(1 for d in deltas if d.verdict == BaselineVerdict.WARN)
+
+        if overall == BaselineVerdict.PASS:
+            summary = "All metrics within baseline tolerance. No regression detected."
+        elif overall == BaselineVerdict.WARN:
+            summary = (
+                f"{warn_count} metric(s) approaching regression threshold. "
+                "Monitor closely."
+            )
+        else:
+            summary = (
+                f"{fail_count} metric(s) regressed beyond {regression_threshold_pct}% "
+                f"threshold. Investigation recommended."
+            )
+
+        return BaselineComparison(
+            deltas=deltas,
+            overall_verdict=overall,
+            regression_threshold_pct=regression_threshold_pct,
+            warn_threshold_pct=warn_threshold,
+            summary=summary,
+        )
+
+
+def save_baseline(data: BenchmarkData) -> BaselineProfile:
+    """Programmatic API: create a baseline profile from benchmark data."""
+    return BaselineManager().save(data)
+
+
+def compare_baseline(
+    data: BenchmarkData,
+    baseline: BaselineProfile,
+    regression_threshold_pct: float = 10.0,
+) -> BaselineComparison:
+    """Programmatic API: compare benchmark data against a baseline."""
+    return BaselineManager().compare(data, baseline, regression_threshold_pct)

--- a/src/xpyd_plan/cli/_baseline.py
+++ b/src/xpyd_plan/cli/_baseline.py
@@ -1,0 +1,131 @@
+"""CLI baseline command — save and compare latency baselines."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.baseline import BaselineManager
+from xpyd_plan.bench_adapter import load_benchmark_auto
+
+
+def _cmd_baseline(args: argparse.Namespace) -> None:
+    """Handle the 'baseline' subcommand."""
+    console = Console()
+    manager = BaselineManager()
+
+    action = args.baseline_action
+    output_format = getattr(args, "output_format", "table")
+
+    if action == "save":
+        data = load_benchmark_auto(args.benchmark)
+        profile = manager.save_to_file(data, args.output)
+        if output_format == "json":
+            json.dump(profile.model_dump(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+            return
+        console.print(f"[green]Baseline saved to {args.output}[/green]")
+        table = Table(title="Baseline Profile")
+        table.add_column("Metric", justify="left")
+        table.add_column("P50 (ms)", justify="right")
+        table.add_column("P95 (ms)", justify="right")
+        table.add_column("P99 (ms)", justify="right")
+        for name, m in [
+            ("TTFT", profile.ttft),
+            ("TPOT", profile.tpot),
+            ("Total Latency", profile.total_latency),
+        ]:
+            table.add_row(name, f"{m.p50_ms:.1f}", f"{m.p95_ms:.1f}", f"{m.p99_ms:.1f}")
+        console.print(table)
+        console.print(f"QPS: {profile.qps:.1f}  |  Requests: {profile.request_count}")
+
+    elif action == "compare":
+        data = load_benchmark_auto(args.benchmark)
+        baseline = manager.load(args.baseline_file)
+        report = manager.compare(
+            data, baseline, regression_threshold_pct=args.regression_threshold
+        )
+        if output_format == "json":
+            json.dump(report.model_dump(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+            return
+        table = Table(title="Baseline Comparison")
+        table.add_column("Metric", justify="left")
+        table.add_column("Percentile", justify="center")
+        table.add_column("Baseline (ms)", justify="right")
+        table.add_column("Current (ms)", justify="right")
+        table.add_column("Delta (ms)", justify="right")
+        table.add_column("Delta (%)", justify="right")
+        table.add_column("Verdict", justify="center")
+
+        verdict_style = {
+            "pass": "[green]PASS[/green]",
+            "warn": "[yellow]WARN[/yellow]",
+            "fail": "[bold red]FAIL[/bold red]",
+        }
+        for d in report.deltas:
+            table.add_row(
+                d.metric,
+                d.percentile.upper(),
+                f"{d.baseline_ms:.1f}",
+                f"{d.current_ms:.1f}",
+                f"{d.delta_ms:+.1f}",
+                f"{d.delta_pct:+.1f}%",
+                verdict_style.get(d.verdict.value, d.verdict.value),
+            )
+        console.print(table)
+        overall_style = verdict_style.get(
+            report.overall_verdict.value, report.overall_verdict.value
+        )
+        console.print(f"\nOverall: {overall_style}")
+        console.print(f"[bold]{report.summary}[/bold]")
+
+        if report.overall_verdict.value == "fail":
+            sys.exit(1)
+
+
+def add_baseline_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the baseline subcommand parser."""
+    parser = subparsers.add_parser(
+        "baseline",
+        help="Save and compare latency baselines",
+    )
+    sub = parser.add_subparsers(dest="baseline_action", required=True)
+
+    # baseline save
+    save_p = sub.add_parser("save", help="Save a baseline from benchmark data")
+    save_p.add_argument("--benchmark", required=True, help="Path to benchmark JSON")
+    save_p.add_argument(
+        "--output", required=True, help="Output path for baseline JSON"
+    )
+    save_p.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+
+    # baseline compare
+    cmp_p = sub.add_parser("compare", help="Compare benchmark against saved baseline")
+    cmp_p.add_argument("--benchmark", required=True, help="Path to benchmark JSON")
+    cmp_p.add_argument(
+        "--baseline-file", required=True, help="Path to saved baseline JSON"
+    )
+    cmp_p.add_argument(
+        "--regression-threshold",
+        type=float,
+        default=10.0,
+        help="Regression threshold %% (default: 10.0)",
+    )
+    cmp_p.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+
+    parser.set_defaults(func=_cmd_baseline)

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -11,6 +11,7 @@ from xpyd_plan.cli._analyze import _cmd_analyze
 from xpyd_plan.cli._annotate import _cmd_annotate
 from xpyd_plan.cli._anomaly_classify import add_anomaly_classify_parser
 from xpyd_plan.cli._arrival_pattern import _cmd_arrival_pattern, add_arrival_pattern_parser
+from xpyd_plan.cli._baseline import add_baseline_parser
 from xpyd_plan.cli._batch_analysis import add_batch_analysis_parser
 from xpyd_plan.cli._budget import _cmd_budget
 from xpyd_plan.cli._budget_tracker import _cmd_budget_tracker
@@ -929,6 +930,7 @@ def main(argv: list[str] | None = None) -> None:
     add_variance_parser(subparsers)
     add_anomaly_classify_parser(subparsers)
     add_sla_headroom_parser(subparsers)
+    add_baseline_parser(subparsers)
     add_jitter_parser(subparsers)
     add_cold_start_parser(subparsers)
     add_dedup_parser(subparsers)

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,0 +1,287 @@
+"""Tests for BaselineManager — save, load, compare latency baselines."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_plan.baseline import (
+    BaselineComparison,
+    BaselineManager,
+    BaselineProfile,
+    BaselineVerdict,
+    MetricDelta,
+    compare_baseline,
+    save_baseline,
+)
+from xpyd_plan.benchmark_models import (
+    BenchmarkData,
+    BenchmarkMetadata,
+    BenchmarkRequest,
+)
+
+
+def _make_requests(
+    n: int = 100,
+    ttft_base: float = 50.0,
+    tpot_base: float = 10.0,
+    total_base: float = 200.0,
+) -> list[BenchmarkRequest]:
+    """Generate deterministic benchmark requests with controlled latency spread."""
+    reqs = []
+    for i in range(n):
+        frac = i / max(n - 1, 1)
+        reqs.append(
+            BenchmarkRequest(
+                request_id=f"req-{i:04d}",
+                prompt_tokens=100 + i,
+                output_tokens=50 + i,
+                ttft_ms=ttft_base + frac * ttft_base,
+                tpot_ms=tpot_base + frac * tpot_base,
+                total_latency_ms=total_base + frac * total_base,
+                timestamp=1000.0 + i * 0.1,
+            )
+        )
+    return reqs
+
+
+def _make_data(
+    n: int = 100,
+    ttft_base: float = 50.0,
+    tpot_base: float = 10.0,
+    total_base: float = 200.0,
+    qps: float = 100.0,
+    prefill: int = 2,
+    decode: int = 6,
+) -> BenchmarkData:
+    return BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=prefill,
+            num_decode_instances=decode,
+            total_instances=prefill + decode,
+            measured_qps=qps,
+        ),
+        requests=_make_requests(n, ttft_base, tpot_base, total_base),
+    )
+
+
+class TestBaselineManager:
+    """Tests for BaselineManager core operations."""
+
+    def test_save_creates_profile(self) -> None:
+        data = _make_data()
+        mgr = BaselineManager()
+        profile = mgr.save(data)
+        assert isinstance(profile, BaselineProfile)
+        assert profile.qps == 100.0
+        assert profile.request_count == 100
+        assert profile.num_prefill_instances == 2
+        assert profile.num_decode_instances == 6
+        assert profile.ttft.p50_ms > 0
+        assert profile.ttft.p95_ms > profile.ttft.p50_ms
+        assert profile.ttft.p99_ms >= profile.ttft.p95_ms
+
+    def test_save_to_file_and_load(self, tmp_path: Path) -> None:
+        data = _make_data()
+        mgr = BaselineManager()
+        out_path = tmp_path / "baseline.json"
+        profile = mgr.save_to_file(data, out_path)
+        assert out_path.exists()
+
+        loaded = mgr.load(out_path)
+        assert loaded.qps == profile.qps
+        assert loaded.ttft.p95_ms == profile.ttft.p95_ms
+        assert loaded.tpot.p99_ms == profile.tpot.p99_ms
+
+    def test_save_file_is_valid_json(self, tmp_path: Path) -> None:
+        data = _make_data()
+        mgr = BaselineManager()
+        out_path = tmp_path / "baseline.json"
+        mgr.save_to_file(data, out_path)
+        raw = json.loads(out_path.read_text())
+        assert "ttft" in raw
+        assert "tpot" in raw
+        assert "total_latency" in raw
+        assert "qps" in raw
+
+    def test_compare_no_regression(self) -> None:
+        data = _make_data()
+        mgr = BaselineManager()
+        baseline = mgr.save(data)
+        result = mgr.compare(data, baseline)
+        assert result.overall_verdict == BaselineVerdict.PASS
+        assert all(d.verdict == BaselineVerdict.PASS for d in result.deltas)
+        assert "No regression" in result.summary
+
+    def test_compare_with_regression(self) -> None:
+        baseline_data = _make_data(ttft_base=50.0)
+        current_data = _make_data(ttft_base=60.0)  # 20% increase
+        mgr = BaselineManager()
+        baseline = mgr.save(baseline_data)
+        result = mgr.compare(current_data, baseline, regression_threshold_pct=10.0)
+        assert result.overall_verdict == BaselineVerdict.FAIL
+        ttft_fails = [
+            d for d in result.deltas if d.metric == "ttft" and d.verdict == BaselineVerdict.FAIL
+        ]
+        assert len(ttft_fails) > 0
+
+    def test_compare_with_warn(self) -> None:
+        baseline_data = _make_data(ttft_base=50.0)
+        # ~8% increase — above warn (5%) but below fail (10%)
+        current_data = _make_data(ttft_base=54.0)
+        mgr = BaselineManager()
+        baseline = mgr.save(baseline_data)
+        result = mgr.compare(current_data, baseline, regression_threshold_pct=10.0)
+        warn_deltas = [d for d in result.deltas if d.verdict == BaselineVerdict.WARN]
+        assert len(warn_deltas) > 0
+
+    def test_compare_improvement_is_pass(self) -> None:
+        baseline_data = _make_data(ttft_base=60.0)
+        current_data = _make_data(ttft_base=50.0)  # improvement
+        mgr = BaselineManager()
+        baseline = mgr.save(baseline_data)
+        result = mgr.compare(current_data, baseline)
+        assert result.overall_verdict == BaselineVerdict.PASS
+
+    def test_compare_custom_threshold(self) -> None:
+        baseline_data = _make_data(ttft_base=50.0)
+        current_data = _make_data(ttft_base=53.0)  # ~6%
+        mgr = BaselineManager()
+        baseline = mgr.save(baseline_data)
+        # With 5% threshold, this should fail
+        result = mgr.compare(current_data, baseline, regression_threshold_pct=5.0)
+        assert result.overall_verdict == BaselineVerdict.FAIL
+
+    def test_deltas_have_correct_fields(self) -> None:
+        data = _make_data()
+        mgr = BaselineManager()
+        baseline = mgr.save(data)
+        result = mgr.compare(data, baseline)
+        assert len(result.deltas) == 9  # 3 metrics × 3 percentiles
+        for d in result.deltas:
+            assert isinstance(d, MetricDelta)
+            assert d.metric in ("ttft", "tpot", "total_latency")
+            assert d.percentile in ("p50", "p95", "p99")
+            assert d.delta_ms == pytest.approx(0.0, abs=0.01)
+
+    def test_compare_report_thresholds(self) -> None:
+        data = _make_data()
+        mgr = BaselineManager()
+        baseline = mgr.save(data)
+        result = mgr.compare(data, baseline, regression_threshold_pct=20.0)
+        assert result.regression_threshold_pct == 20.0
+        assert result.warn_threshold_pct == 10.0
+
+    def test_metric_baseline_values(self) -> None:
+        data = _make_data(n=100, ttft_base=100.0)
+        mgr = BaselineManager()
+        profile = mgr.save(data)
+        # With linear spread 100-200, P50 ≈ 150
+        assert 140 < profile.ttft.p50_ms < 160
+        assert profile.ttft.p95_ms > profile.ttft.p50_ms
+
+    def test_single_request(self) -> None:
+        data = BenchmarkData(
+            metadata=BenchmarkMetadata(
+                num_prefill_instances=1,
+                num_decode_instances=1,
+                total_instances=2,
+                measured_qps=1.0,
+            ),
+            requests=[
+                BenchmarkRequest(
+                    request_id="req-0",
+                    prompt_tokens=100,
+                    output_tokens=50,
+                    ttft_ms=42.0,
+                    tpot_ms=8.0,
+                    total_latency_ms=150.0,
+                    timestamp=1000.0,
+                )
+            ],
+        )
+        mgr = BaselineManager()
+        profile = mgr.save(data)
+        assert profile.ttft.p50_ms == 42.0
+        assert profile.ttft.p95_ms == 42.0
+        assert profile.request_count == 1
+
+    def test_compare_multiple_metric_regression(self) -> None:
+        baseline_data = _make_data(ttft_base=50.0, tpot_base=10.0, total_base=200.0)
+        current_data = _make_data(ttft_base=60.0, tpot_base=12.0, total_base=250.0)
+        mgr = BaselineManager()
+        baseline = mgr.save(baseline_data)
+        result = mgr.compare(current_data, baseline, regression_threshold_pct=10.0)
+        assert result.overall_verdict == BaselineVerdict.FAIL
+        fail_metrics = {d.metric for d in result.deltas if d.verdict == BaselineVerdict.FAIL}
+        assert len(fail_metrics) >= 2
+
+    def test_summary_fail_message_includes_count(self) -> None:
+        baseline_data = _make_data(ttft_base=50.0)
+        current_data = _make_data(ttft_base=100.0)
+        mgr = BaselineManager()
+        baseline = mgr.save(baseline_data)
+        result = mgr.compare(current_data, baseline)
+        assert "regressed" in result.summary
+        assert "10.0%" in result.summary
+
+
+class TestProgrammaticAPI:
+    """Tests for save_baseline() and compare_baseline() functions."""
+
+    def test_save_baseline_api(self) -> None:
+        data = _make_data()
+        profile = save_baseline(data)
+        assert isinstance(profile, BaselineProfile)
+        assert profile.request_count == 100
+
+    def test_compare_baseline_api(self) -> None:
+        data = _make_data()
+        baseline = save_baseline(data)
+        result = compare_baseline(data, baseline)
+        assert isinstance(result, BaselineComparison)
+        assert result.overall_verdict == BaselineVerdict.PASS
+
+    def test_compare_baseline_api_with_threshold(self) -> None:
+        baseline_data = _make_data(ttft_base=50.0)
+        current_data = _make_data(ttft_base=55.0)
+        baseline = save_baseline(baseline_data)
+        result = compare_baseline(current_data, baseline, regression_threshold_pct=5.0)
+        assert result.overall_verdict == BaselineVerdict.FAIL
+
+    def test_roundtrip_via_file(self, tmp_path: Path) -> None:
+        data = _make_data()
+        mgr = BaselineManager()
+        path = tmp_path / "bl.json"
+        mgr.save_to_file(data, path)
+        loaded = mgr.load(path)
+        result = compare_baseline(data, loaded)
+        assert result.overall_verdict == BaselineVerdict.PASS
+
+    def test_zero_baseline_value(self) -> None:
+        """Edge case: baseline with zero value should handle division gracefully."""
+        data = BenchmarkData(
+            metadata=BenchmarkMetadata(
+                num_prefill_instances=1,
+                num_decode_instances=1,
+                total_instances=2,
+                measured_qps=1.0,
+            ),
+            requests=[
+                BenchmarkRequest(
+                    request_id="r0",
+                    prompt_tokens=10,
+                    output_tokens=10,
+                    ttft_ms=0.0,
+                    tpot_ms=0.0,
+                    total_latency_ms=0.0,
+                    timestamp=1000.0,
+                )
+            ],
+        )
+        baseline = save_baseline(data)
+        result = compare_baseline(data, baseline)
+        # Should not crash, all zeros → PASS
+        assert result.overall_verdict == BaselineVerdict.PASS


### PR DESCRIPTION
## M104: Latency Baseline Manager

- `BaselineManager` class in `baseline.py`
- `BaselineProfile`, `BaselineComparison`, `BaselineVerdict`, `MetricBaseline`, `MetricDelta` Pydantic models
- Save golden baseline profile (P50/P95/P99 for TTFT, TPOT, total_latency + QPS + cluster config)
- Load baseline from JSON file
- Compare current benchmark against saved baseline with configurable regression threshold (default 10%)
- Per-metric-percentile delta reporting with PASS/WARN/FAIL verdict
- Warning threshold at half of regression threshold
- Overall verdict: worst across all metric-percentile pairs
- CLI `baseline` subcommand: `baseline save` and `baseline compare`
- Non-zero exit code on FAIL verdict (CI/CD friendly)
- Programmatic `save_baseline()` and `compare_baseline()` APIs
- 19 new tests

Closes #229