### PR TITLE
feat: vLLM Benchmark Format Importer (M108)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1419,3 +1419,49 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Non-zero exit code on FAIL verdict (CI/CD friendly)
 - Programmatic `save_baseline()` and `compare_baseline()` APIs
 - 19 new tests
+
+### M105 ✅ Expand GPU Profile Library
+
+*Completed — PR #234*
+
+- Added 5 new built-in GPU profiles: A10G-24G, A100-40G, L40S-48G, H200-141G, B200-192G
+- GPU library expanded from 2 to 7 profiles
+- 10 tests covering all profiles
+
+### M106 ✅ Custom GPU Profile Loading from YAML
+
+*Completed — PR #236*
+
+- `load_gpu_profiles(path)` function to load custom GPU profiles from YAML files
+- `get_all_profiles()` for merged built-in + custom profiles
+- Updated `get_gpu_profile()` and `list_gpu_profiles()` with optional `custom_profiles_path`
+- Users with custom/proprietary GPUs (AMD MI300X, Intel Gaudi, etc.) can now use all tools without modifying source code
+- 17 new tests
+
+### M107 ✅ Request Rate Limiter Recommender
+
+*Completed — PR #238*
+
+- `RateLimitRecommender` class in `rate_limit.py`
+- `BurstConfig`, `HeadroomInfo`, `RateLimitReport` Pydantic models
+- Analyze benchmarks at different QPS levels, fit QPS→latency relationships
+- Find maximum safe QPS with configurable safety margin (default 10%)
+- Burst allowance computation with configurable time window
+- Per-metric headroom analysis at recommended QPS
+- CLI `rate-limit` subcommand with `--benchmark`, `--sla-ttft`, `--sla-tpot`, `--sla-total`, `--safety-margin`, `--burst-window`
+- Programmatic API via `RateLimitRecommender.recommend()`
+- 19 new tests
+
+### M108 🔄 vLLM Benchmark Format Importer
+
+*In progress — PR #TBD*
+
+- `VLLMImporter` class in `vllm_import.py`
+- `VLLMBenchmarkData`, `VLLMRequest`, `ImportResult`, `ImportConfig` Pydantic models
+- Parse vLLM `benchmark_serving.py` output format (list of dicts with prompt_len, output_len, ttft, tpot/itl, request_latency, timestamp)
+- Convert to native xpyd-plan BenchmarkData format
+- Auto-detect vLLM format vs native format
+- Handle missing fields gracefully (no timestamp → generate sequential, no ttft → estimate, itl used as tpot fallback)
+- CLI `import` subcommand with `--input`, `--format vllm|auto`, `--output`, `--prefill-instances`, `--decode-instances`
+- Programmatic `import_vllm()` API
+- 32 new tests

--- a/docs/iterations/current.md
+++ b/docs/iterations/current.md
@@ -1,24 +1,26 @@
 # xPyD-plan Current Iteration Status
 
-> Last updated: 2026-04-05
+> Last updated: 2026-04-06
 
 ---
 
-## Current Milestone: M107 — Request Rate Limiter Recommender ✅
+## Current Milestone: M108 — vLLM Benchmark Format Importer 🔄
 
-Recommend safe request rate limits based on multi-QPS benchmark data. Interpolates latency vs QPS curves to find the maximum sustainable QPS within SLA constraints, then suggests rate limits with configurable safety margins.
+Support direct import of vLLM `benchmark_serving.py` JSON output and convert to native xpyd-plan BenchmarkData format.
 
 ### Changes
-- **`src/xpyd_plan/rate_recommender.py`**: `RateRecommender` class with interpolation-based max QPS finder and safety margin
-- **`tests/test_rate_recommender.py`**: 19 new tests
-- **`src/xpyd_plan/cli/_rate_recommend.py`**: CLI `rate-recommend` subcommand
-- **`src/xpyd_plan/__init__.py`**: Added exports (preserved M106 `load_gpu_profiles`, `get_all_profiles`)
+- **`src/xpyd_plan/vllm_import.py`**: `VLLMImporter` class, `VLLMBenchmarkData`, `VLLMRequest`, `ImportResult`, `ImportConfig` models, `import_vllm()` API
+- **`src/xpyd_plan/cli/_import.py`**: CLI `import` subcommand
+- **`src/xpyd_plan/cli/_main.py`**: Register import subcommand
+- **`src/xpyd_plan/__init__.py`**: Added exports (preserved all prior exports)
+- **`tests/test_vllm_import.py`**: 32 new tests
+- **`ROADMAP.md`**: Added M105, M106, M107, M108 entries
 
 ---
 
 ## Previous Milestones
 
-The project has completed **105 milestones**, covering the full feature chain from core analysis to advanced optimization.
+The project has completed **107 milestones**, covering the full feature chain from core analysis to advanced optimization.
 
 ---
 
@@ -27,7 +29,7 @@ The project has completed **105 milestones**, covering the full feature chain fr
 1. **Offline analysis only** — Does not support real-time streaming ingestion of production traffic data
 2. **Linear scaling assumption** — `plan-capacity` uses a linear model, which may deviate from reality under high concurrency
 3. **Single-cluster perspective** — Cross-cluster/cross-region joint optimization is not yet supported
-4. **Benchmark format** — Only supports xpyd-bench native format and compatible JSON; direct import from other benchmark tools is not supported
+4. **Benchmark format** — Now supports vLLM format import in addition to native format
 
 ---
 
@@ -38,11 +40,11 @@ The project has completed **105 milestones**, covering the full feature chain fr
 - Closed-loop integration with xPyD-proxy auto-tuning
 - Web UI dashboard (replacing TUI)
 - Richer visualizations (interactive charts)
-- Custom GPU profile loading from YAML config
+- Support additional benchmark tool formats (TensorRT-LLM, SGLang)
 
 ## Iteration History
 
 | # | Date | Task | Result | Reviewer Comments |
 |---|------|------|--------|-------------------|
-| 1 | 2026-04-06 | M107 Rate Limiter Recommender | 🔄 changes requested | Both bots: __init__.py dropped M106 exports, current.md missing M107 info |
-| 2 | 2026-04-06 | M107 fix review comments | ⏳ pending re-review | Restored M106 exports, added M107 iteration record |
+| 1 | 2026-04-06 | M107 Rate Limiter Recommender | ✅ merged | PR #238 |
+| 2 | 2026-04-06 | M108 vLLM Benchmark Importer | ⏳ pending review | PR #TBD |

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -1407,3 +1407,21 @@ __all__ += [
     "compare_baseline",
     "save_baseline",
 ]
+
+from xpyd_plan.vllm_import import (  # noqa: E402
+    ImportConfig,
+    ImportResult,
+    VLLMBenchmarkData,
+    VLLMImporter,
+    VLLMRequest,
+    import_vllm,
+)
+
+__all__ += [
+    "ImportConfig",
+    "ImportResult",
+    "VLLMBenchmarkData",
+    "VLLMImporter",
+    "VLLMRequest",
+    "import_vllm",
+]

--- a/src/xpyd_plan/cli/_import.py
+++ b/src/xpyd_plan/cli/_import.py
@@ -1,0 +1,103 @@
+"""CLI import command — import vLLM benchmark data."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from rich.console import Console
+
+from xpyd_plan.vllm_import import import_vllm
+
+
+def _cmd_import(args: argparse.Namespace) -> None:
+    """Handle the 'import' subcommand."""
+    console = Console()
+
+    if args.prefill_instances is None or args.decode_instances is None:
+        console.print(
+            "[red]Error: --prefill-instances and --decode-instances are required[/red]"
+        )
+        sys.exit(1)
+
+    try:
+        result = import_vllm(
+            input_path=args.input,
+            num_prefill_instances=args.prefill_instances,
+            num_decode_instances=args.decode_instances,
+            output_path=args.output,
+            format=args.format,
+        )
+    except (ValueError, FileNotFoundError, json.JSONDecodeError) as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        sys.exit(1)
+
+    output_format = getattr(args, "output_format", "table")
+    if output_format == "json":
+        json.dump(result.model_dump(), sys.stdout, indent=2, default=str)
+        sys.stdout.write("\n")
+        return
+
+    console.print("\n[bold]Import Result[/bold]")
+    console.print(f"  Source format: {result.source_format}")
+    console.print(f"  Requests imported: {result.num_requests}")
+    meta = result.benchmark_data.metadata
+    console.print(f"  Prefill instances: {meta.num_prefill_instances}")
+    console.print(f"  Decode instances: {meta.num_decode_instances}")
+    console.print(f"  Measured QPS: {meta.measured_qps:.2f}")
+
+    if result.warnings:
+        console.print(f"\n[yellow]Warnings ({len(result.warnings)}):[/yellow]")
+        for w in result.warnings[:10]:
+            console.print(f"  ⚠ {w}")
+        if len(result.warnings) > 10:
+            console.print(f"  ... and {len(result.warnings) - 10} more")
+
+    if args.output:
+        console.print(f"\n  Output saved to: {args.output}")
+
+    console.print()
+
+
+def add_import_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Add the import subcommand parser."""
+    parser = subparsers.add_parser(
+        "import",
+        help="Import vLLM benchmark data to native format",
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Path to input benchmark JSON file",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["vllm", "native", "auto"],
+        default="auto",
+        help="Input format (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Path to save converted native-format JSON",
+    )
+    parser.add_argument(
+        "--prefill-instances",
+        type=int,
+        required=True,
+        help="Number of prefill instances in the cluster",
+    )
+    parser.add_argument(
+        "--decode-instances",
+        type=int,
+        required=True,
+        help="Number of decode instances in the cluster",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.set_defaults(func=_cmd_import)

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -44,6 +44,7 @@ from xpyd_plan.cli._generate import _cmd_generate
 from xpyd_plan.cli._goodput import add_goodput_parser
 from xpyd_plan.cli._health_check import _cmd_health_check, add_health_check_parser
 from xpyd_plan.cli._heatmap import _cmd_heatmap, add_heatmap_parser
+from xpyd_plan.cli._import import add_import_parser
 from xpyd_plan.cli._interpolate import _cmd_interpolate
 from xpyd_plan.cli._jitter import add_jitter_parser
 from xpyd_plan.cli._load_profile import add_load_profile_parser
@@ -957,6 +958,7 @@ def main(argv: list[str] | None = None) -> None:
     # --- timeline subcommand ---
     add_throughput_parser(subparsers)
     add_queue_parser(subparsers)
+    add_import_parser(subparsers)
     add_rate_limit_parser(subparsers)
     add_batch_analysis_parser(subparsers)
     add_stat_summary_parser(subparsers)

--- a/src/xpyd_plan/vllm_import.py
+++ b/src/xpyd_plan/vllm_import.py
@@ -1,0 +1,357 @@
+"""vLLM Benchmark Format Importer — import vLLM benchmark_serving.py output.
+
+Converts vLLM benchmark JSON output (list of request dicts) into the native
+xpyd-plan BenchmarkData format for downstream analysis.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+
+
+class VLLMRequest(BaseModel):
+    """A single request record from vLLM benchmark_serving.py output."""
+
+    prompt_len: int = Field(..., ge=1, description="Number of prompt tokens")
+    output_len: int = Field(..., ge=1, description="Number of output/generated tokens")
+    ttft: float = Field(..., ge=0, description="Time to first token (seconds)")
+    tpot: float | None = Field(None, ge=0, description="Time per output token (seconds)")
+    itl: float | None = Field(None, ge=0, description="Inter-token latency (seconds)")
+    request_latency: float = Field(..., ge=0, description="Total request latency (seconds)")
+    timestamp: float | None = Field(None, description="Request start timestamp (epoch seconds)")
+
+
+class VLLMBenchmarkData(BaseModel):
+    """Parsed vLLM benchmark data (list of request records)."""
+
+    requests: list[VLLMRequest] = Field(..., min_length=1)
+
+
+class ImportConfig(BaseModel):
+    """Configuration for vLLM import."""
+
+    num_prefill_instances: int = Field(..., ge=1, description="Number of prefill instances")
+    num_decode_instances: int = Field(..., ge=1, description="Number of decode instances")
+    format: str = Field("auto", description="Input format: 'vllm', 'native', or 'auto'")
+
+
+class ImportResult(BaseModel):
+    """Result of a vLLM import operation."""
+
+    benchmark_data: BenchmarkData
+    source_format: str = Field(..., description="Detected source format")
+    num_requests: int = Field(..., ge=1, description="Number of requests imported")
+    warnings: list[str] = Field(default_factory=list, description="Import warnings")
+
+
+def _detect_format(data: Any) -> str:
+    """Detect whether data is vLLM format or native format.
+
+    vLLM format: list of dicts with 'prompt_len' and 'request_latency' keys.
+    Native format: dict with 'metadata' and 'requests' keys.
+
+    Returns
+    -------
+    str
+        'vllm' or 'native'.
+
+    Raises
+    ------
+    ValueError
+        If the format cannot be determined.
+    """
+    if isinstance(data, list):
+        if len(data) == 0:
+            raise ValueError("Empty list: cannot detect format")
+        first = data[0]
+        if isinstance(first, dict) and "prompt_len" in first and "request_latency" in first:
+            return "vllm"
+        raise ValueError(
+            "List format detected but missing expected vLLM fields "
+            "(prompt_len, request_latency)"
+        )
+    if isinstance(data, dict):
+        if "metadata" in data and "requests" in data:
+            return "native"
+        # Could be a vLLM wrapper with a results key
+        if "results" in data and isinstance(data["results"], list):
+            return "vllm"
+        raise ValueError(
+            "Dict format detected but missing expected fields "
+            "(metadata+requests for native, or results for vLLM wrapper)"
+        )
+    raise ValueError(f"Unexpected data type: {type(data).__name__}")
+
+
+def _extract_vllm_requests(data: Any) -> list[dict[str, Any]]:
+    """Extract the request list from vLLM data (handles both list and wrapper dict)."""
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict) and "results" in data:
+        return data["results"]
+    raise ValueError("Cannot extract vLLM request list from data")
+
+
+def _parse_vllm_request(raw: dict[str, Any], index: int) -> tuple[VLLMRequest, list[str]]:
+    """Parse a single vLLM request dict, handling missing/alternative fields.
+
+    Returns (VLLMRequest, warnings).
+    """
+    warnings: list[str] = []
+
+    prompt_len = raw.get("prompt_len")
+    if prompt_len is None:
+        raise ValueError(f"Request {index}: missing required field 'prompt_len'")
+
+    output_len = raw.get("output_len")
+    if output_len is None:
+        raise ValueError(f"Request {index}: missing required field 'output_len'")
+
+    request_latency = raw.get("request_latency")
+    if request_latency is None:
+        raise ValueError(f"Request {index}: missing required field 'request_latency'")
+
+    ttft = raw.get("ttft")
+    if ttft is None:
+        # Fall back: estimate TTFT as 10% of request_latency
+        ttft = request_latency * 0.1
+        warnings.append(f"Request {index}: missing 'ttft', estimated from request_latency")
+
+    # tpot: try tpot first, then itl
+    tpot = raw.get("tpot")
+    itl = raw.get("itl")
+    if tpot is None and itl is not None:
+        tpot = itl
+    if tpot is None and output_len > 1:
+        # Estimate from (total - ttft) / (output_tokens - 1)
+        remaining = request_latency - ttft
+        tpot = remaining / (output_len - 1) if output_len > 1 else 0.0
+        warnings.append(f"Request {index}: missing 'tpot'/'itl', estimated from latency")
+
+    timestamp = raw.get("timestamp")
+
+    return VLLMRequest(
+        prompt_len=int(prompt_len),
+        output_len=int(output_len),
+        ttft=float(ttft),
+        tpot=float(tpot) if tpot is not None else None,
+        itl=float(itl) if itl is not None else None,
+        request_latency=float(request_latency),
+        timestamp=float(timestamp) if timestamp is not None else None,
+    ), warnings
+
+
+class VLLMImporter:
+    """Import vLLM benchmark_serving.py output into native BenchmarkData format.
+
+    Parameters
+    ----------
+    num_prefill_instances : int
+        Number of prefill instances in the cluster.
+    num_decode_instances : int
+        Number of decode instances in the cluster.
+    """
+
+    def __init__(
+        self,
+        num_prefill_instances: int,
+        num_decode_instances: int,
+    ) -> None:
+        if num_prefill_instances < 1:
+            raise ValueError("num_prefill_instances must be >= 1")
+        if num_decode_instances < 1:
+            raise ValueError("num_decode_instances must be >= 1")
+        self._prefill = num_prefill_instances
+        self._decode = num_decode_instances
+
+    def import_data(self, data: Any) -> ImportResult:
+        """Import vLLM benchmark data from parsed JSON.
+
+        Parameters
+        ----------
+        data : Any
+            Parsed JSON data — either a list of request dicts or a wrapper dict.
+
+        Returns
+        -------
+        ImportResult
+            The converted benchmark data and metadata.
+        """
+        raw_requests = _extract_vllm_requests(data)
+        if not raw_requests:
+            raise ValueError("No requests found in vLLM data")
+
+        all_warnings: list[str] = []
+        vllm_requests: list[VLLMRequest] = []
+
+        for i, raw in enumerate(raw_requests):
+            req, warns = _parse_vllm_request(raw, i)
+            vllm_requests.append(req)
+            all_warnings.extend(warns)
+
+        # Convert to native BenchmarkRequest format
+        benchmark_requests: list[BenchmarkRequest] = []
+        has_timestamps = any(r.timestamp is not None for r in vllm_requests)
+
+        for i, vr in enumerate(vllm_requests):
+            # Generate sequential timestamps if missing
+            if vr.timestamp is not None:
+                ts = vr.timestamp
+            elif has_timestamps:
+                # Some have timestamps, some don't — use 0.0 for missing
+                ts = 0.0
+                all_warnings.append(
+                    f"Request {i}: missing timestamp while others have it, using 0.0"
+                )
+            else:
+                # No timestamps at all — generate sequential
+                ts = float(i)
+
+            # vLLM times are in seconds, convert to ms
+            ttft_ms = vr.ttft * 1000.0
+            total_latency_ms = vr.request_latency * 1000.0
+
+            # TPOT: use tpot if available, otherwise estimate
+            if vr.tpot is not None:
+                tpot_ms = vr.tpot * 1000.0
+            elif vr.output_len > 1:
+                tpot_ms = (total_latency_ms - ttft_ms) / (vr.output_len - 1)
+            else:
+                tpot_ms = 0.0
+
+            benchmark_requests.append(
+                BenchmarkRequest(
+                    request_id=f"vllm-{i:06d}",
+                    prompt_tokens=vr.prompt_len,
+                    output_tokens=vr.output_len,
+                    ttft_ms=ttft_ms,
+                    tpot_ms=tpot_ms,
+                    total_latency_ms=total_latency_ms,
+                    timestamp=ts,
+                )
+            )
+
+        # Compute measured QPS
+        if len(benchmark_requests) >= 2 and has_timestamps:
+            timestamps = [r.timestamp for r in benchmark_requests]
+            duration = max(timestamps) - min(timestamps)
+            measured_qps = (
+                len(benchmark_requests) / duration
+                if duration > 0
+                else float(len(benchmark_requests))
+            )
+        else:
+            # Estimate from total latencies
+            total_time = sum(vr.request_latency for vr in vllm_requests)
+            measured_qps = (
+                len(vllm_requests) / (total_time / len(vllm_requests))
+                if total_time > 0
+                else 1.0
+            )
+
+        metadata = BenchmarkMetadata(
+            num_prefill_instances=self._prefill,
+            num_decode_instances=self._decode,
+            total_instances=self._prefill + self._decode,
+            measured_qps=measured_qps,
+        )
+
+        benchmark_data = BenchmarkData(
+            metadata=metadata,
+            requests=benchmark_requests,
+        )
+
+        return ImportResult(
+            benchmark_data=benchmark_data,
+            source_format="vllm",
+            num_requests=len(benchmark_requests),
+            warnings=all_warnings,
+        )
+
+    def import_file(self, path: str | Path) -> ImportResult:
+        """Import from a JSON file.
+
+        Parameters
+        ----------
+        path : str or Path
+            Path to the vLLM benchmark JSON file.
+
+        Returns
+        -------
+        ImportResult
+        """
+        path = Path(path)
+        with path.open() as f:
+            data = json.load(f)
+        return self.import_data(data)
+
+
+def import_vllm(
+    input_path: str | Path,
+    num_prefill_instances: int,
+    num_decode_instances: int,
+    output_path: str | Path | None = None,
+    format: str = "auto",
+) -> ImportResult:
+    """Import vLLM benchmark data and optionally save as native format.
+
+    This is the programmatic API for vLLM benchmark import.
+
+    Parameters
+    ----------
+    input_path : str or Path
+        Path to the input benchmark JSON file.
+    num_prefill_instances : int
+        Number of prefill instances in the cluster.
+    num_decode_instances : int
+        Number of decode instances in the cluster.
+    output_path : str or Path or None
+        If provided, save the converted data to this path.
+    format : str
+        Input format: 'vllm', 'native', or 'auto' (default).
+
+    Returns
+    -------
+    ImportResult
+    """
+    input_path = Path(input_path)
+    with input_path.open() as f:
+        data = json.load(f)
+
+    # Detect or use specified format
+    if format == "auto":
+        detected = _detect_format(data)
+    else:
+        detected = format
+
+    if detected == "native":
+        # Already native — just load it
+        from .bench_adapter import load_benchmark_auto
+
+        benchmark_data = load_benchmark_auto(str(input_path))
+        return ImportResult(
+            benchmark_data=benchmark_data,
+            source_format="native",
+            num_requests=len(benchmark_data.requests),
+            warnings=[],
+        )
+
+    importer = VLLMImporter(
+        num_prefill_instances=num_prefill_instances,
+        num_decode_instances=num_decode_instances,
+    )
+    result = importer.import_data(data)
+
+    if output_path is not None:
+        output_path = Path(output_path)
+        with output_path.open("w") as f:
+            json.dump(result.benchmark_data.model_dump(), f, indent=2)
+            f.write("\n")
+
+    return result

--- a/tests/test_vllm_import.py
+++ b/tests/test_vllm_import.py
@@ -1,0 +1,308 @@
+"""Tests for vLLM Benchmark Format Importer (M108)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from xpyd_plan.vllm_import import (
+    ImportConfig,
+    VLLMBenchmarkData,
+    VLLMImporter,
+    VLLMRequest,
+    _detect_format,
+    _parse_vllm_request,
+    import_vllm,
+)
+
+
+def _make_vllm_requests(n: int = 5, with_timestamps: bool = True) -> list[dict]:
+    """Generate sample vLLM request dicts."""
+    requests = []
+    for i in range(n):
+        req = {
+            "prompt_len": 100 + i * 10,
+            "output_len": 50 + i * 5,
+            "ttft": 0.05 + i * 0.01,
+            "tpot": 0.02 + i * 0.001,
+            "request_latency": 1.0 + i * 0.1,
+        }
+        if with_timestamps:
+            req["timestamp"] = 1700000000.0 + i * 0.5
+        requests.append(req)
+    return requests
+
+
+def _write_json(data, suffix=".json") -> Path:
+    """Write data to a temp JSON file and return its path."""
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=suffix, delete=False)
+    json.dump(data, f)
+    f.close()
+    return Path(f.name)
+
+
+class TestFormatDetection:
+    """Tests for format auto-detection."""
+
+    def test_detect_vllm_list(self):
+        data = _make_vllm_requests(2)
+        assert _detect_format(data) == "vllm"
+
+    def test_detect_native_dict(self):
+        data = {"metadata": {}, "requests": []}
+        assert _detect_format(data) == "native"
+
+    def test_detect_vllm_wrapper(self):
+        data = {"results": _make_vllm_requests(2)}
+        assert _detect_format(data) == "vllm"
+
+    def test_detect_empty_list_raises(self):
+        with pytest.raises(ValueError, match="Empty list"):
+            _detect_format([])
+
+    def test_detect_unknown_dict_raises(self):
+        with pytest.raises(ValueError, match="Dict format detected"):
+            _detect_format({"foo": "bar"})
+
+    def test_detect_unknown_list_raises(self):
+        with pytest.raises(ValueError, match="missing expected vLLM fields"):
+            _detect_format([{"foo": "bar"}])
+
+    def test_detect_wrong_type_raises(self):
+        with pytest.raises(ValueError, match="Unexpected data type"):
+            _detect_format("not a dict or list")
+
+
+class TestVLLMRequest:
+    """Tests for VLLMRequest model."""
+
+    def test_basic_request(self):
+        req = VLLMRequest(
+            prompt_len=100, output_len=50, ttft=0.05, tpot=0.02,
+            request_latency=1.0, timestamp=1700000000.0,
+        )
+        assert req.prompt_len == 100
+        assert req.tpot == 0.02
+
+    def test_request_without_optional_fields(self):
+        req = VLLMRequest(
+            prompt_len=100, output_len=50, ttft=0.05,
+            request_latency=1.0,
+        )
+        assert req.tpot is None
+        assert req.timestamp is None
+
+
+class TestParseVLLMRequest:
+    """Tests for single request parsing with graceful fallbacks."""
+
+    def test_full_fields(self):
+        raw = {
+            "prompt_len": 100, "output_len": 50, "ttft": 0.05,
+            "tpot": 0.02, "request_latency": 1.0, "timestamp": 1.0,
+        }
+        req, warns = _parse_vllm_request(raw, 0)
+        assert req.prompt_len == 100
+        assert len(warns) == 0
+
+    def test_missing_ttft_estimated(self):
+        raw = {
+            "prompt_len": 100, "output_len": 50,
+            "request_latency": 1.0,
+        }
+        req, warns = _parse_vllm_request(raw, 0)
+        assert req.ttft == pytest.approx(0.1)  # 10% of 1.0
+        assert any("missing 'ttft'" in w for w in warns)
+
+    def test_itl_used_as_tpot(self):
+        raw = {
+            "prompt_len": 100, "output_len": 50, "ttft": 0.05,
+            "itl": 0.03, "request_latency": 1.0,
+        }
+        req, warns = _parse_vllm_request(raw, 0)
+        assert req.tpot == 0.03
+        assert req.itl == 0.03
+
+    def test_missing_tpot_estimated(self):
+        raw = {
+            "prompt_len": 100, "output_len": 50, "ttft": 0.05,
+            "request_latency": 1.0,
+        }
+        req, warns = _parse_vllm_request(raw, 0)
+        assert req.tpot is not None
+        assert any("missing 'tpot'" in w for w in warns)
+
+    def test_missing_prompt_len_raises(self):
+        with pytest.raises(ValueError, match="missing required field 'prompt_len'"):
+            _parse_vllm_request({"output_len": 50, "request_latency": 1.0}, 0)
+
+    def test_missing_request_latency_raises(self):
+        with pytest.raises(ValueError, match="missing required field 'request_latency'"):
+            _parse_vllm_request({"prompt_len": 100, "output_len": 50}, 0)
+
+
+class TestVLLMImporter:
+    """Tests for VLLMImporter class."""
+
+    def test_basic_import(self):
+        data = _make_vllm_requests(5)
+        importer = VLLMImporter(num_prefill_instances=2, num_decode_instances=4)
+        result = importer.import_data(data)
+        assert result.num_requests == 5
+        assert result.source_format == "vllm"
+        assert result.benchmark_data.metadata.num_prefill_instances == 2
+        assert result.benchmark_data.metadata.num_decode_instances == 4
+        assert result.benchmark_data.metadata.total_instances == 6
+
+    def test_import_converts_to_ms(self):
+        data = [{"prompt_len": 100, "output_len": 50, "ttft": 0.05,
+                 "tpot": 0.02, "request_latency": 1.0, "timestamp": 1.0}]
+        importer = VLLMImporter(num_prefill_instances=1, num_decode_instances=1)
+        result = importer.import_data(data)
+        req = result.benchmark_data.requests[0]
+        assert req.ttft_ms == pytest.approx(50.0)
+        assert req.tpot_ms == pytest.approx(20.0)
+        assert req.total_latency_ms == pytest.approx(1000.0)
+
+    def test_import_without_timestamps(self):
+        data = _make_vllm_requests(3, with_timestamps=False)
+        importer = VLLMImporter(num_prefill_instances=1, num_decode_instances=1)
+        result = importer.import_data(data)
+        # Sequential timestamps: 0.0, 1.0, 2.0
+        timestamps = [r.timestamp for r in result.benchmark_data.requests]
+        assert timestamps == [0.0, 1.0, 2.0]
+
+    def test_import_wrapper_dict(self):
+        data = {"results": _make_vllm_requests(3)}
+        importer = VLLMImporter(num_prefill_instances=1, num_decode_instances=1)
+        result = importer.import_data(data)
+        assert result.num_requests == 3
+
+    def test_import_empty_raises(self):
+        importer = VLLMImporter(num_prefill_instances=1, num_decode_instances=1)
+        with pytest.raises(ValueError, match="No requests found"):
+            importer.import_data([])
+
+    def test_invalid_instances_raises(self):
+        with pytest.raises(ValueError, match="num_prefill_instances must be >= 1"):
+            VLLMImporter(num_prefill_instances=0, num_decode_instances=1)
+        with pytest.raises(ValueError, match="num_decode_instances must be >= 1"):
+            VLLMImporter(num_prefill_instances=1, num_decode_instances=0)
+
+    def test_import_file(self, tmp_path):
+        data = _make_vllm_requests(3)
+        path = tmp_path / "bench.json"
+        path.write_text(json.dumps(data))
+        importer = VLLMImporter(num_prefill_instances=2, num_decode_instances=3)
+        result = importer.import_file(path)
+        assert result.num_requests == 3
+
+    def test_request_ids_sequential(self):
+        data = _make_vllm_requests(3)
+        importer = VLLMImporter(num_prefill_instances=1, num_decode_instances=1)
+        result = importer.import_data(data)
+        ids = [r.request_id for r in result.benchmark_data.requests]
+        assert ids == ["vllm-000000", "vllm-000001", "vllm-000002"]
+
+    def test_measured_qps_from_timestamps(self):
+        data = _make_vllm_requests(5, with_timestamps=True)
+        importer = VLLMImporter(num_prefill_instances=1, num_decode_instances=1)
+        result = importer.import_data(data)
+        # 5 requests over 2.0 seconds → 2.5 QPS
+        assert result.benchmark_data.metadata.measured_qps == pytest.approx(2.5)
+
+
+class TestImportVLLMFunction:
+    """Tests for the programmatic import_vllm() API."""
+
+    def test_import_vllm_auto_detect(self, tmp_path):
+        data = _make_vllm_requests(5)
+        input_path = tmp_path / "input.json"
+        input_path.write_text(json.dumps(data))
+        result = import_vllm(input_path, num_prefill_instances=2, num_decode_instances=3)
+        assert result.source_format == "vllm"
+        assert result.num_requests == 5
+
+    def test_import_vllm_with_output(self, tmp_path):
+        data = _make_vllm_requests(3)
+        input_path = tmp_path / "input.json"
+        input_path.write_text(json.dumps(data))
+        output_path = tmp_path / "output.json"
+        import_vllm(
+            input_path, num_prefill_instances=1, num_decode_instances=1,
+            output_path=output_path,
+        )
+        assert output_path.exists()
+        saved = json.loads(output_path.read_text())
+        assert "metadata" in saved
+        assert "requests" in saved
+        assert len(saved["requests"]) == 3
+
+    def test_import_native_passthrough(self, tmp_path):
+        """Native format should be passed through without conversion."""
+        native_data = {
+            "metadata": {
+                "num_prefill_instances": 2,
+                "num_decode_instances": 4,
+                "total_instances": 6,
+                "measured_qps": 10.0,
+            },
+            "requests": [
+                {
+                    "request_id": "r0",
+                    "prompt_tokens": 100,
+                    "output_tokens": 50,
+                    "ttft_ms": 50.0,
+                    "tpot_ms": 20.0,
+                    "total_latency_ms": 1000.0,
+                    "timestamp": 1.0,
+                }
+            ],
+        }
+        input_path = tmp_path / "native.json"
+        input_path.write_text(json.dumps(native_data))
+        result = import_vllm(
+            input_path, num_prefill_instances=1, num_decode_instances=1,
+            format="auto",
+        )
+        assert result.source_format == "native"
+
+    def test_import_explicit_vllm_format(self, tmp_path):
+        data = _make_vllm_requests(2)
+        input_path = tmp_path / "input.json"
+        input_path.write_text(json.dumps(data))
+        result = import_vllm(
+            input_path, num_prefill_instances=1, num_decode_instances=1,
+            format="vllm",
+        )
+        assert result.source_format == "vllm"
+
+
+class TestImportConfig:
+    """Tests for ImportConfig model."""
+
+    def test_defaults(self):
+        cfg = ImportConfig(num_prefill_instances=2, num_decode_instances=4)
+        assert cfg.format == "auto"
+
+    def test_custom_format(self):
+        cfg = ImportConfig(num_prefill_instances=1, num_decode_instances=1, format="vllm")
+        assert cfg.format == "vllm"
+
+
+class TestVLLMBenchmarkData:
+    """Tests for VLLMBenchmarkData model."""
+
+    def test_basic(self):
+        reqs = [
+            VLLMRequest(prompt_len=100, output_len=50, ttft=0.05, request_latency=1.0)
+        ]
+        data = VLLMBenchmarkData(requests=reqs)
+        assert len(data.requests) == 1
+
+    def test_empty_raises(self):
+        with pytest.raises(Exception):
+            VLLMBenchmarkData(requests=[])


### PR DESCRIPTION
## Summary

Support direct import of vLLM `benchmark_serving.py` JSON output and convert to native xpyd-plan BenchmarkData format.

## Changes

- **`src/xpyd_plan/vllm_import.py`**: `VLLMImporter` class, `VLLMBenchmarkData`, `VLLMRequest`, `ImportResult`, `ImportConfig` Pydantic models, `import_vllm()` API
- **`src/xpyd_plan/cli/_import.py`**: CLI `import` subcommand with `--input`, `--format vllm|auto`, `--output`, `--prefill-instances`, `--decode-instances`
- **`src/xpyd_plan/cli/_main.py`**: Register import subcommand
- **`src/xpyd_plan/__init__.py`**: Added exports (preserved all prior exports)
- **`tests/test_vllm_import.py`**: 32 new tests
- **`ROADMAP.md`**: Added M105, M106, M107, M108 entries
- **`docs/iterations/current.md`**: Updated for M108

## Features

- Parse vLLM benchmark_serving.py output (list of dicts with prompt_len, output_len, ttft, tpot/itl, request_latency, timestamp)
- Auto-detect vLLM format vs native format
- Handle missing fields gracefully (no timestamp → sequential, no ttft → estimate, itl as tpot fallback)
- Users specify instance counts since vLLM output doesn't include cluster config
- Seconds-to-milliseconds conversion for all latency fields

Closes #239