### PR TITLE
feat: custom GPU profile loading from YAML config (M106)

### DIFF
--- a/docs/iterations/current.md
+++ b/docs/iterations/current.md
@@ -1,8 +1,28 @@
 # xPyD-plan Current Iteration Status
 
-> Last updated: 2026-04-05
+> Last updated: 2026-04-06
 
 ---
+
+## Current: M106 — Custom GPU Profile Loading from YAML
+
+### What
+
+Add `load_gpu_profiles(path)` to load custom GPU profiles from YAML files, merging with built-in profiles. Enables users with custom/proprietary GPUs to use fleet calculator, normalizer, and capacity planner.
+
+### Changes
+
+- `gpu_profiles.py`: added `load_gpu_profiles()`, `get_all_profiles()`, updated `get_gpu_profile()` and `list_gpu_profiles()` with optional `custom_profiles_path`
+- `__init__.py`: export new functions
+- 17 new tests in `test_custom_gpu_profiles.py`
+
+### Status
+
+- [x] Implementation
+- [x] Tests (17 passing)
+- [x] Lint passing
+- [ ] PR created
+- [ ] Review
 
 ## Current Milestone: M105 — Expand GPU Profile Library ✅
 

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -185,7 +185,12 @@ from xpyd_plan.goodput import (
     GoodputWindow,
     analyze_goodput,
 )
-from xpyd_plan.gpu_profiles import get_gpu_profile, list_gpu_profiles
+from xpyd_plan.gpu_profiles import (
+    get_all_profiles,
+    get_gpu_profile,
+    list_gpu_profiles,
+    load_gpu_profiles,
+)
 from xpyd_plan.health_check import (
     CheckResult,
     HealthChecker,
@@ -512,6 +517,8 @@ __all__ = [
     "UtilizationResult",
     "get_gpu_profile",
     "list_gpu_profiles",
+    "load_gpu_profiles",
+    "get_all_profiles",
     "load_config",
     "track_trend",
     "TrendEntry",

--- a/src/xpyd_plan/gpu_profiles.py
+++ b/src/xpyd_plan/gpu_profiles.py
@@ -1,6 +1,11 @@
-"""Built-in GPU profile library."""
+"""Built-in GPU profile library with optional YAML custom profiles."""
 
 from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+import yaml
 
 from xpyd_plan.models import GPUProfile
 
@@ -60,18 +65,111 @@ _BUILTIN_PROFILES: dict[str, GPUProfile] = {
 }
 
 
-def get_gpu_profile(name: str) -> GPUProfile:
-    """Get a built-in GPU profile by name.
+def load_gpu_profiles(path: Union[str, Path]) -> dict[str, GPUProfile]:
+    """Load custom GPU profiles from a YAML file.
+
+    YAML format::
+
+        profiles:
+          - name: MI300X-192G
+            prefill_tokens_per_sec: 180000
+            decode_tokens_per_sec: 9000
+            memory_gb: 192.0
+            cost_per_hour: 6.50
+
+    Args:
+        path: Path to YAML file containing GPU profile definitions.
+
+    Returns:
+        Dictionary mapping profile name to GPUProfile.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        ValueError: If the YAML structure is invalid or missing required fields.
+    """
+    filepath = Path(path)
+    if not filepath.exists():
+        raise FileNotFoundError(f"GPU profiles file not found: {filepath}")
+
+    with open(filepath) as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict) or "profiles" not in data:
+        raise ValueError(
+            "Invalid GPU profiles YAML: expected top-level 'profiles' key"
+        )
+
+    profiles_list = data["profiles"]
+    if not isinstance(profiles_list, list):
+        raise ValueError("Invalid GPU profiles YAML: 'profiles' must be a list")
+
+    result: dict[str, GPUProfile] = {}
+    for i, entry in enumerate(profiles_list):
+        if not isinstance(entry, dict):
+            raise ValueError(f"Invalid GPU profiles YAML: entry {i} must be a mapping")
+        if "name" not in entry:
+            raise ValueError(
+                f"Invalid GPU profiles YAML: entry {i} missing required 'name' field"
+            )
+        try:
+            profile = GPUProfile(**entry)
+        except Exception as exc:
+            raise ValueError(
+                f"Invalid GPU profiles YAML: entry {i} ({entry.get('name', '?')}): {exc}"
+            ) from exc
+        result[profile.name] = profile
+
+    return result
+
+
+def get_all_profiles(
+    custom_profiles_path: Union[str, Path, None] = None,
+) -> dict[str, GPUProfile]:
+    """Get all GPU profiles (built-in + custom).
+
+    Custom profiles override built-in profiles with the same name.
+
+    Args:
+        custom_profiles_path: Optional path to YAML file with custom profiles.
+
+    Returns:
+        Merged dictionary of all GPU profiles.
+    """
+    merged = {k: v.model_copy() for k, v in _BUILTIN_PROFILES.items()}
+    if custom_profiles_path is not None:
+        custom = load_gpu_profiles(custom_profiles_path)
+        merged.update(custom)
+    return merged
+
+
+def get_gpu_profile(
+    name: str,
+    custom_profiles_path: Union[str, Path, None] = None,
+) -> GPUProfile:
+    """Get a GPU profile by name.
+
+    Searches custom profiles (if provided) first, then built-in profiles.
+
+    Args:
+        name: GPU profile name.
+        custom_profiles_path: Optional path to YAML file with custom profiles.
 
     Raises:
         KeyError: If the profile name is not found.
     """
-    if name not in _BUILTIN_PROFILES:
-        available = ", ".join(sorted(_BUILTIN_PROFILES.keys()))
+    all_profiles = get_all_profiles(custom_profiles_path)
+    if name not in all_profiles:
+        available = ", ".join(sorted(all_profiles.keys()))
         raise KeyError(f"Unknown GPU profile '{name}'. Available: {available}")
-    return _BUILTIN_PROFILES[name].model_copy()
+    return all_profiles[name]
 
 
-def list_gpu_profiles() -> list[str]:
-    """Return names of all built-in GPU profiles."""
-    return sorted(_BUILTIN_PROFILES.keys())
+def list_gpu_profiles(
+    custom_profiles_path: Union[str, Path, None] = None,
+) -> list[str]:
+    """Return names of all available GPU profiles.
+
+    Args:
+        custom_profiles_path: Optional path to YAML file with custom profiles.
+    """
+    return sorted(get_all_profiles(custom_profiles_path).keys())

--- a/tests/test_custom_gpu_profiles.py
+++ b/tests/test_custom_gpu_profiles.py
@@ -1,0 +1,204 @@
+"""Tests for custom GPU profile loading from YAML."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from xpyd_plan.gpu_profiles import (
+    get_all_profiles,
+    get_gpu_profile,
+    list_gpu_profiles,
+    load_gpu_profiles,
+)
+
+
+@pytest.fixture()
+def valid_yaml(tmp_path):
+    """Create a valid custom GPU profiles YAML file."""
+    data = {
+        "profiles": [
+            {
+                "name": "MI300X-192G",
+                "prefill_tokens_per_sec": 180_000,
+                "decode_tokens_per_sec": 9_000,
+                "memory_gb": 192.0,
+                "cost_per_hour": 6.50,
+            },
+            {
+                "name": "Gaudi3-128G",
+                "prefill_tokens_per_sec": 100_000,
+                "decode_tokens_per_sec": 4_500,
+                "memory_gb": 128.0,
+                "cost_per_hour": 3.80,
+            },
+        ]
+    }
+    path = tmp_path / "gpus.yaml"
+    path.write_text(yaml.dump(data))
+    return path
+
+
+@pytest.fixture()
+def override_yaml(tmp_path):
+    """YAML that overrides a built-in profile."""
+    data = {
+        "profiles": [
+            {
+                "name": "A100-80G",
+                "prefill_tokens_per_sec": 55_000,
+                "decode_tokens_per_sec": 2_200,
+                "memory_gb": 80.0,
+                "cost_per_hour": 2.00,
+            },
+        ]
+    }
+    path = tmp_path / "override.yaml"
+    path.write_text(yaml.dump(data))
+    return path
+
+
+def test_load_valid_yaml(valid_yaml):
+    """Load custom profiles from valid YAML."""
+    profiles = load_gpu_profiles(valid_yaml)
+    assert len(profiles) == 2
+    assert "MI300X-192G" in profiles
+    assert "Gaudi3-128G" in profiles
+    assert profiles["MI300X-192G"].prefill_tokens_per_sec == 180_000
+    assert profiles["Gaudi3-128G"].cost_per_hour == 3.80
+
+
+def test_load_file_not_found(tmp_path):
+    """Raise FileNotFoundError for missing file."""
+    with pytest.raises(FileNotFoundError):
+        load_gpu_profiles(tmp_path / "nonexistent.yaml")
+
+
+def test_load_invalid_no_profiles_key(tmp_path):
+    """Raise ValueError when 'profiles' key missing."""
+    path = tmp_path / "bad.yaml"
+    path.write_text(yaml.dump({"gpus": []}))
+    with pytest.raises(ValueError, match="profiles"):
+        load_gpu_profiles(path)
+
+
+def test_load_invalid_profiles_not_list(tmp_path):
+    """Raise ValueError when profiles is not a list."""
+    path = tmp_path / "bad.yaml"
+    path.write_text(yaml.dump({"profiles": "not-a-list"}))
+    with pytest.raises(ValueError, match="must be a list"):
+        load_gpu_profiles(path)
+
+
+def test_load_invalid_entry_not_mapping(tmp_path):
+    """Raise ValueError when an entry is not a mapping."""
+    path = tmp_path / "bad.yaml"
+    path.write_text(yaml.dump({"profiles": ["just-a-string"]}))
+    with pytest.raises(ValueError, match="must be a mapping"):
+        load_gpu_profiles(path)
+
+
+def test_load_missing_name(tmp_path):
+    """Raise ValueError when entry missing 'name'."""
+    path = tmp_path / "bad.yaml"
+    path.write_text(
+        yaml.dump(
+            {
+                "profiles": [
+                    {
+                        "prefill_tokens_per_sec": 100,
+                        "decode_tokens_per_sec": 50,
+                    }
+                ]
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="missing required 'name'"):
+        load_gpu_profiles(path)
+
+
+def test_load_missing_required_field(tmp_path):
+    """Raise ValueError when required model fields missing."""
+    path = tmp_path / "bad.yaml"
+    path.write_text(
+        yaml.dump(
+            {
+                "profiles": [
+                    {
+                        "name": "Bad-GPU",
+                        # missing prefill_tokens_per_sec and decode_tokens_per_sec
+                    }
+                ]
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="Bad-GPU"):
+        load_gpu_profiles(path)
+
+
+def test_get_all_profiles_without_custom():
+    """get_all_profiles returns only built-in when no custom path."""
+    profiles = get_all_profiles()
+    assert "A100-80G" in profiles
+    assert "H100-80G" in profiles
+
+
+def test_get_all_profiles_with_custom(valid_yaml):
+    """get_all_profiles merges built-in and custom."""
+    profiles = get_all_profiles(valid_yaml)
+    assert "A100-80G" in profiles  # built-in
+    assert "MI300X-192G" in profiles  # custom
+
+
+def test_get_all_profiles_override(override_yaml):
+    """Custom profile overrides built-in with same name."""
+    profiles = get_all_profiles(override_yaml)
+    a100 = profiles["A100-80G"]
+    assert a100.prefill_tokens_per_sec == 55_000
+    assert a100.cost_per_hour == 2.00
+
+
+def test_get_gpu_profile_custom(valid_yaml):
+    """get_gpu_profile can retrieve custom profile."""
+    profile = get_gpu_profile("MI300X-192G", custom_profiles_path=valid_yaml)
+    assert profile.decode_tokens_per_sec == 9_000
+
+
+def test_get_gpu_profile_unknown_with_custom(valid_yaml):
+    """KeyError includes custom profiles in available list."""
+    with pytest.raises(KeyError, match="MI300X-192G"):
+        get_gpu_profile("Nonexistent-GPU", custom_profiles_path=valid_yaml)
+
+
+def test_list_gpu_profiles_with_custom(valid_yaml):
+    """list_gpu_profiles includes custom profiles."""
+    names = list_gpu_profiles(custom_profiles_path=valid_yaml)
+    assert "MI300X-192G" in names
+    assert "Gaudi3-128G" in names
+    assert "A100-80G" in names  # built-in still present
+
+
+def test_backward_compat_get_gpu_profile():
+    """get_gpu_profile still works without custom path (backward compat)."""
+    profile = get_gpu_profile("H100-80G")
+    assert profile.prefill_tokens_per_sec == 120_000
+
+
+def test_backward_compat_list_gpu_profiles():
+    """list_gpu_profiles still works without custom path."""
+    names = list_gpu_profiles()
+    assert "H100-80G" in names
+
+
+def test_empty_profiles_list(tmp_path):
+    """Empty profiles list is valid, returns empty dict."""
+    path = tmp_path / "empty.yaml"
+    path.write_text(yaml.dump({"profiles": []}))
+    profiles = load_gpu_profiles(path)
+    assert profiles == {}
+
+
+def test_load_string_path(valid_yaml):
+    """load_gpu_profiles accepts string path."""
+    profiles = load_gpu_profiles(str(valid_yaml))
+    assert len(profiles) == 2


### PR DESCRIPTION
## Summary

Add `load_gpu_profiles(path)` to load custom GPU profiles from YAML files, merging with built-in profiles. Users with custom/proprietary GPUs (AMD MI300X, Intel Gaudi, etc.) can now use the fleet calculator, normalizer, and capacity planner without modifying source code.

## Changes

- `gpu_profiles.py`: `load_gpu_profiles()`, `get_all_profiles()`, updated `get_gpu_profile()` and `list_gpu_profiles()` with optional `custom_profiles_path`
- `__init__.py`: export new functions
- 17 new tests in `test_custom_gpu_profiles.py`
- Updated `docs/iterations/current.md`

## YAML Format

```yaml
profiles:
  - name: MI300X-192G
    prefill_tokens_per_sec: 180000
    decode_tokens_per_sec: 9000
    memory_gb: 192.0
    cost_per_hour: 6.50
```

Closes #235