### PR TITLE
feat: SGLang Benchmark Format Importer (M110)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1452,9 +1452,9 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Programmatic API via `RateLimitRecommender.recommend()`
 - 19 new tests
 
-### M108 🔄 vLLM Benchmark Format Importer
+### M108 ✅ vLLM Benchmark Format Importer
 
-*In progress — PR #TBD*
+*Completed — PR #240*
 
 - `VLLMImporter` class in `vllm_import.py`
 - `VLLMBenchmarkData`, `VLLMRequest`, `ImportResult`, `ImportConfig` Pydantic models
@@ -1465,3 +1465,29 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `import` subcommand with `--input`, `--format vllm|auto`, `--output`, `--prefill-instances`, `--decode-instances`
 - Programmatic `import_vllm()` API
 - 32 new tests
+
+### M109 ✅ vLLM Benchmark Command Generator
+
+*Completed — PR #242*
+
+- `CommandGenerator` class in `vllm_commands.py`
+- `CommandConfig`, `GeneratedCommand`, `CommandSet` Pydantic models
+- Generate vLLM server launch and benchmark_serving.py commands for all valid P:D ratio splits
+- Shell script output with server lifecycle management (background, sleep, kill)
+- CLI `vllm-commands` subcommand with `--total-instances`, table + JSON output
+- Programmatic API via `CommandGenerator`
+- 20 new tests
+
+### M110 ✅ SGLang Benchmark Format Importer
+
+*Completed — PR #TBD*
+
+- `SGLangRequest`, `SGLangBenchmarkData`, `SGLangImportConfig`, `SGLangImportResult` Pydantic models
+- Parse SGLang `bench_serving` output (list of RequestFuncOutput dicts)
+- Convert to native xpyd-plan BenchmarkData format
+- Auto-detect SGLang format (itl as list + latency field, no request_latency)
+- Failed request filtering (success=false) with count in warnings
+- TPOT computed as mean of itl list, with fallback estimation
+- CLI `import` subcommand updated with `--format sglang|auto` support
+- Programmatic `import_sglang()` and `import_sglang_data()` APIs
+- 23 new tests (2495 total)

--- a/docs/iterations/current.md
+++ b/docs/iterations/current.md
@@ -4,23 +4,36 @@
 
 ---
 
-## Current Milestone: M109 — vLLM Benchmark Command Generator 🔄
+## Current Milestone: M110 — SGLang Benchmark Format Importer ✅
 
-Generate ready-to-run vLLM server and benchmark_serving.py commands for P:D ratio exploration.
+Import SGLang `bench_serving` output into native xpyd-plan format for downstream analysis.
+
+### What was done
+
+- `SGLangImporter` logic in `sglang_import.py`
+- Pydantic models: `SGLangRequest`, `SGLangBenchmarkData`, `SGLangImportConfig`, `SGLangImportResult`
+- Auto-detect SGLang format (presence of `itl` as list + `latency` field, absence of `request_latency`)
+- Failed request filtering with count in warnings
+- TPOT computed as mean of `itl` list, with fallback estimation
+- CLI `import` subcommand updated with `--format sglang|auto` support
+- Programmatic `import_sglang()` and `import_sglang_data()` APIs
+- 23 new tests (2495 total)
 
 ### Changes
-- **`src/xpyd_plan/vllm_import.py`**: `VLLMImporter` class, `VLLMBenchmarkData`, `VLLMRequest`, `ImportResult`, `ImportConfig` models, `import_vllm()` API
-- **`src/xpyd_plan/cli/_import.py`**: CLI `import` subcommand
-- **`src/xpyd_plan/cli/_main.py`**: Register import subcommand
-- **`src/xpyd_plan/__init__.py`**: Added exports (preserved all prior exports)
-- **`tests/test_vllm_import.py`**: 32 new tests
-- **`ROADMAP.md`**: Added M105, M106, M107, M108 entries
+
+| File | Change |
+|------|--------|
+| `src/xpyd_plan/sglang_import.py` | New — SGLang import logic |
+| `src/xpyd_plan/cli/_import.py` | Updated — SGLang format support in import CLI |
+| `src/xpyd_plan/__init__.py` | Updated — export SGLang symbols |
+| `tests/test_sglang_import.py` | New — 23 tests |
+| `docs/iterations/current.md` | Updated |
 
 ---
 
-## Previous Milestones
+## Project Status
 
-The project has completed **107 milestones**, covering the full feature chain from core analysis to advanced optimization.
+The project has completed **110 milestones**, covering the full feature chain from core analysis to advanced optimization.
 
 ---
 
@@ -29,7 +42,7 @@ The project has completed **107 milestones**, covering the full feature chain fr
 1. **Offline analysis only** — Does not support real-time streaming ingestion of production traffic data
 2. **Linear scaling assumption** — `plan-capacity` uses a linear model, which may deviate from reality under high concurrency
 3. **Single-cluster perspective** — Cross-cluster/cross-region joint optimization is not yet supported
-4. **Benchmark format** — Now supports vLLM format import in addition to native format
+4. **Benchmark format** — Now supports vLLM and SGLang format import in addition to native format
 
 ---
 
@@ -40,12 +53,13 @@ The project has completed **107 milestones**, covering the full feature chain fr
 - Closed-loop integration with xPyD-proxy auto-tuning
 - Web UI dashboard (replacing TUI)
 - Richer visualizations (interactive charts)
-- Support additional benchmark tool formats (TensorRT-LLM, SGLang)
+- Support additional benchmark tool formats (TensorRT-LLM)
 
 ## Iteration History
 
 | # | Date | Task | Result | Reviewer Comments |
 |---|------|------|--------|-------------------|
 | 1 | 2026-04-06 | M107 Rate Limiter Recommender | ✅ merged | PR #238 |
-| 2 | 2026-04-06 | M108 vLLM Benchmark Importer | ⏳ pending review | PR #TBD |
-| 3 | 2026-04-06 | M109 vLLM Benchmark Command Generator | ⏳ awaiting review | Issue #241, PR #TBD |
+| 2 | 2026-04-06 | M108 vLLM Benchmark Importer | ✅ merged | PR #240 |
+| 3 | 2026-04-06 | M109 vLLM Benchmark Command Generator | ✅ merged | PR #242 |
+| 4 | 2026-04-06 | M110 SGLang Benchmark Format Importer | ⏳ pending review | Issue #243 |

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -1441,3 +1441,21 @@ __all__ += [
     "VLLMRequest",
     "import_vllm",
 ]
+
+from xpyd_plan.sglang_import import (  # noqa: E402
+    SGLangBenchmarkData,
+    SGLangImportConfig,
+    SGLangImportResult,
+    SGLangRequest,
+    import_sglang,
+    import_sglang_data,
+)
+
+__all__ += [
+    "SGLangBenchmarkData",
+    "SGLangImportConfig",
+    "SGLangImportResult",
+    "SGLangRequest",
+    "import_sglang",
+    "import_sglang_data",
+]

--- a/src/xpyd_plan/cli/_import.py
+++ b/src/xpyd_plan/cli/_import.py
@@ -1,13 +1,20 @@
-"""CLI import command — import vLLM benchmark data."""
+"""CLI import command — import vLLM/SGLang benchmark data."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import sys
+from pathlib import Path
 
 from rich.console import Console
 
+from xpyd_plan.sglang_import import (
+    SGLangImportConfig,
+    _detect_sglang_format,
+    import_sglang,
+    import_sglang_data,
+)
 from xpyd_plan.vllm_import import import_vllm
 
 
@@ -21,14 +28,52 @@ def _cmd_import(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
+    fmt = args.format
+
     try:
-        result = import_vllm(
-            input_path=args.input,
-            num_prefill_instances=args.prefill_instances,
-            num_decode_instances=args.decode_instances,
-            output_path=args.output,
-            format=args.format,
-        )
+        if fmt == "sglang":
+            config = SGLangImportConfig(
+                num_prefill_instances=args.prefill_instances,
+                num_decode_instances=args.decode_instances,
+                format="sglang",
+            )
+            result = import_sglang(args.input, config)
+            if args.output:
+                Path(args.output).write_text(
+                    result.benchmark_data.model_dump_json(indent=2),
+                    encoding="utf-8",
+                )
+        elif fmt == "auto":
+            # Try SGLang detection first, then fall back to vLLM importer
+            raw = json.loads(Path(args.input).read_text(encoding="utf-8"))
+            if _detect_sglang_format(raw):
+                config = SGLangImportConfig(
+                    num_prefill_instances=args.prefill_instances,
+                    num_decode_instances=args.decode_instances,
+                    format="sglang",
+                )
+                result = import_sglang_data(raw, config)
+                if args.output:
+                    Path(args.output).write_text(
+                        result.benchmark_data.model_dump_json(indent=2),
+                        encoding="utf-8",
+                    )
+            else:
+                result = import_vllm(
+                    input_path=args.input,
+                    num_prefill_instances=args.prefill_instances,
+                    num_decode_instances=args.decode_instances,
+                    output_path=args.output,
+                    format="auto",
+                )
+        else:
+            result = import_vllm(
+                input_path=args.input,
+                num_prefill_instances=args.prefill_instances,
+                num_decode_instances=args.decode_instances,
+                output_path=args.output,
+                format=fmt,
+            )
     except (ValueError, FileNotFoundError, json.JSONDecodeError) as exc:
         console.print(f"[red]Error: {exc}[/red]")
         sys.exit(1)
@@ -64,7 +109,7 @@ def add_import_parser(subparsers: argparse._SubParsersAction) -> None:
     """Add the import subcommand parser."""
     parser = subparsers.add_parser(
         "import",
-        help="Import vLLM benchmark data to native format",
+        help="Import vLLM/SGLang benchmark data to native format",
     )
     parser.add_argument(
         "--input",
@@ -73,7 +118,7 @@ def add_import_parser(subparsers: argparse._SubParsersAction) -> None:
     )
     parser.add_argument(
         "--format",
-        choices=["vllm", "native", "auto"],
+        choices=["vllm", "sglang", "native", "auto"],
         default="auto",
         help="Input format (default: auto-detect)",
     )

--- a/src/xpyd_plan/sglang_import.py
+++ b/src/xpyd_plan/sglang_import.py
@@ -1,0 +1,256 @@
+"""SGLang Benchmark Format Importer — import sglang.bench_serving output.
+
+Converts SGLang benchmark JSON output (list of RequestFuncOutput dicts) into
+the native xpyd-plan BenchmarkData format for downstream analysis.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+
+
+class SGLangRequest(BaseModel):
+    """A single request record from SGLang bench_serving output."""
+
+    prompt_len: int = Field(..., ge=1, description="Number of prompt tokens")
+    output_len: int = Field(..., ge=1, description="Number of output/generated tokens")
+    ttft: float = Field(..., ge=0, description="Time to first token (seconds)")
+    itl: list[float] = Field(
+        default_factory=list,
+        description="List of inter-token latencies (seconds)",
+    )
+    latency: float = Field(..., ge=0, description="Total request latency (seconds)")
+    start_time: float | None = Field(
+        None, description="Request start timestamp (epoch seconds)"
+    )
+    success: bool = Field(True, description="Whether the request succeeded")
+
+
+class SGLangBenchmarkData(BaseModel):
+    """Parsed SGLang benchmark data (list of request records)."""
+
+    requests: list[SGLangRequest] = Field(..., min_length=1)
+
+
+class SGLangImportConfig(BaseModel):
+    """Configuration for SGLang import."""
+
+    num_prefill_instances: int = Field(
+        ..., ge=1, description="Number of prefill instances"
+    )
+    num_decode_instances: int = Field(
+        ..., ge=1, description="Number of decode instances"
+    )
+    format: str = Field(
+        "auto", description="Input format: 'sglang', 'native', or 'auto'"
+    )
+
+
+class SGLangImportResult(BaseModel):
+    """Result of an SGLang import operation."""
+
+    benchmark_data: BenchmarkData
+    source_format: str = Field(..., description="Detected source format")
+    num_requests: int = Field(..., ge=1, description="Number of requests imported")
+    num_failed_filtered: int = Field(
+        0, description="Number of failed requests filtered out"
+    )
+    warnings: list[str] = Field(default_factory=list, description="Import warnings")
+
+
+def _detect_sglang_format(data: Any) -> bool:
+    """Detect whether data is SGLang format.
+
+    SGLang format: list of dicts with 'prompt_len', 'latency', and 'itl' (list) keys.
+    """
+    if not isinstance(data, list) or len(data) == 0:
+        return False
+    first = data[0]
+    if not isinstance(first, dict):
+        return False
+    # SGLang has 'latency' (not 'request_latency') and 'itl' as a list
+    has_latency = "latency" in first
+    has_prompt_len = "prompt_len" in first
+    has_itl = "itl" in first and isinstance(first.get("itl"), list)
+    # Distinguish from vLLM: vLLM uses 'request_latency', SGLang uses 'latency'
+    # and SGLang's itl is a list while vLLM's is a scalar or absent
+    not_vllm = "request_latency" not in first
+    return has_latency and has_prompt_len and has_itl and not_vllm
+
+
+def _convert_requests(
+    sglang_requests: list[SGLangRequest],
+) -> tuple[list[BenchmarkRequest], list[str], int]:
+    """Convert SGLang requests to native format.
+
+    Returns (native_requests, warnings, num_failed_filtered).
+    """
+    warnings: list[str] = []
+    native_requests: list[BenchmarkRequest] = []
+    num_failed = 0
+
+    # Filter failed requests
+    successful = [r for r in sglang_requests if r.success]
+    num_failed = len(sglang_requests) - len(successful)
+    if num_failed > 0:
+        warnings.append(
+            f"Filtered {num_failed} failed request(s) (success=false)"
+        )
+
+    if not successful:
+        raise ValueError(
+            "No successful requests to import — all requests have success=false"
+        )
+
+    # Generate sequential timestamps if missing
+    has_timestamps = any(r.start_time is not None for r in successful)
+
+    for i, req in enumerate(successful):
+        # Compute TPOT from itl list (mean of inter-token latencies)
+        if req.itl and len(req.itl) > 0:
+            tpot_s = sum(req.itl) / len(req.itl)
+        else:
+            # Fallback: estimate from (latency - ttft) / output_len
+            if req.output_len > 1:
+                tpot_s = (req.latency - req.ttft) / (req.output_len - 1)
+            else:
+                tpot_s = 0.0
+            warnings.append(
+                f"Request {i}: empty itl list, estimated TPOT from latency"
+            ) if i == 0 else None  # Only warn once
+
+        # Determine timestamp
+        if req.start_time is not None:
+            timestamp = req.start_time
+        elif has_timestamps:
+            timestamp = 0.0  # Placeholder
+        else:
+            timestamp = float(i)
+
+        native_requests.append(
+            BenchmarkRequest(
+                request_id=str(i + 1),
+                prompt_tokens=req.prompt_len,
+                output_tokens=req.output_len,
+                ttft_ms=req.ttft * 1000.0,
+                tpot_ms=tpot_s * 1000.0,
+                total_latency_ms=req.latency * 1000.0,
+                timestamp=timestamp,
+            )
+        )
+
+    # Deduplicate warnings
+    seen: set[str] = set()
+    unique_warnings: list[str] = []
+    for w in warnings:
+        if w and w not in seen:
+            seen.add(w)
+            unique_warnings.append(w)
+
+    return native_requests, unique_warnings, num_failed
+
+
+def import_sglang(
+    path: str | Path,
+    config: SGLangImportConfig,
+) -> SGLangImportResult:
+    """Import an SGLang benchmark file and convert to native format.
+
+    Parameters
+    ----------
+    path
+        Path to the SGLang benchmark JSON file.
+    config
+        Import configuration (instance counts, format hint).
+
+    Returns
+    -------
+    SGLangImportResult
+        Converted benchmark data with metadata.
+    """
+    path = Path(path)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    return import_sglang_data(raw, config)
+
+
+def import_sglang_data(
+    data: Any,
+    config: SGLangImportConfig,
+) -> SGLangImportResult:
+    """Import SGLang benchmark data from a parsed JSON object.
+
+    Parameters
+    ----------
+    data
+        Parsed JSON data (expected: list of request dicts).
+    config
+        Import configuration.
+
+    Returns
+    -------
+    SGLangImportResult
+        Converted benchmark data with metadata.
+    """
+    # Format detection
+    if config.format == "auto":
+        if _detect_sglang_format(data):
+            source_format = "sglang"
+        elif isinstance(data, dict) and "metadata" in data and "requests" in data:
+            source_format = "native"
+        else:
+            raise ValueError(
+                "Cannot auto-detect format. Use --format sglang or --format native."
+            )
+    else:
+        source_format = config.format
+
+    if source_format == "native":
+        benchmark_data = BenchmarkData.model_validate(data)
+        return SGLangImportResult(
+            benchmark_data=benchmark_data,
+            source_format="native",
+            num_requests=len(benchmark_data.requests),
+            num_failed_filtered=0,
+            warnings=[],
+        )
+
+    # Parse SGLang format
+    if not isinstance(data, list):
+        raise ValueError("SGLang format expects a JSON array of request objects")
+
+    sglang_data = SGLangBenchmarkData(requests=[SGLangRequest(**r) for r in data])
+    native_requests, warnings, num_failed = _convert_requests(sglang_data.requests)
+
+    # Compute measured QPS
+    if len(native_requests) >= 2:
+        timestamps = [r.timestamp for r in native_requests]
+        duration = max(timestamps) - min(timestamps)
+        measured_qps = len(native_requests) / duration if duration > 0 else 0.0
+    else:
+        measured_qps = 0.0
+
+    total_instances = config.num_prefill_instances + config.num_decode_instances
+
+    benchmark_data = BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=config.num_prefill_instances,
+            num_decode_instances=config.num_decode_instances,
+            total_instances=total_instances,
+            measured_qps=measured_qps,
+        ),
+        requests=native_requests,
+    )
+
+    return SGLangImportResult(
+        benchmark_data=benchmark_data,
+        source_format="sglang",
+        num_requests=len(native_requests),
+        num_failed_filtered=num_failed,
+        warnings=warnings,
+    )

--- a/tests/test_sglang_import.py
+++ b/tests/test_sglang_import.py
@@ -1,0 +1,340 @@
+"""Tests for SGLang Benchmark Format Importer (M110)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_plan.sglang_import import (
+    SGLangImportConfig,
+    SGLangImportResult,
+    SGLangRequest,
+    _convert_requests,
+    _detect_sglang_format,
+    import_sglang,
+    import_sglang_data,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_sglang_request(
+    prompt_len: int = 128,
+    output_len: int = 64,
+    ttft: float = 0.05,
+    itl: list[float] | None = None,
+    latency: float = 1.0,
+    start_time: float | None = None,
+    success: bool = True,
+) -> dict:
+    """Build a raw SGLang request dict."""
+    r: dict = {
+        "prompt_len": prompt_len,
+        "output_len": output_len,
+        "ttft": ttft,
+        "itl": itl if itl is not None else [0.015, 0.014, 0.016],
+        "latency": latency,
+        "success": success,
+    }
+    if start_time is not None:
+        r["start_time"] = start_time
+    return r
+
+
+def _make_sglang_data(n: int = 10, qps: float = 5.0) -> list[dict]:
+    """Generate n SGLang request dicts."""
+    interval = 1.0 / qps if qps > 0 else 0.2
+    return [
+        _make_sglang_request(
+            prompt_len=100 + i * 10,
+            output_len=50 + i * 5,
+            ttft=0.04 + i * 0.001,
+            itl=[0.012 + i * 0.0001] * 10,
+            latency=0.5 + i * 0.05,
+            start_time=1000.0 + i * interval,
+        )
+        for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Format detection
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDetection:
+    def test_detect_sglang_format(self):
+        data = _make_sglang_data(3)
+        assert _detect_sglang_format(data) is True
+
+    def test_not_sglang_if_empty(self):
+        assert _detect_sglang_format([]) is False
+
+    def test_not_sglang_if_dict(self):
+        assert _detect_sglang_format({"metadata": {}, "requests": []}) is False
+
+    def test_not_sglang_if_vllm_format(self):
+        """vLLM uses 'request_latency' not 'latency'."""
+        data = [
+            {
+                "prompt_len": 128,
+                "output_len": 64,
+                "ttft": 0.05,
+                "itl": 0.015,
+                "request_latency": 1.0,
+            }
+        ]
+        assert _detect_sglang_format(data) is False
+
+    def test_not_sglang_if_itl_scalar(self):
+        """SGLang itl is always a list."""
+        data = [
+            {
+                "prompt_len": 128,
+                "output_len": 64,
+                "ttft": 0.05,
+                "itl": 0.015,
+                "latency": 1.0,
+            }
+        ]
+        assert _detect_sglang_format(data) is False
+
+
+# ---------------------------------------------------------------------------
+# Model validation
+# ---------------------------------------------------------------------------
+
+
+class TestModels:
+    def test_sglang_request_valid(self):
+        r = SGLangRequest(
+            prompt_len=128, output_len=64, ttft=0.05, itl=[0.01, 0.02], latency=1.0
+        )
+        assert r.prompt_len == 128
+        assert len(r.itl) == 2
+        assert r.success is True
+
+    def test_sglang_request_invalid_prompt_len(self):
+        with pytest.raises(Exception):
+            SGLangRequest(prompt_len=0, output_len=64, ttft=0.05, latency=1.0)
+
+    def test_import_config_valid(self):
+        c = SGLangImportConfig(num_prefill_instances=2, num_decode_instances=4)
+        assert c.format == "auto"
+
+
+# ---------------------------------------------------------------------------
+# Conversion
+# ---------------------------------------------------------------------------
+
+
+class TestConversion:
+    def test_basic_conversion(self):
+        requests = [
+            SGLangRequest(
+                prompt_len=128,
+                output_len=64,
+                ttft=0.05,
+                itl=[0.01, 0.02, 0.03],
+                latency=1.0,
+                start_time=1000.0,
+            )
+        ]
+        native, warnings, num_failed = _convert_requests(requests)
+        assert len(native) == 1
+        assert native[0].prompt_tokens == 128
+        assert native[0].output_tokens == 64
+        assert native[0].ttft_ms == pytest.approx(50.0)
+        # TPOT = mean([0.01, 0.02, 0.03]) * 1000 = 20.0
+        assert native[0].tpot_ms == pytest.approx(20.0)
+        assert native[0].total_latency_ms == pytest.approx(1000.0)
+        assert num_failed == 0
+
+    def test_failed_requests_filtered(self):
+        requests = [
+            SGLangRequest(
+                prompt_len=128, output_len=64, ttft=0.05, latency=1.0, success=True
+            ),
+            SGLangRequest(
+                prompt_len=128, output_len=64, ttft=0.05, latency=1.0, success=False
+            ),
+        ]
+        native, warnings, num_failed = _convert_requests(requests)
+        assert len(native) == 1
+        assert num_failed == 1
+        assert any("Filtered 1 failed" in w for w in warnings)
+
+    def test_all_failed_raises(self):
+        requests = [
+            SGLangRequest(
+                prompt_len=128, output_len=64, ttft=0.05, latency=1.0, success=False
+            ),
+        ]
+        with pytest.raises(ValueError, match="No successful requests"):
+            _convert_requests(requests)
+
+    def test_empty_itl_fallback(self):
+        requests = [
+            SGLangRequest(
+                prompt_len=128,
+                output_len=10,
+                ttft=0.05,
+                itl=[],
+                latency=1.0,
+                start_time=0.0,
+            )
+        ]
+        native, warnings, _ = _convert_requests(requests)
+        # TPOT fallback = (1.0 - 0.05) / (10 - 1) seconds = 0.10556 s = 105.56 ms
+        expected_tpot = (1.0 - 0.05) / 9.0 * 1000.0
+        assert native[0].tpot_ms == pytest.approx(expected_tpot, rel=1e-3)
+
+    def test_sequential_timestamps_when_missing(self):
+        requests = [
+            SGLangRequest(
+                prompt_len=128, output_len=64, ttft=0.05, latency=1.0
+            ),
+            SGLangRequest(
+                prompt_len=256, output_len=32, ttft=0.03, latency=0.8
+            ),
+        ]
+        native, _, _ = _convert_requests(requests)
+        assert native[0].timestamp == 0.0
+        assert native[1].timestamp == 1.0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end import
+# ---------------------------------------------------------------------------
+
+
+class TestImportSGLang:
+    def test_import_from_file(self, tmp_path: Path):
+        data = _make_sglang_data(5)
+        p = tmp_path / "sglang_bench.json"
+        p.write_text(json.dumps(data))
+        config = SGLangImportConfig(
+            num_prefill_instances=2, num_decode_instances=4, format="sglang"
+        )
+        result = import_sglang(p, config)
+        assert result.source_format == "sglang"
+        assert result.num_requests == 5
+        assert result.benchmark_data.metadata.num_prefill_instances == 2
+        assert result.benchmark_data.metadata.num_decode_instances == 4
+        assert result.benchmark_data.metadata.total_instances == 6
+
+    def test_auto_detect_sglang(self):
+        data = _make_sglang_data(3)
+        config = SGLangImportConfig(
+            num_prefill_instances=1, num_decode_instances=1, format="auto"
+        )
+        result = import_sglang_data(data, config)
+        assert result.source_format == "sglang"
+        assert result.num_requests == 3
+
+    def test_auto_detect_native(self):
+        native = {
+            "metadata": {
+                "num_prefill_instances": 2,
+                "num_decode_instances": 4,
+                "total_instances": 6,
+                "measured_qps": 10.0,
+            },
+            "requests": [
+                {
+                    "request_id": "1",
+                    "prompt_tokens": 128,
+                    "output_tokens": 64,
+                    "ttft_ms": 50.0,
+                    "tpot_ms": 20.0,
+                    "total_latency_ms": 1000.0,
+                    "timestamp": 0.0,
+                }
+            ],
+        }
+        config = SGLangImportConfig(
+            num_prefill_instances=2, num_decode_instances=4, format="auto"
+        )
+        result = import_sglang_data(native, config)
+        assert result.source_format == "native"
+
+    def test_auto_detect_unknown_raises(self):
+        config = SGLangImportConfig(
+            num_prefill_instances=1, num_decode_instances=1, format="auto"
+        )
+        with pytest.raises(ValueError, match="Cannot auto-detect"):
+            import_sglang_data({"random": "data"}, config)
+
+    def test_measured_qps_computed(self):
+        data = _make_sglang_data(10, qps=5.0)
+        config = SGLangImportConfig(
+            num_prefill_instances=1, num_decode_instances=1, format="sglang"
+        )
+        result = import_sglang_data(data, config)
+        assert result.benchmark_data.metadata.measured_qps > 0
+
+    def test_with_failed_requests(self):
+        data = _make_sglang_data(5)
+        data.append(_make_sglang_request(success=False, start_time=2000.0))
+        config = SGLangImportConfig(
+            num_prefill_instances=1, num_decode_instances=1, format="sglang"
+        )
+        result = import_sglang_data(data, config)
+        assert result.num_requests == 5
+        assert result.num_failed_filtered == 1
+        assert len(result.warnings) > 0
+
+    def test_non_list_raises(self):
+        config = SGLangImportConfig(
+            num_prefill_instances=1, num_decode_instances=1, format="sglang"
+        )
+        with pytest.raises(ValueError, match="JSON array"):
+            import_sglang_data({"not": "a list"}, config)
+
+    def test_output_file(self, tmp_path: Path):
+        data = _make_sglang_data(3)
+        infile = tmp_path / "in.json"
+        infile.write_text(json.dumps(data))
+        config = SGLangImportConfig(
+            num_prefill_instances=1, num_decode_instances=1, format="sglang"
+        )
+        result = import_sglang(infile, config)
+        # Write output manually (as CLI would)
+        outfile = tmp_path / "out.json"
+        outfile.write_text(result.benchmark_data.model_dump_json(indent=2))
+        loaded = json.loads(outfile.read_text())
+        assert "metadata" in loaded
+        assert "requests" in loaded
+        assert len(loaded["requests"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Result model
+# ---------------------------------------------------------------------------
+
+
+class TestResultModel:
+    def test_result_fields(self):
+        data = _make_sglang_data(3)
+        config = SGLangImportConfig(
+            num_prefill_instances=2, num_decode_instances=2, format="sglang"
+        )
+        result = import_sglang_data(data, config)
+        assert isinstance(result, SGLangImportResult)
+        assert result.source_format == "sglang"
+        assert result.num_failed_filtered == 0
+        assert isinstance(result.warnings, list)
+
+    def test_result_serializable(self):
+        data = _make_sglang_data(3)
+        config = SGLangImportConfig(
+            num_prefill_instances=1, num_decode_instances=1, format="sglang"
+        )
+        result = import_sglang_data(data, config)
+        d = result.model_dump()
+        assert "benchmark_data" in d
+        assert "num_requests" in d
+        assert "num_failed_filtered" in d


### PR DESCRIPTION
## Summary

Add SGLang benchmark format import support, complementing the existing vLLM importer (M108).

### Changes
- `src/xpyd_plan/sglang_import.py` — New module with SGLang import logic
- `src/xpyd_plan/cli/_import.py` — Updated CLI with `--format sglang|auto` support
- `src/xpyd_plan/__init__.py` — Export new symbols
- `tests/test_sglang_import.py` — 23 new tests
- `ROADMAP.md` — Updated M108 ✅, added M109 ✅, M110 ✅
- `docs/iterations/current.md` — Updated

### Key Features
- Auto-detect SGLang format (itl as list + latency field)
- Failed request filtering with warnings
- TPOT computed as mean of itl list with fallback
- Programmatic API: `import_sglang()`, `import_sglang_data()`

Closes #243