### PR TITLE
feat: SGLang Benchmark Command Generator (M111)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1491,3 +1491,16 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `import` subcommand updated with `--format sglang|auto` support
 - Programmatic `import_sglang()` and `import_sglang_data()` APIs
 - 23 new tests (2495 total)
+
+### M111 🔄 SGLang Benchmark Command Generator
+
+*In progress — PR #TBD*
+
+- `SGLangCommandGenerator` class in `sglang_commands.py`
+- `SGLangCommandConfig`, `SGLangServerCommand`, `SGLangBenchmarkCommand`, `SGLangCommandSet` Pydantic models
+- Generate SGLang server launch (`sglang.launch_server`) and bench_serving commands for each P:D ratio
+- SGLang-specific options: dp_size, chunked_prefill, context_length
+- Shell script output with server lifecycle management (background, sleep, kill)
+- CLI `sglang-commands` subcommand with `--total-instances`, `--model`, `--qps`, table + JSON output
+- Programmatic `generate_sglang_commands()` API
+- 25 new tests

--- a/docs/iterations/current.md
+++ b/docs/iterations/current.md
@@ -62,4 +62,5 @@ The project has completed **110 milestones**, covering the full feature chain fr
 | 1 | 2026-04-06 | M107 Rate Limiter Recommender | ✅ merged | PR #238 |
 | 2 | 2026-04-06 | M108 vLLM Benchmark Importer | ✅ merged | PR #240 |
 | 3 | 2026-04-06 | M109 vLLM Benchmark Command Generator | ✅ merged | PR #242 |
-| 4 | 2026-04-06 | M110 SGLang Benchmark Format Importer | ⏳ pending review | Issue #243 |
+| 4 | 2026-04-06 | M110 SGLang Benchmark Format Importer | ✅ merged | PR #244 |
+| 5 | 2026-04-06 | M111 SGLang Benchmark Command Generator | ⏳ pending review | Issue #245 |

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -1408,7 +1408,11 @@ __all__ += [
     "save_baseline",
 ]
 
-from xpyd_plan.vllm_commands import BenchmarkCommand  # noqa: E402, I001
+from xpyd_plan.sglang_commands import SGLangCommandConfig  # noqa: E402, I001
+from xpyd_plan.sglang_commands import SGLangCommandGenerator  # noqa: E402
+from xpyd_plan.sglang_commands import SGLangCommandSet  # noqa: E402
+from xpyd_plan.sglang_commands import generate_sglang_commands  # noqa: E402
+from xpyd_plan.vllm_commands import BenchmarkCommand  # noqa: E402
 from xpyd_plan.vllm_commands import CommandGenerator  # noqa: E402
 from xpyd_plan.vllm_commands import CommandSet  # noqa: E402
 from xpyd_plan.vllm_commands import ServerCommand  # noqa: E402
@@ -1422,6 +1426,10 @@ __all__ += [
     "ServerCommand",
     "VLLMCommandConfig",
     "generate_vllm_commands",
+    "generate_sglang_commands",
+    "SGLangCommandConfig",
+    "SGLangCommandGenerator",
+    "SGLangCommandSet",
 ]
 
 from xpyd_plan.vllm_import import (  # noqa: E402

--- a/src/xpyd_plan/cli/_main.py
+++ b/src/xpyd_plan/cli/_main.py
@@ -80,6 +80,7 @@ from xpyd_plan.cli._scaling import _cmd_scaling, add_scaling_parser
 from xpyd_plan.cli._scaling_policy import add_scaling_policy_parser
 from xpyd_plan.cli._scorecard import _cmd_scorecard, add_scorecard_parser
 from xpyd_plan.cli._session import _cmd_session
+from xpyd_plan.cli._sglang_commands import register_sglang_commands
 from xpyd_plan.cli._size_distribution import _cmd_size_distribution, add_size_distribution_parser
 from xpyd_plan.cli._sla_headroom import add_sla_headroom_parser
 from xpyd_plan.cli._sla_tier import add_sla_tier_parser
@@ -961,6 +962,7 @@ def main(argv: list[str] | None = None) -> None:
     add_queue_parser(subparsers)
     add_import_parser(subparsers)
     register_vllm_commands(subparsers)
+    register_sglang_commands(subparsers)
     add_rate_limit_parser(subparsers)
     add_batch_analysis_parser(subparsers)
     add_stat_summary_parser(subparsers)
@@ -1302,6 +1304,10 @@ def main(argv: list[str] | None = None) -> None:
         from xpyd_plan.cli._vllm_commands import _cmd_vllm_commands
 
         _cmd_vllm_commands(args)
+    elif args.command == "sglang-commands":
+        from xpyd_plan.cli._sglang_commands import _cmd_sglang_commands
+
+        _cmd_sglang_commands(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/xpyd_plan/cli/_sglang_commands.py
+++ b/src/xpyd_plan/cli/_sglang_commands.py
@@ -1,0 +1,140 @@
+"""CLI sglang-commands subcommand."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_plan.sglang_commands import SGLangCommandConfig, SGLangCommandGenerator
+
+
+def _cmd_sglang_commands(args: argparse.Namespace) -> None:
+    """Handle the 'sglang-commands' subcommand."""
+    console = Console()
+
+    qps_levels = [float(q) for q in args.qps.split(",")]
+
+    config = SGLangCommandConfig(
+        model=args.model,
+        total_instances=args.total_instances,
+        qps_levels=qps_levels,
+        tp_size=getattr(args, "tp_size", 1),
+        dp_size=getattr(args, "dp_size", 1),
+        max_model_len=getattr(args, "max_model_len", None),
+        chunked_prefill=getattr(args, "chunked_prefill", False),
+        dataset=getattr(args, "dataset", None),
+        num_prompts=getattr(args, "num_prompts", 1000),
+        host=getattr(args, "host", "localhost"),
+        port=getattr(args, "port", 30000),
+    )
+
+    gen = SGLangCommandGenerator(config)
+    result = gen.generate()
+
+    if args.output_script:
+        script = _to_shell_script(result, config)
+        with open(args.output_script, "w") as f:
+            f.write(script)
+        console.print(
+            f"[green]Shell script written to {args.output_script} "
+            f"({len(result)} ratios)[/green]"
+        )
+        return
+
+    output_format = getattr(args, "output_format", "table")
+
+    if output_format == "json":
+        print(json.dumps([cs.model_dump() for cs in result], indent=2, default=str))
+        return
+
+    # Table output
+    console.print("\n[bold]SGLang Benchmark Commands[/bold]")
+    console.print(
+        f"Model: {config.model} | Instances: {config.total_instances} | "
+        f"Ratios: {len(result)}\n"
+    )
+
+    table = Table(title="Benchmark Runs")
+    table.add_column("P:D Ratio")
+    table.add_column("Prefill", justify="right")
+    table.add_column("Decode", justify="right")
+    table.add_column("QPS Levels")
+
+    for cs in result:
+        table.add_row(
+            cs.server.ratio,
+            str(cs.server.prefill_instances),
+            str(cs.server.decode_instances),
+            ", ".join(f"{b.qps}" for b in cs.benchmarks),
+        )
+
+    console.print(table)
+    console.print(
+        "\n[dim]Use --output-script to generate an executable shell script[/dim]"
+    )
+
+
+def _to_shell_script(
+    command_sets: list,
+    config: SGLangCommandConfig,
+) -> str:
+    """Build a complete shell script from command sets."""
+    lines = [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        f"# SGLang Benchmark Script — {config.model}",
+        f"# Total instances: {config.total_instances}",
+        f"# QPS levels: {', '.join(str(q) for q in config.qps_levels)}",
+        "",
+    ]
+    for cs in command_sets:
+        lines.append(cs.script_snippet)
+    lines.append("echo 'All benchmarks complete!'")
+    return "\n".join(lines) + "\n"
+
+
+def register_sglang_commands(subparsers: argparse._SubParsersAction) -> None:
+    """Register the sglang-commands subcommand."""
+    p = subparsers.add_parser(
+        "sglang-commands",
+        help="Generate SGLang benchmark commands for P:D ratio exploration",
+    )
+    p.add_argument("--model", type=str, required=True, help="HuggingFace model name")
+    p.add_argument(
+        "--total-instances",
+        type=int,
+        required=True,
+        help="Total instances (prefill + decode)",
+    )
+    p.add_argument(
+        "--qps",
+        type=str,
+        required=True,
+        help="Comma-separated QPS levels (e.g. 1,2,4)",
+    )
+    p.add_argument("--tp-size", type=int, default=1, help="Tensor parallel size")
+    p.add_argument("--dp-size", type=int, default=1, help="Data parallel size")
+    p.add_argument("--max-model-len", type=int, default=None, help="Max model length")
+    p.add_argument(
+        "--chunked-prefill",
+        action="store_true",
+        default=False,
+        help="Enable chunked prefill",
+    )
+    p.add_argument("--dataset", type=str, default=None, help="Dataset path")
+    p.add_argument("--num-prompts", type=int, default=1000, help="Prompts per run")
+    p.add_argument("--host", type=str, default="localhost", help="Server host")
+    p.add_argument("--port", type=int, default=30000, help="Server port")
+    p.add_argument(
+        "--output-script", type=str, default=None, help="Write shell script"
+    )
+    p.add_argument(
+        "--output-format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format",
+    )
+    p.set_defaults(func=_cmd_sglang_commands)

--- a/src/xpyd_plan/sglang_commands.py
+++ b/src/xpyd_plan/sglang_commands.py
@@ -1,0 +1,181 @@
+"""SGLang Benchmark Command Generator — generate ready-to-run SGLang commands.
+
+Given total instances, model name, and QPS levels, generate SGLang server
+and bench_serving commands for each planned P:D ratio configuration.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class SGLangCommandConfig(BaseModel):
+    """Configuration for SGLang command generation."""
+
+    model: str = Field(..., min_length=1, description="HuggingFace model name")
+    total_instances: int = Field(..., ge=2, description="Total instances (P+D)")
+    qps_levels: list[float] = Field(
+        ..., min_length=1, description="QPS levels to benchmark"
+    )
+    tp_size: int = Field(1, ge=1, description="Tensor parallel size")
+    dp_size: int = Field(1, ge=1, description="Data parallel size")
+    max_model_len: int | None = Field(None, ge=1, description="Max model length")
+    chunked_prefill: bool = Field(False, description="Enable chunked prefill")
+    dataset: str | None = Field(None, description="Dataset path")
+    num_prompts: int = Field(1000, ge=1, description="Number of prompts per run")
+    host: str = Field("localhost", description="Server host")
+    port: int = Field(30000, ge=1, le=65535, description="Server port")
+
+
+class SGLangServerCommand(BaseModel):
+    """An SGLang server launch command for one P:D ratio."""
+
+    ratio: str = Field(..., description="e.g. '2P:3D'")
+    prefill_instances: int = Field(..., ge=1)
+    decode_instances: int = Field(..., ge=1)
+    command: str = Field(..., description="Shell command")
+
+
+class SGLangBenchmarkCommand(BaseModel):
+    """A bench_serving invocation command."""
+
+    ratio: str = Field(..., description="P:D ratio string")
+    qps: float = Field(..., gt=0)
+    command: str = Field(..., description="Shell command")
+
+
+class SGLangCommandSet(BaseModel):
+    """Complete command set for one P:D ratio."""
+
+    server: SGLangServerCommand
+    benchmarks: list[SGLangBenchmarkCommand]
+    script_snippet: str = Field("", description="Combined shell script snippet")
+
+
+class SGLangCommandGenerator:
+    """Generate SGLang server and benchmark commands for P:D ratio exploration."""
+
+    def __init__(self, config: SGLangCommandConfig) -> None:
+        self._config = config
+
+    def generate(self) -> list[SGLangCommandSet]:
+        """Generate command sets for all valid P:D ratios."""
+        total = self._config.total_instances
+        results: list[SGLangCommandSet] = []
+
+        for p in range(1, total):
+            d = total - p
+            if d < 1:
+                continue
+            ratio_str = f"{p}P:{d}D"
+            server_cmd = self._build_server_command(p, d, ratio_str)
+            bench_cmds = [
+                self._build_benchmark_command(ratio_str, qps)
+                for qps in self._config.qps_levels
+            ]
+            snippet = self._build_script_snippet(server_cmd, bench_cmds)
+            results.append(
+                SGLangCommandSet(
+                    server=server_cmd,
+                    benchmarks=bench_cmds,
+                    script_snippet=snippet,
+                )
+            )
+
+        return results
+
+    def _build_server_command(
+        self, prefill: int, decode: int, ratio: str
+    ) -> SGLangServerCommand:
+        cfg = self._config
+        parts = [
+            "python3 -m sglang.launch_server",
+            f"--model-path {cfg.model}",
+            f"--tp {cfg.tp_size}",
+            f"--dp {cfg.dp_size}",
+            f"--host {cfg.host}",
+            f"--port {cfg.port}",
+        ]
+        if cfg.max_model_len is not None:
+            parts.append(f"--context-length {cfg.max_model_len}")
+        if cfg.chunked_prefill:
+            parts.append("--chunked-prefill-size 8192")
+        return SGLangServerCommand(
+            ratio=ratio,
+            prefill_instances=prefill,
+            decode_instances=decode,
+            command=" \\\n  ".join(parts),
+        )
+
+    def _build_benchmark_command(
+        self, ratio: str, qps: float
+    ) -> SGLangBenchmarkCommand:
+        cfg = self._config
+        parts = [
+            "python3 -m sglang.bench_serving",
+            "--backend sglang",
+            f"--host {cfg.host}",
+            f"--port {cfg.port}",
+            f"--num-prompts {cfg.num_prompts}",
+            f"--request-rate {qps}",
+        ]
+        if cfg.dataset is not None:
+            parts.append(f"--dataset-path {cfg.dataset}")
+        output_file = f"bench_{ratio.replace(':', '_')}_qps{qps}.json"
+        parts.append(f"--output-file {output_file}")
+        return SGLangBenchmarkCommand(
+            ratio=ratio,
+            qps=qps,
+            command=" \\\n  ".join(parts),
+        )
+
+    def _build_script_snippet(
+        self,
+        server: SGLangServerCommand,
+        benchmarks: list[SGLangBenchmarkCommand],
+    ) -> str:
+        lines = [
+            f"# --- {server.ratio} ---",
+            f"{server.command} &",
+            "SERVER_PID=$!",
+            "sleep 120  # wait for SGLang server to load model",
+            "",
+        ]
+        for bench in benchmarks:
+            lines.append(f"{bench.command}")
+            lines.append("")
+        lines.append("kill $SERVER_PID")
+        lines.append(f"echo 'Done with {server.ratio}'")
+        lines.append("")
+        return "\n".join(lines)
+
+
+def generate_sglang_commands(
+    model: str,
+    total_instances: int,
+    qps_levels: list[float],
+    *,
+    tp_size: int = 1,
+    dp_size: int = 1,
+    max_model_len: int | None = None,
+    chunked_prefill: bool = False,
+    dataset: str | None = None,
+    num_prompts: int = 1000,
+    host: str = "localhost",
+    port: int = 30000,
+) -> list[SGLangCommandSet]:
+    """Programmatic API: generate SGLang benchmark commands."""
+    config = SGLangCommandConfig(
+        model=model,
+        total_instances=total_instances,
+        qps_levels=qps_levels,
+        tp_size=tp_size,
+        dp_size=dp_size,
+        max_model_len=max_model_len,
+        chunked_prefill=chunked_prefill,
+        dataset=dataset,
+        num_prompts=num_prompts,
+        host=host,
+        port=port,
+    )
+    return SGLangCommandGenerator(config).generate()

--- a/tests/test_sglang_commands.py
+++ b/tests/test_sglang_commands.py
@@ -1,0 +1,272 @@
+"""Tests for SGLang Benchmark Command Generator (M111)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from xpyd_plan.cli import main
+from xpyd_plan.sglang_commands import (
+    SGLangCommandConfig,
+    SGLangCommandGenerator,
+    SGLangCommandSet,
+    generate_sglang_commands,
+)
+
+# ── Config validation ──────────────────────────────────────────────
+
+
+def test_config_valid():
+    cfg = SGLangCommandConfig(
+        model="meta-llama/Llama-3-8B", total_instances=4, qps_levels=[1, 2]
+    )
+    assert cfg.total_instances == 4
+    assert cfg.port == 30000
+
+
+def test_config_min_instances():
+    with pytest.raises(Exception):
+        SGLangCommandConfig(
+            model="m", total_instances=1, qps_levels=[1]
+        )
+
+
+def test_config_empty_qps():
+    with pytest.raises(Exception):
+        SGLangCommandConfig(
+            model="m", total_instances=4, qps_levels=[]
+        )
+
+
+# ── Generator basics ──────────────────────────────────────────────
+
+
+def _make_gen(total: int = 4, qps: list[float] | None = None) -> SGLangCommandGenerator:
+    cfg = SGLangCommandConfig(
+        model="meta-llama/Llama-3-8B",
+        total_instances=total,
+        qps_levels=qps or [1.0],
+    )
+    return SGLangCommandGenerator(cfg)
+
+
+def test_generate_count():
+    result = _make_gen(4).generate()
+    # 1P:3D, 2P:2D, 3P:1D
+    assert len(result) == 3
+
+
+def test_generate_ratios():
+    result = _make_gen(4).generate()
+    ratios = [cs.server.ratio for cs in result]
+    assert ratios == ["1P:3D", "2P:2D", "3P:1D"]
+
+
+def test_generate_min_instances():
+    result = _make_gen(2).generate()
+    assert len(result) == 1
+    assert result[0].server.ratio == "1P:1D"
+
+
+def test_server_command_contains_model():
+    result = _make_gen(3).generate()
+    assert "meta-llama/Llama-3-8B" in result[0].server.command
+
+
+def test_server_command_contains_sglang():
+    result = _make_gen(3).generate()
+    assert "sglang.launch_server" in result[0].server.command
+
+
+def test_benchmark_command_contains_sglang():
+    result = _make_gen(3).generate()
+    assert "sglang.bench_serving" in result[0].benchmarks[0].command
+
+
+def test_benchmark_command_qps():
+    result = _make_gen(3, qps=[2.5]).generate()
+    assert "--request-rate 2.5" in result[0].benchmarks[0].command
+
+
+def test_multiple_qps_levels():
+    result = _make_gen(3, qps=[1.0, 2.0, 4.0]).generate()
+    assert len(result[0].benchmarks) == 3
+
+
+def test_server_command_prefill_decode():
+    result = _make_gen(5).generate()
+    first = result[0]
+    assert first.server.prefill_instances == 1
+    assert first.server.decode_instances == 4
+
+
+# ── Optional config flags ──────────────────────────────────────────
+
+
+def test_chunked_prefill_flag():
+    cfg = SGLangCommandConfig(
+        model="m", total_instances=3, qps_levels=[1], chunked_prefill=True
+    )
+    gen = SGLangCommandGenerator(cfg)
+    result = gen.generate()
+    assert "--chunked-prefill-size" in result[0].server.command
+
+
+def test_max_model_len():
+    cfg = SGLangCommandConfig(
+        model="m", total_instances=3, qps_levels=[1], max_model_len=4096
+    )
+    gen = SGLangCommandGenerator(cfg)
+    result = gen.generate()
+    assert "--context-length 4096" in result[0].server.command
+
+
+def test_dp_size():
+    cfg = SGLangCommandConfig(
+        model="m", total_instances=3, qps_levels=[1], dp_size=2
+    )
+    gen = SGLangCommandGenerator(cfg)
+    result = gen.generate()
+    assert "--dp 2" in result[0].server.command
+
+
+def test_dataset_flag():
+    cfg = SGLangCommandConfig(
+        model="m", total_instances=3, qps_levels=[1], dataset="/data/sharegpt.json"
+    )
+    gen = SGLangCommandGenerator(cfg)
+    result = gen.generate()
+    assert "--dataset-path /data/sharegpt.json" in result[0].benchmarks[0].command
+
+
+def test_custom_port():
+    cfg = SGLangCommandConfig(
+        model="m", total_instances=3, qps_levels=[1], port=8080
+    )
+    gen = SGLangCommandGenerator(cfg)
+    result = gen.generate()
+    assert "--port 8080" in result[0].server.command
+    assert "--port 8080" in result[0].benchmarks[0].command
+
+
+# ── Script snippet ──────────────────────────────────────────────
+
+
+def test_script_snippet_has_kill():
+    result = _make_gen(3).generate()
+    assert "kill $SERVER_PID" in result[0].script_snippet
+
+
+def test_script_snippet_has_sleep():
+    result = _make_gen(3).generate()
+    assert "sleep 120" in result[0].script_snippet
+
+
+# ── Programmatic API ──────────────────────────────────────────────
+
+
+def test_programmatic_api():
+    result = generate_sglang_commands(
+        model="m", total_instances=4, qps_levels=[1.0, 2.0]
+    )
+    assert len(result) == 3
+    assert all(isinstance(cs, SGLangCommandSet) for cs in result)
+
+
+def test_programmatic_api_options():
+    result = generate_sglang_commands(
+        model="m",
+        total_instances=3,
+        qps_levels=[1.0],
+        tp_size=2,
+        dp_size=4,
+        chunked_prefill=True,
+        port=9000,
+    )
+    assert "--tp 2" in result[0].server.command
+    assert "--dp 4" in result[0].server.command
+
+
+# ── CLI integration ──────────────────────────────────────────────
+
+
+def test_cli_table_output(capsys):
+    with patch(
+        "sys.argv",
+        [
+            "xpyd-plan",
+            "sglang-commands",
+            "--model",
+            "meta-llama/Llama-3-8B",
+            "--total-instances",
+            "4",
+            "--qps",
+            "1,2",
+        ],
+    ):
+        main()
+    captured = capsys.readouterr()
+    assert "SGLang Benchmark Commands" in captured.out
+
+
+def test_cli_json_output(capsys):
+    with patch(
+        "sys.argv",
+        [
+            "xpyd-plan",
+            "sglang-commands",
+            "--model",
+            "m",
+            "--total-instances",
+            "3",
+            "--qps",
+            "1",
+            "--output-format",
+            "json",
+        ],
+    ):
+        main()
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert len(data) == 2
+
+
+def test_cli_output_script():
+    with tempfile.NamedTemporaryFile(suffix=".sh", delete=False) as f:
+        path = f.name
+
+    with patch(
+        "sys.argv",
+        [
+            "xpyd-plan",
+            "sglang-commands",
+            "--model",
+            "m",
+            "--total-instances",
+            "3",
+            "--qps",
+            "1",
+            "--output-script",
+            path,
+        ],
+    ):
+        main()
+    content = Path(path).read_text()
+    assert "#!/usr/bin/env bash" in content
+    assert "sglang" in content
+    Path(path).unlink()
+
+
+# ── Model serialization ──────────────────────────────────────────
+
+
+def test_model_dump():
+    result = _make_gen(3).generate()
+    d = result[0].model_dump()
+    assert "server" in d
+    assert "benchmarks" in d
+    assert "script_snippet" in d


### PR DESCRIPTION
## Summary

SGLang benchmark command generator — parallel to M109 (vLLM commands) for SGLang users.

### Changes
- `SGLangCommandGenerator` class in `sglang_commands.py`
- `SGLangCommandConfig`, `SGLangServerCommand`, `SGLangBenchmarkCommand`, `SGLangCommandSet` Pydantic models
- Generate `sglang.launch_server` and `bench_serving` commands for each P:D ratio
- SGLang-specific options: dp_size, chunked_prefill, context_length
- Shell script output with server lifecycle management (background, sleep 120, kill)
- CLI `sglang-commands` subcommand with `--total-instances`, `--model`, `--qps`, table + JSON output
- Programmatic `generate_sglang_commands()` API
- 25 new tests

Closes #245