### PR TITLE
feat: vLLM Benchmark Command Generator (M109)

### DIFF
--- a/docs/iterations/current.md
+++ b/docs/iterations/current.md
@@ -4,9 +4,9 @@
 
 ---
 
-## Current Milestone: M108 — vLLM Benchmark Format Importer 🔄
+## Current Milestone: M109 — vLLM Benchmark Command Generator 🔄
 
-Support direct import of vLLM `benchmark_serving.py` JSON output and convert to native xpyd-plan BenchmarkData format.
+Generate ready-to-run vLLM server and benchmark_serving.py commands for P:D ratio exploration.
 
 ### Changes
 - **`src/xpyd_plan/vllm_import.py`**: `VLLMImporter` class, `VLLMBenchmarkData`, `VLLMRequest`, `ImportResult`, `ImportConfig` models, `import_vllm()` API
@@ -48,3 +48,4 @@ The project has completed **107 milestones**, covering the full feature chain fr
 |---|------|------|--------|-------------------|
 | 1 | 2026-04-06 | M107 Rate Limiter Recommender | ✅ merged | PR #238 |
 | 2 | 2026-04-06 | M108 vLLM Benchmark Importer | ⏳ pending review | PR #TBD |
+| 3 | 2026-04-06 | M109 vLLM Benchmark Command Generator | ⏳ awaiting review | Issue #241, PR #TBD |

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -1408,6 +1408,22 @@ __all__ += [
     "save_baseline",
 ]
 
+from xpyd_plan.vllm_commands import BenchmarkCommand  # noqa: E402, I001
+from xpyd_plan.vllm_commands import CommandGenerator  # noqa: E402
+from xpyd_plan.vllm_commands import CommandSet  # noqa: E402
+from xpyd_plan.vllm_commands import ServerCommand  # noqa: E402
+from xpyd_plan.vllm_commands import generate_vllm_commands  # noqa: E402
+from xpyd_plan.vllm_commands import CommandConfig as VLLMCommandConfig  # noqa: E402
+
+__all__ += [
+    "BenchmarkCommand",
+    "CommandGenerator",
+    "CommandSet",
+    "ServerCommand",
+    "VLLMCommandConfig",
+    "generate_vllm_commands",
+]
+
 from xpyd_plan.vllm_import import (  # noqa: E402
     ImportConfig,
     ImportResult,

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -97,6 +97,7 @@ from xpyd_plan.cli._token_efficiency import add_token_efficiency_parser, handle_
 from xpyd_plan.cli._trend import _cmd_trend
 from xpyd_plan.cli._validate import _cmd_validate
 from xpyd_plan.cli._variance import _cmd_variance, add_variance_parser
+from xpyd_plan.cli._vllm_commands import register_vllm_commands
 from xpyd_plan.cli._warmup_filter import _cmd_warmup_filter, add_warmup_filter_parser
 from xpyd_plan.cli._weighted_goodput import register as _register_weighted_goodput
 from xpyd_plan.cli._whatif import _cmd_what_if
@@ -959,6 +960,7 @@ def main(argv: list[str] | None = None) -> None:
     add_throughput_parser(subparsers)
     add_queue_parser(subparsers)
     add_import_parser(subparsers)
+    register_vllm_commands(subparsers)
     add_rate_limit_parser(subparsers)
     add_batch_analysis_parser(subparsers)
     add_stat_summary_parser(subparsers)
@@ -1296,6 +1298,10 @@ def main(argv: list[str] | None = None) -> None:
         from xpyd_plan.cli._rate_limit import _cmd_rate_limit
 
         _cmd_rate_limit(args)
+    elif args.command == "vllm-commands":
+        from xpyd_plan.cli._vllm_commands import _cmd_vllm_commands
+
+        _cmd_vllm_commands(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/cli/_vllm_commands.py
+++ b/src/xpyd_plan/cli/_vllm_commands.py
@@ -1,0 +1,104 @@
+"""CLI vllm-commands subcommand."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.vllm_commands import CommandConfig, CommandGenerator
+
+
+def _cmd_vllm_commands(args: argparse.Namespace) -> None:
+    """Handle the 'vllm-commands' subcommand."""
+    console = Console()
+
+    qps_levels = [float(q) for q in args.qps.split(",")]
+
+    config = CommandConfig(
+        model=args.model,
+        total_instances=args.total_instances,
+        qps_levels=qps_levels,
+        tp_size=getattr(args, "tp_size", 1),
+        max_model_len=getattr(args, "max_model_len", None),
+        dataset=getattr(args, "dataset", None),
+        num_prompts=getattr(args, "num_prompts", 1000),
+        host=getattr(args, "host", "localhost"),
+        port=getattr(args, "port", 8000),
+    )
+
+    gen = CommandGenerator()
+    result = gen.generate(config)
+
+    if args.output_script:
+        script = gen.to_shell_script(result)
+        with open(args.output_script, "w") as f:
+            f.write(script)
+        console.print(
+            f"[green]Shell script written to {args.output_script} "
+            f"({len(result)} ratios)[/green]"
+        )
+        return
+
+    output_format = getattr(args, "output_format", "table")
+
+    if output_format == "json":
+        print(json.dumps([cs.model_dump() for cs in result], indent=2, default=str))
+        return
+
+    # Table output
+    console.print("\n[bold]vLLM Benchmark Commands[/bold]")
+    console.print(
+        f"Model: {config.model} | Instances: {config.total_instances} | "
+        f"Ratios: {len(result)}\n"
+    )
+
+    table = Table(title="Benchmark Runs")
+    table.add_column("P:D Ratio")
+    table.add_column("Prefill", justify="right")
+    table.add_column("Decode", justify="right")
+    table.add_column("QPS Levels")
+
+    for cs in result:
+        table.add_row(
+            cs.server.ratio,
+            str(cs.server.prefill_instances),
+            str(cs.server.decode_instances),
+            ", ".join(f"{b.qps}" for b in cs.benchmarks),
+        )
+
+    console.print(table)
+    console.print(
+        "\n[dim]Use --output-script to generate an executable shell script[/dim]"
+    )
+
+
+def register_vllm_commands(subparsers: argparse._SubParsersAction) -> None:
+    """Register the vllm-commands subcommand."""
+    p = subparsers.add_parser(
+        "vllm-commands",
+        help="Generate vLLM benchmark commands for P:D ratio exploration",
+    )
+    p.add_argument("--model", type=str, required=True, help="HuggingFace model name")
+    p.add_argument(
+        "--total-instances", type=int, required=True,
+        help="Total instances (prefill + decode)",
+    )
+    p.add_argument(
+        "--qps", type=str, required=True,
+        help="Comma-separated QPS levels (e.g. 1,2,4)",
+    )
+    p.add_argument("--tp-size", type=int, default=1, help="Tensor parallel size")
+    p.add_argument("--max-model-len", type=int, default=None, help="Max model length")
+    p.add_argument("--dataset", type=str, default=None, help="Dataset path")
+    p.add_argument("--num-prompts", type=int, default=1000, help="Prompts per run")
+    p.add_argument("--host", type=str, default="localhost", help="Server host")
+    p.add_argument("--port", type=int, default=8000, help="Server port")
+    p.add_argument("--output-script", type=str, default=None, help="Write shell script")
+    p.add_argument(
+        "--output-format", choices=["table", "json"], default="table",
+        help="Output format",
+    )
+    p.set_defaults(func=_cmd_vllm_commands)

--- a/src/xpyd_plan/vllm_commands.py
+++ b/src/xpyd_plan/vllm_commands.py
@@ -1,0 +1,162 @@
+"""vLLM Benchmark Command Generator — generate ready-to-run vLLM commands.
+
+Given total instances, model name, and QPS levels, generate vLLM server
+and benchmark_serving.py commands for each planned P:D ratio configuration.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CommandConfig(BaseModel):
+    """Configuration for command generation."""
+
+    model: str = Field(..., min_length=1, description="HuggingFace model name")
+    total_instances: int = Field(..., ge=2, description="Total instances (P+D)")
+    qps_levels: list[float] = Field(
+        ..., min_length=1, description="QPS levels to benchmark"
+    )
+    tp_size: int = Field(1, ge=1, description="Tensor parallel size")
+    max_model_len: int | None = Field(None, ge=1, description="Max model length")
+    dataset: str | None = Field(None, description="Dataset path")
+    num_prompts: int = Field(1000, ge=1, description="Number of prompts per run")
+    host: str = Field("localhost", description="Server host")
+    port: int = Field(8000, ge=1, le=65535, description="Server port")
+
+
+class ServerCommand(BaseModel):
+    """A vLLM server launch command for one P:D ratio."""
+
+    ratio: str = Field(..., description="e.g. '2P:3D'")
+    prefill_instances: int = Field(..., ge=1)
+    decode_instances: int = Field(..., ge=1)
+    command: str = Field(..., description="Shell command")
+
+
+class BenchmarkCommand(BaseModel):
+    """A benchmark_serving.py invocation command."""
+
+    ratio: str = Field(..., description="P:D ratio string")
+    qps: float = Field(..., gt=0)
+    command: str = Field(..., description="Shell command")
+
+
+class CommandSet(BaseModel):
+    """Complete command set for one P:D ratio."""
+
+    server: ServerCommand
+    benchmarks: list[BenchmarkCommand]
+    script_snippet: str = Field("", description="Combined shell script snippet")
+
+
+class CommandGenerator:
+    """Generate vLLM serve and benchmark commands for P:D ratio exploration."""
+
+    def generate(self, config: CommandConfig) -> list[CommandSet]:
+        """Generate command sets for all valid P:D ratios."""
+        total = config.total_instances
+        results: list[CommandSet] = []
+
+        for p in range(1, total):
+            d = total - p
+            if d < 1:
+                break
+            ratio_str = f"{p}P:{d}D"
+
+            server_cmd = self._build_server_command(config, p, d, ratio_str)
+            bench_cmds = [
+                self._build_benchmark_command(config, ratio_str, qps)
+                for qps in config.qps_levels
+            ]
+            snippet = self._build_snippet(server_cmd, bench_cmds)
+
+            results.append(
+                CommandSet(
+                    server=server_cmd,
+                    benchmarks=bench_cmds,
+                    script_snippet=snippet,
+                )
+            )
+
+        return results
+
+    def _build_server_command(
+        self,
+        config: CommandConfig,
+        prefill: int,
+        decode: int,
+        ratio_str: str,
+    ) -> ServerCommand:
+        parts = [
+            f"vllm serve {config.model}",
+            f"--tensor-parallel-size {config.tp_size}",
+            f"--disaggregated-prefill-instance {prefill}",
+            f"--disaggregated-decode-instance {decode}",
+            f"--host {config.host}",
+            f"--port {config.port}",
+        ]
+        if config.max_model_len is not None:
+            parts.append(f"--max-model-len {config.max_model_len}")
+        return ServerCommand(
+            ratio=ratio_str,
+            prefill_instances=prefill,
+            decode_instances=decode,
+            command=" ".join(parts),
+        )
+
+    def _build_benchmark_command(
+        self,
+        config: CommandConfig,
+        ratio_str: str,
+        qps: float,
+    ) -> BenchmarkCommand:
+        parts = [
+            "python benchmark_serving.py",
+            "--backend vllm",
+            f"--model {config.model}",
+            f"--base-url http://{config.host}:{config.port}",
+            f"--request-rate {qps}",
+            f"--num-prompts {config.num_prompts}",
+        ]
+        if config.dataset is not None:
+            parts.append(f"--dataset-path {config.dataset}")
+        return BenchmarkCommand(
+            ratio=ratio_str,
+            qps=qps,
+            command=" ".join(parts),
+        )
+
+    def _build_snippet(
+        self, server: ServerCommand, benchmarks: list[BenchmarkCommand]
+    ) -> str:
+        lines = [
+            f"# --- {server.ratio} ---",
+            f"{server.command} &",
+            "SERVER_PID=$!",
+            "sleep 30  # wait for server startup",
+            "",
+        ]
+        for bc in benchmarks:
+            lines.append(bc.command)
+            lines.append("")
+        lines.append("kill $SERVER_PID")
+        lines.append("wait $SERVER_PID 2>/dev/null || true")
+        lines.append("")
+        return "\n".join(lines)
+
+    def to_shell_script(self, command_sets: list[CommandSet]) -> str:
+        """Combine all command sets into a single shell script."""
+        lines = [
+            "#!/usr/bin/env bash",
+            "set -euo pipefail",
+            "",
+        ]
+        for cs in command_sets:
+            lines.append(cs.script_snippet)
+        return "\n".join(lines)
+
+
+def generate_vllm_commands(config: CommandConfig) -> list[CommandSet]:
+    """Convenience function — generate vLLM commands for all P:D ratios."""
+    return CommandGenerator().generate(config)

--- a/tests/test_vllm_commands.py
+++ b/tests/test_vllm_commands.py
@@ -1,0 +1,232 @@
+"""Tests for vllm_commands module."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from xpyd_plan.cli import main
+from xpyd_plan.vllm_commands import (
+    BenchmarkCommand,
+    CommandConfig,
+    CommandGenerator,
+    CommandSet,
+    ServerCommand,
+    generate_vllm_commands,
+)
+
+
+class TestCommandConfig:
+    """Tests for CommandConfig model."""
+
+    def test_minimal_config(self):
+        cfg = CommandConfig(model="meta-llama/Llama-3-8B", total_instances=4, qps_levels=[1.0])
+        assert cfg.model == "meta-llama/Llama-3-8B"
+        assert cfg.tp_size == 1
+        assert cfg.host == "localhost"
+        assert cfg.port == 8000
+        assert cfg.num_prompts == 1000
+
+    def test_full_config(self):
+        cfg = CommandConfig(
+            model="my-model",
+            total_instances=8,
+            qps_levels=[1.0, 2.0, 4.0],
+            tp_size=2,
+            max_model_len=4096,
+            dataset="/data/sharegpt.json",
+            num_prompts=500,
+            host="0.0.0.0",
+            port=9000,
+        )
+        assert cfg.max_model_len == 4096
+        assert cfg.dataset == "/data/sharegpt.json"
+
+    def test_invalid_total_instances(self):
+        with pytest.raises(Exception):
+            CommandConfig(model="m", total_instances=1, qps_levels=[1.0])
+
+    def test_empty_qps_levels(self):
+        with pytest.raises(Exception):
+            CommandConfig(model="m", total_instances=4, qps_levels=[])
+
+    def test_serializable(self):
+        cfg = CommandConfig(model="m", total_instances=4, qps_levels=[1.0, 2.0])
+        data = cfg.model_dump()
+        restored = CommandConfig.model_validate(data)
+        assert restored.model == cfg.model
+
+
+class TestCommandGenerator:
+    """Tests for CommandGenerator."""
+
+    def _default_config(self, **kwargs) -> CommandConfig:
+        defaults = dict(model="meta-llama/Llama-3-8B", total_instances=4, qps_levels=[1.0, 2.0])
+        defaults.update(kwargs)
+        return CommandConfig(**defaults)
+
+    def test_generates_correct_number_of_ratios(self):
+        cfg = self._default_config(total_instances=4)
+        result = CommandGenerator().generate(cfg)
+        # total=4 -> 1P:3D, 2P:2D, 3P:1D = 3 ratios
+        assert len(result) == 3
+
+    def test_generates_correct_number_of_ratios_6(self):
+        cfg = self._default_config(total_instances=6)
+        result = CommandGenerator().generate(cfg)
+        # 1P:5D, 2P:4D, 3P:3D, 4P:2D, 5P:1D = 5
+        assert len(result) == 5
+
+    def test_server_command_format(self):
+        cfg = self._default_config(total_instances=4, tp_size=2)
+        result = CommandGenerator().generate(cfg)
+        cmd = result[0].server
+        assert cmd.ratio == "1P:3D"
+        assert cmd.prefill_instances == 1
+        assert cmd.decode_instances == 3
+        assert "vllm serve" in cmd.command
+        assert "--tensor-parallel-size 2" in cmd.command
+        assert "--disaggregated-prefill-instance 1" in cmd.command
+        assert "--disaggregated-decode-instance 3" in cmd.command
+
+    def test_server_command_with_max_model_len(self):
+        cfg = self._default_config(max_model_len=4096)
+        result = CommandGenerator().generate(cfg)
+        assert "--max-model-len 4096" in result[0].server.command
+
+    def test_server_command_without_max_model_len(self):
+        cfg = self._default_config()
+        result = CommandGenerator().generate(cfg)
+        assert "--max-model-len" not in result[0].server.command
+
+    def test_benchmark_command_format(self):
+        cfg = self._default_config(qps_levels=[5.0])
+        result = CommandGenerator().generate(cfg)
+        bc = result[0].benchmarks[0]
+        assert "benchmark_serving.py" in bc.command
+        assert "--backend vllm" in bc.command
+        assert "--request-rate 5.0" in bc.command
+        assert "--num-prompts 1000" in bc.command
+        assert "--base-url http://localhost:8000" in bc.command
+
+    def test_benchmark_command_with_dataset(self):
+        cfg = self._default_config(dataset="/data/test.json")
+        result = CommandGenerator().generate(cfg)
+        assert "--dataset-path /data/test.json" in result[0].benchmarks[0].command
+
+    def test_benchmark_command_without_dataset(self):
+        cfg = self._default_config()
+        result = CommandGenerator().generate(cfg)
+        assert "--dataset-path" not in result[0].benchmarks[0].command
+
+    def test_cross_product_qps(self):
+        cfg = self._default_config(total_instances=3, qps_levels=[1.0, 2.0, 4.0])
+        result = CommandGenerator().generate(cfg)
+        # total=3 -> 2 ratios, 3 QPS each = 6 benchmark commands total
+        for cs in result:
+            assert len(cs.benchmarks) == 3
+        assert len(result) == 2
+
+    def test_command_set_has_snippet(self):
+        cfg = self._default_config()
+        result = CommandGenerator().generate(cfg)
+        for cs in result:
+            assert cs.script_snippet
+            assert "SERVER_PID" in cs.script_snippet
+            assert "kill $SERVER_PID" in cs.script_snippet
+
+    def test_shell_script_generation(self):
+        cfg = self._default_config()
+        gen = CommandGenerator()
+        result = gen.generate(cfg)
+        script = gen.to_shell_script(result)
+        assert script.startswith("#!/usr/bin/env bash")
+        assert "set -euo pipefail" in script
+        for cs in result:
+            assert cs.server.ratio in script
+
+    def test_shell_script_empty(self):
+        gen = CommandGenerator()
+        script = gen.to_shell_script([])
+        assert "#!/usr/bin/env bash" in script
+
+    def test_total_instances_2(self):
+        cfg = self._default_config(total_instances=2)
+        result = CommandGenerator().generate(cfg)
+        # Only 1P:1D
+        assert len(result) == 1
+        assert result[0].server.ratio == "1P:1D"
+
+
+class TestConvenienceFunction:
+    """Tests for generate_vllm_commands()."""
+
+    def test_convenience_matches_class(self):
+        cfg = CommandConfig(model="m", total_instances=4, qps_levels=[1.0])
+        result = generate_vllm_commands(cfg)
+        assert len(result) == 3
+        assert isinstance(result[0], CommandSet)
+
+
+class TestModels:
+    """Tests for Pydantic models serialization."""
+
+    def test_server_command_serializable(self):
+        sc = ServerCommand(ratio="2P:2D", prefill_instances=2, decode_instances=2, command="test")
+        data = sc.model_dump()
+        restored = ServerCommand.model_validate(data)
+        assert restored.ratio == "2P:2D"
+
+    def test_command_set_json_roundtrip(self):
+        cs = CommandSet(
+            server=ServerCommand(
+                ratio="1P:1D", prefill_instances=1, decode_instances=1, command="s",
+            ),
+            benchmarks=[BenchmarkCommand(ratio="1P:1D", qps=1.0, command="b")],
+            script_snippet="echo test",
+        )
+        j = cs.model_dump_json()
+        restored = CommandSet.model_validate_json(j)
+        assert restored.server.ratio == "1P:1D"
+        assert len(restored.benchmarks) == 1
+
+
+class TestVLLMCommandsCLI:
+    """Tests for the CLI vllm-commands subcommand."""
+
+    def test_cli_json_output(self, capsys):
+        main([
+            "vllm-commands",
+            "--model", "test-model",
+            "--total-instances", "4",
+            "--qps", "1,2",
+            "--output-format", "json",
+        ])
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert len(data) == 3
+        assert "server" in data[0]
+        assert "benchmarks" in data[0]
+
+    def test_cli_table_output(self, capsys):
+        main([
+            "vllm-commands",
+            "--model", "test-model",
+            "--total-instances", "4",
+            "--qps", "1,2",
+            "--output-format", "table",
+        ])
+
+    def test_cli_shell_script_output(self, tmp_path):
+        out_path = tmp_path / "run.sh"
+        main([
+            "vllm-commands",
+            "--model", "test-model",
+            "--total-instances", "4",
+            "--qps", "1,2",
+            "--output-script", str(out_path),
+        ])
+        content = out_path.read_text()
+        assert "#!/usr/bin/env bash" in content
+        assert "vllm serve" in content


### PR DESCRIPTION
## M109: vLLM Benchmark Command Generator

Generate ready-to-run vLLM server and benchmark_serving.py commands for P:D ratio exploration.

### Changes
- `CommandGenerator` class in `vllm_commands.py`
- `CommandConfig`, `ServerCommand`, `BenchmarkCommand`, `CommandSet` Pydantic models
- Generate `vllm serve` commands with disaggregated prefill/decode flags
- Generate `benchmark_serving.py` commands for each P:D ratio × QPS level
- Shell script output mode (`.sh` file)
- CLI `vllm-commands` subcommand with table + JSON output
- Programmatic `generate_vllm_commands()` API
- 24 new tests (2472 total)

Closes #241