### PR TITLE
feat: TensorRT-LLM Benchmark Format Importer (M112)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1492,9 +1492,9 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - Programmatic `import_sglang()` and `import_sglang_data()` APIs
 - 23 new tests (2495 total)
 
-### M111 🔄 SGLang Benchmark Command Generator
+### M111 ✅ SGLang Benchmark Command Generator
 
-*In progress — PR #TBD*
+*Completed — PR #246*
 
 - `SGLangCommandGenerator` class in `sglang_commands.py`
 - `SGLangCommandConfig`, `SGLangServerCommand`, `SGLangBenchmarkCommand`, `SGLangCommandSet` Pydantic models
@@ -1504,3 +1504,16 @@ Help users find the **optimal Prefill:Decode instance ratio** based on **real be
 - CLI `sglang-commands` subcommand with `--total-instances`, `--model`, `--qps`, table + JSON output
 - Programmatic `generate_sglang_commands()` API
 - 25 new tests
+
+### M112 🔄 TensorRT-LLM Benchmark Format Importer
+
+*In progress — PR #TBD*
+
+- `TRTLLMImporter` module in `trtllm_import.py`
+- `TRTLLMRequest`, `TRTLLMBenchmarkData`, `TRTLLMImportConfig`, `TRTLLMImportResult` Pydantic models
+- Convert TensorRT-LLM benchmark JSON (input_tokens, output_tokens, first_token_latency, inter_token_latencies, end_to_end_latency) to native format
+- Format auto-detection via `_detect_trtllm_format()` distinguishing from vLLM/SGLang
+- Failed-request filtering (status != "completed") with warnings
+- CLI `import --format trtllm` support
+- Programmatic `import_trtllm()` and `import_trtllm_data()` API
+- 25+ new tests

--- a/docs/iterations/current.md
+++ b/docs/iterations/current.md
@@ -63,4 +63,5 @@ The project has completed **110 milestones**, covering the full feature chain fr
 | 2 | 2026-04-06 | M108 vLLM Benchmark Importer | ✅ merged | PR #240 |
 | 3 | 2026-04-06 | M109 vLLM Benchmark Command Generator | ✅ merged | PR #242 |
 | 4 | 2026-04-06 | M110 SGLang Benchmark Format Importer | ✅ merged | PR #244 |
-| 5 | 2026-04-06 | M111 SGLang Benchmark Command Generator | ⏳ pending review | Issue #245 |
+| 5 | 2026-04-06 | M111 SGLang Benchmark Command Generator | ✅ merged | PR #246 |
+| 6 | 2026-04-06 | M112 TensorRT-LLM Benchmark Format Importer | ⏳ pending review | Issue #247 |

--- a/src/xpyd_plan/__init__.py
+++ b/src/xpyd_plan/__init__.py
@@ -1467,3 +1467,21 @@ __all__ += [
     "import_sglang",
     "import_sglang_data",
 ]
+
+from xpyd_plan.trtllm_import import (  # noqa: E402
+    TRTLLMBenchmarkData,
+    TRTLLMImportConfig,
+    TRTLLMImportResult,
+    TRTLLMRequest,
+    import_trtllm,
+    import_trtllm_data,
+)
+
+__all__ += [
+    "TRTLLMBenchmarkData",
+    "TRTLLMImportConfig",
+    "TRTLLMImportResult",
+    "TRTLLMRequest",
+    "import_trtllm",
+    "import_trtllm_data",
+]

--- a/src/xpyd_plan/cli/_import.py
+++ b/src/xpyd_plan/cli/_import.py
@@ -1,4 +1,4 @@
-"""CLI import command — import vLLM/SGLang benchmark data."""
+"""CLI import command — import vLLM/SGLang/TensorRT-LLM benchmark data."""
 
 from __future__ import annotations
 
@@ -14,6 +14,12 @@ from xpyd_plan.sglang_import import (
     _detect_sglang_format,
     import_sglang,
     import_sglang_data,
+)
+from xpyd_plan.trtllm_import import (
+    TRTLLMImportConfig,
+    _detect_trtllm_format,
+    import_trtllm,
+    import_trtllm_data,
 )
 from xpyd_plan.vllm_import import import_vllm
 
@@ -31,7 +37,19 @@ def _cmd_import(args: argparse.Namespace) -> None:
     fmt = args.format
 
     try:
-        if fmt == "sglang":
+        if fmt == "trtllm":
+            config = TRTLLMImportConfig(
+                num_prefill_instances=args.prefill_instances,
+                num_decode_instances=args.decode_instances,
+                format="trtllm",
+            )
+            result = import_trtllm(args.input, config)
+            if args.output:
+                Path(args.output).write_text(
+                    result.benchmark_data.model_dump_json(indent=2),
+                    encoding="utf-8",
+                )
+        elif fmt == "sglang":
             config = SGLangImportConfig(
                 num_prefill_instances=args.prefill_instances,
                 num_decode_instances=args.decode_instances,
@@ -44,15 +62,26 @@ def _cmd_import(args: argparse.Namespace) -> None:
                     encoding="utf-8",
                 )
         elif fmt == "auto":
-            # Try SGLang detection first, then fall back to vLLM importer
             raw = json.loads(Path(args.input).read_text(encoding="utf-8"))
-            if _detect_sglang_format(raw):
-                config = SGLangImportConfig(
+            if _detect_trtllm_format(raw):
+                trtllm_config = TRTLLMImportConfig(
+                    num_prefill_instances=args.prefill_instances,
+                    num_decode_instances=args.decode_instances,
+                    format="trtllm",
+                )
+                result = import_trtllm_data(raw, trtllm_config)
+                if args.output:
+                    Path(args.output).write_text(
+                        result.benchmark_data.model_dump_json(indent=2),
+                        encoding="utf-8",
+                    )
+            elif _detect_sglang_format(raw):
+                sglang_config = SGLangImportConfig(
                     num_prefill_instances=args.prefill_instances,
                     num_decode_instances=args.decode_instances,
                     format="sglang",
                 )
-                result = import_sglang_data(raw, config)
+                result = import_sglang_data(raw, sglang_config)
                 if args.output:
                     Path(args.output).write_text(
                         result.benchmark_data.model_dump_json(indent=2),
@@ -109,7 +138,7 @@ def add_import_parser(subparsers: argparse._SubParsersAction) -> None:
     """Add the import subcommand parser."""
     parser = subparsers.add_parser(
         "import",
-        help="Import vLLM/SGLang benchmark data to native format",
+        help="Import vLLM/SGLang/TensorRT-LLM benchmark data to native format",
     )
     parser.add_argument(
         "--input",
@@ -118,7 +147,7 @@ def add_import_parser(subparsers: argparse._SubParsersAction) -> None:
     )
     parser.add_argument(
         "--format",
-        choices=["vllm", "sglang", "native", "auto"],
+        choices=["vllm", "sglang", "trtllm", "native", "auto"],
         default="auto",
         help="Input format (default: auto-detect)",
     )

--- a/src/xpyd_plan/trtllm_import.py
+++ b/src/xpyd_plan/trtllm_import.py
@@ -1,0 +1,266 @@
+"""TensorRT-LLM Benchmark Format Importer — import TensorRT-LLM benchmark output.
+
+Converts TensorRT-LLM benchmark JSON output (list of request dicts) into
+the native xpyd-plan BenchmarkData format for downstream analysis.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .benchmark_models import BenchmarkData, BenchmarkMetadata, BenchmarkRequest
+
+
+class TRTLLMRequest(BaseModel):
+    """A single request record from TensorRT-LLM benchmark output."""
+
+    input_tokens: int = Field(..., ge=1, description="Number of input/prompt tokens")
+    output_tokens: int = Field(
+        ..., ge=1, description="Number of output/generated tokens"
+    )
+    first_token_latency: float = Field(
+        ..., ge=0, description="Time to first token (seconds)"
+    )
+    inter_token_latencies: list[float] = Field(
+        default_factory=list,
+        description="List of inter-token latencies (seconds)",
+    )
+    end_to_end_latency: float = Field(
+        ..., ge=0, description="Total request latency (seconds)"
+    )
+    timestamp: float | None = Field(
+        None, description="Request start timestamp (epoch seconds)"
+    )
+    status: str = Field(
+        "completed", description="Request status (completed/failed/timeout)"
+    )
+
+
+class TRTLLMBenchmarkData(BaseModel):
+    """Parsed TensorRT-LLM benchmark data (list of request records)."""
+
+    requests: list[TRTLLMRequest] = Field(..., min_length=1)
+
+
+class TRTLLMImportConfig(BaseModel):
+    """Configuration for TensorRT-LLM import."""
+
+    num_prefill_instances: int = Field(
+        ..., ge=1, description="Number of prefill instances"
+    )
+    num_decode_instances: int = Field(
+        ..., ge=1, description="Number of decode instances"
+    )
+    format: str = Field(
+        "auto", description="Input format: 'trtllm', 'native', or 'auto'"
+    )
+
+
+class TRTLLMImportResult(BaseModel):
+    """Result of a TensorRT-LLM import operation."""
+
+    benchmark_data: BenchmarkData
+    source_format: str = Field(..., description="Detected source format")
+    num_requests: int = Field(..., ge=1, description="Number of requests imported")
+    num_failed_filtered: int = Field(
+        0, description="Number of failed requests filtered out"
+    )
+    warnings: list[str] = Field(default_factory=list, description="Import warnings")
+
+
+def _detect_trtllm_format(data: Any) -> bool:
+    """Detect whether data is TensorRT-LLM format.
+
+    TensorRT-LLM format: list of dicts with 'input_tokens',
+    'end_to_end_latency', and 'inter_token_latencies' (list) keys.
+    """
+    if not isinstance(data, list) or len(data) == 0:
+        return False
+    first = data[0]
+    if not isinstance(first, dict):
+        return False
+    has_input_tokens = "input_tokens" in first
+    has_e2e = "end_to_end_latency" in first
+    has_itl = "inter_token_latencies" in first and isinstance(
+        first.get("inter_token_latencies"), list
+    )
+    return has_input_tokens and has_e2e and has_itl
+
+
+def _convert_requests(
+    trtllm_requests: list[TRTLLMRequest],
+) -> tuple[list[BenchmarkRequest], list[str], int]:
+    """Convert TensorRT-LLM requests to native format.
+
+    Returns (native_requests, warnings, num_failed_filtered).
+    """
+    warnings: list[str] = []
+    native_requests: list[BenchmarkRequest] = []
+
+    # Filter non-completed requests
+    successful = [r for r in trtllm_requests if r.status == "completed"]
+    num_failed = len(trtllm_requests) - len(successful)
+    if num_failed > 0:
+        warnings.append(
+            f"Filtered {num_failed} non-completed request(s) "
+            f"(status != 'completed')"
+        )
+
+    if not successful:
+        raise ValueError(
+            "No completed requests to import — all requests have non-completed status"
+        )
+
+    has_timestamps = any(r.timestamp is not None for r in successful)
+    warned_empty_itl = False
+
+    for i, req in enumerate(successful):
+        # Compute TPOT from inter_token_latencies (mean)
+        if req.inter_token_latencies and len(req.inter_token_latencies) > 0:
+            tpot_s = sum(req.inter_token_latencies) / len(
+                req.inter_token_latencies
+            )
+        else:
+            # Fallback: estimate from (e2e - ftl) / (output_tokens - 1)
+            if req.output_tokens > 1:
+                tpot_s = (req.end_to_end_latency - req.first_token_latency) / (
+                    req.output_tokens - 1
+                )
+            else:
+                tpot_s = 0.0
+            if not warned_empty_itl:
+                warnings.append(
+                    "Some requests have empty inter_token_latencies, "
+                    "estimated TPOT from latency"
+                )
+                warned_empty_itl = True
+
+        # Determine timestamp
+        if req.timestamp is not None:
+            timestamp = req.timestamp
+        elif has_timestamps:
+            timestamp = 0.0
+        else:
+            timestamp = float(i)
+
+        native_requests.append(
+            BenchmarkRequest(
+                request_id=str(i + 1),
+                prompt_tokens=req.input_tokens,
+                output_tokens=req.output_tokens,
+                ttft_ms=req.first_token_latency * 1000.0,
+                tpot_ms=tpot_s * 1000.0,
+                total_latency_ms=req.end_to_end_latency * 1000.0,
+                timestamp=timestamp,
+            )
+        )
+
+    return native_requests, warnings, num_failed
+
+
+def import_trtllm(
+    path: str | Path,
+    config: TRTLLMImportConfig,
+) -> TRTLLMImportResult:
+    """Import a TensorRT-LLM benchmark file and convert to native format.
+
+    Parameters
+    ----------
+    path
+        Path to the TensorRT-LLM benchmark JSON file.
+    config
+        Import configuration (instance counts, format hint).
+
+    Returns
+    -------
+    TRTLLMImportResult
+        Converted benchmark data with metadata.
+    """
+    path = Path(path)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    return import_trtllm_data(raw, config)
+
+
+def import_trtllm_data(
+    data: Any,
+    config: TRTLLMImportConfig,
+) -> TRTLLMImportResult:
+    """Import TensorRT-LLM benchmark data from a parsed JSON object.
+
+    Parameters
+    ----------
+    data
+        Parsed JSON data (expected: list of request dicts).
+    config
+        Import configuration.
+
+    Returns
+    -------
+    TRTLLMImportResult
+        Converted benchmark data with metadata.
+    """
+    # Format detection
+    if config.format == "auto":
+        if _detect_trtllm_format(data):
+            source_format = "trtllm"
+        elif isinstance(data, dict) and "metadata" in data and "requests" in data:
+            source_format = "native"
+        else:
+            raise ValueError(
+                "Cannot auto-detect format. Use --format trtllm or --format native."
+            )
+    else:
+        source_format = config.format
+
+    if source_format == "native":
+        benchmark_data = BenchmarkData.model_validate(data)
+        return TRTLLMImportResult(
+            benchmark_data=benchmark_data,
+            source_format="native",
+            num_requests=len(benchmark_data.requests),
+            num_failed_filtered=0,
+            warnings=[],
+        )
+
+    # Parse TensorRT-LLM format
+    if not isinstance(data, list):
+        raise ValueError(
+            "TensorRT-LLM format expects a JSON array of request objects"
+        )
+
+    trtllm_data = TRTLLMBenchmarkData(
+        requests=[TRTLLMRequest(**r) for r in data]
+    )
+    native_requests, warnings, num_failed = _convert_requests(trtllm_data.requests)
+
+    # Compute measured QPS
+    if len(native_requests) >= 2:
+        timestamps = [r.timestamp for r in native_requests]
+        duration = max(timestamps) - min(timestamps)
+        measured_qps = len(native_requests) / duration if duration > 0 else 1.0
+    else:
+        measured_qps = 1.0
+
+    total_instances = config.num_prefill_instances + config.num_decode_instances
+
+    benchmark_data = BenchmarkData(
+        metadata=BenchmarkMetadata(
+            num_prefill_instances=config.num_prefill_instances,
+            num_decode_instances=config.num_decode_instances,
+            total_instances=total_instances,
+            measured_qps=measured_qps,
+        ),
+        requests=native_requests,
+    )
+
+    return TRTLLMImportResult(
+        benchmark_data=benchmark_data,
+        source_format="trtllm",
+        num_requests=len(native_requests),
+        num_failed_filtered=num_failed,
+        warnings=warnings,
+    )

--- a/tests/test_trtllm_import.py
+++ b/tests/test_trtllm_import.py
@@ -1,0 +1,478 @@
+"""Tests for TensorRT-LLM Benchmark Format Importer (M112)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_plan.trtllm_import import (
+    TRTLLMImportConfig,
+    TRTLLMImportResult,
+    TRTLLMRequest,
+    _convert_requests,
+    _detect_trtllm_format,
+    import_trtllm,
+    import_trtllm_data,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_trtllm_request(
+    input_tokens: int = 128,
+    output_tokens: int = 64,
+    first_token_latency: float = 0.05,
+    inter_token_latencies: list[float] | None = None,
+    end_to_end_latency: float = 1.0,
+    timestamp: float | None = None,
+    status: str = "completed",
+) -> dict:
+    """Build a raw TensorRT-LLM request dict."""
+    r: dict = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "first_token_latency": first_token_latency,
+        "inter_token_latencies": (
+            inter_token_latencies
+            if inter_token_latencies is not None
+            else [0.015, 0.014, 0.016]
+        ),
+        "end_to_end_latency": end_to_end_latency,
+        "status": status,
+    }
+    if timestamp is not None:
+        r["timestamp"] = timestamp
+    return r
+
+
+def _make_trtllm_data(n: int = 10, qps: float = 5.0) -> list[dict]:
+    """Generate n TensorRT-LLM request dicts."""
+    interval = 1.0 / qps if qps > 0 else 0.2
+    return [
+        _make_trtllm_request(
+            input_tokens=100 + i * 10,
+            output_tokens=50 + i * 5,
+            first_token_latency=0.04 + i * 0.001,
+            inter_token_latencies=[0.012 + i * 0.0001] * 10,
+            end_to_end_latency=0.5 + i * 0.05,
+            timestamp=1000.0 + i * interval,
+        )
+        for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Format detection
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDetection:
+    def test_detect_trtllm_format(self):
+        data = _make_trtllm_data(3)
+        assert _detect_trtllm_format(data) is True
+
+    def test_not_trtllm_if_empty(self):
+        assert _detect_trtllm_format([]) is False
+
+    def test_not_trtllm_if_dict(self):
+        assert _detect_trtllm_format({"metadata": {}, "requests": []}) is False
+
+    def test_not_trtllm_if_vllm_format(self):
+        """vLLM uses 'prompt_len' and 'request_latency'."""
+        data = [
+            {
+                "prompt_len": 128,
+                "output_len": 64,
+                "ttft": 0.05,
+                "itl": 0.015,
+                "request_latency": 1.0,
+            }
+        ]
+        assert _detect_trtllm_format(data) is False
+
+    def test_not_trtllm_if_sglang_format(self):
+        """SGLang uses 'prompt_len', 'latency', and 'itl' (list)."""
+        data = [
+            {
+                "prompt_len": 128,
+                "output_len": 64,
+                "ttft": 0.05,
+                "itl": [0.01, 0.02],
+                "latency": 1.0,
+            }
+        ]
+        assert _detect_trtllm_format(data) is False
+
+    def test_not_trtllm_if_itl_not_list(self):
+        data = [
+            {
+                "input_tokens": 128,
+                "output_tokens": 64,
+                "first_token_latency": 0.05,
+                "inter_token_latencies": 0.015,
+                "end_to_end_latency": 1.0,
+            }
+        ]
+        assert _detect_trtllm_format(data) is False
+
+    def test_not_trtllm_if_not_list(self):
+        assert _detect_trtllm_format("not a list") is False
+
+
+# ---------------------------------------------------------------------------
+# Model validation
+# ---------------------------------------------------------------------------
+
+
+class TestModels:
+    def test_trtllm_request_valid(self):
+        r = TRTLLMRequest(
+            input_tokens=128,
+            output_tokens=64,
+            first_token_latency=0.05,
+            inter_token_latencies=[0.01, 0.02],
+            end_to_end_latency=1.0,
+        )
+        assert r.input_tokens == 128
+        assert len(r.inter_token_latencies) == 2
+        assert r.status == "completed"
+
+    def test_trtllm_request_invalid_input_tokens(self):
+        with pytest.raises(Exception):
+            TRTLLMRequest(
+                input_tokens=0,
+                output_tokens=64,
+                first_token_latency=0.05,
+                end_to_end_latency=1.0,
+            )
+
+    def test_trtllm_request_invalid_output_tokens(self):
+        with pytest.raises(Exception):
+            TRTLLMRequest(
+                input_tokens=128,
+                output_tokens=0,
+                first_token_latency=0.05,
+                end_to_end_latency=1.0,
+            )
+
+    def test_import_config_valid(self):
+        c = TRTLLMImportConfig(num_prefill_instances=2, num_decode_instances=4)
+        assert c.format == "auto"
+
+    def test_import_config_invalid_instances(self):
+        with pytest.raises(Exception):
+            TRTLLMImportConfig(num_prefill_instances=0, num_decode_instances=4)
+
+
+# ---------------------------------------------------------------------------
+# Conversion
+# ---------------------------------------------------------------------------
+
+
+class TestConversion:
+    def test_basic_conversion(self):
+        requests = [
+            TRTLLMRequest(
+                input_tokens=128,
+                output_tokens=64,
+                first_token_latency=0.05,
+                inter_token_latencies=[0.01, 0.02, 0.03],
+                end_to_end_latency=1.0,
+                timestamp=1000.0,
+            )
+        ]
+        native, warnings, num_failed = _convert_requests(requests)
+        assert len(native) == 1
+        assert native[0].prompt_tokens == 128
+        assert native[0].output_tokens == 64
+        assert native[0].ttft_ms == pytest.approx(50.0)
+        # TPOT = mean([0.01, 0.02, 0.03]) * 1000 = 20.0
+        assert native[0].tpot_ms == pytest.approx(20.0)
+        assert native[0].total_latency_ms == pytest.approx(1000.0)
+        assert num_failed == 0
+
+    def test_failed_requests_filtered(self):
+        requests = [
+            TRTLLMRequest(
+                input_tokens=128,
+                output_tokens=64,
+                first_token_latency=0.05,
+                end_to_end_latency=1.0,
+                status="completed",
+            ),
+            TRTLLMRequest(
+                input_tokens=128,
+                output_tokens=64,
+                first_token_latency=0.05,
+                end_to_end_latency=1.0,
+                status="failed",
+            ),
+        ]
+        native, warnings, num_failed = _convert_requests(requests)
+        assert len(native) == 1
+        assert num_failed == 1
+        assert any("Filtered 1 non-completed" in w for w in warnings)
+
+    def test_timeout_requests_filtered(self):
+        requests = [
+            TRTLLMRequest(
+                input_tokens=128,
+                output_tokens=64,
+                first_token_latency=0.05,
+                end_to_end_latency=1.0,
+                status="completed",
+            ),
+            TRTLLMRequest(
+                input_tokens=128,
+                output_tokens=64,
+                first_token_latency=0.05,
+                end_to_end_latency=5.0,
+                status="timeout",
+            ),
+        ]
+        native, warnings, num_failed = _convert_requests(requests)
+        assert len(native) == 1
+        assert num_failed == 1
+
+    def test_all_failed_raises(self):
+        requests = [
+            TRTLLMRequest(
+                input_tokens=128,
+                output_tokens=64,
+                first_token_latency=0.05,
+                end_to_end_latency=1.0,
+                status="failed",
+            ),
+        ]
+        with pytest.raises(ValueError, match="No completed requests"):
+            _convert_requests(requests)
+
+    def test_empty_itl_fallback(self):
+        requests = [
+            TRTLLMRequest(
+                input_tokens=128,
+                output_tokens=10,
+                first_token_latency=0.05,
+                inter_token_latencies=[],
+                end_to_end_latency=1.0,
+                timestamp=0.0,
+            )
+        ]
+        native, warnings, _ = _convert_requests(requests)
+        # TPOT fallback = (1.0 - 0.05) / (10 - 1) seconds = 0.10556 s = 105.56 ms
+        expected_tpot = (1.0 - 0.05) / 9.0 * 1000.0
+        assert native[0].tpot_ms == pytest.approx(expected_tpot, rel=1e-3)
+        assert any("empty inter_token_latencies" in w for w in warnings)
+
+    def test_single_output_token_tpot_zero(self):
+        requests = [
+            TRTLLMRequest(
+                input_tokens=128,
+                output_tokens=1,
+                first_token_latency=0.05,
+                inter_token_latencies=[],
+                end_to_end_latency=0.06,
+                timestamp=0.0,
+            )
+        ]
+        native, _, _ = _convert_requests(requests)
+        assert native[0].tpot_ms == pytest.approx(0.0)
+
+    def test_sequential_timestamps_when_missing(self):
+        requests = [
+            TRTLLMRequest(
+                input_tokens=128,
+                output_tokens=64,
+                first_token_latency=0.05,
+                end_to_end_latency=1.0,
+            ),
+            TRTLLMRequest(
+                input_tokens=256,
+                output_tokens=32,
+                first_token_latency=0.03,
+                end_to_end_latency=0.8,
+            ),
+        ]
+        native, _, _ = _convert_requests(requests)
+        assert native[0].timestamp == 0.0
+        assert native[1].timestamp == 1.0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end import
+# ---------------------------------------------------------------------------
+
+
+class TestImportTRTLLM:
+    def test_import_from_file(self, tmp_path: Path):
+        data = _make_trtllm_data(5)
+        p = tmp_path / "trtllm_bench.json"
+        p.write_text(json.dumps(data))
+        config = TRTLLMImportConfig(
+            num_prefill_instances=2, num_decode_instances=4, format="trtllm"
+        )
+        result = import_trtllm(p, config)
+        assert result.source_format == "trtllm"
+        assert result.num_requests == 5
+        assert result.benchmark_data.metadata.num_prefill_instances == 2
+        assert result.benchmark_data.metadata.num_decode_instances == 4
+        assert result.benchmark_data.metadata.total_instances == 6
+
+    def test_auto_detect_trtllm(self):
+        data = _make_trtllm_data(3)
+        config = TRTLLMImportConfig(
+            num_prefill_instances=1, num_decode_instances=1, format="auto"
+        )
+        result = import_trtllm_data(data, config)
+        assert result.source_format == "trtllm"
+        assert result.num_requests == 3
+
+    def test_auto_detect_native(self):
+        native = {
+            "metadata": {
+                "num_prefill_instances": 2,
+                "num_decode_instances": 4,
+                "total_instances": 6,
+                "measured_qps": 10.0,
+            },
+            "requests": [
+                {
+                    "request_id": "1",
+                    "prompt_tokens": 128,
+                    "output_tokens": 64,
+                    "ttft_ms": 50.0,
+                    "tpot_ms": 20.0,
+                    "total_latency_ms": 1000.0,
+                    "timestamp": 0.0,
+                }
+            ],
+        }
+        config = TRTLLMImportConfig(
+            num_prefill_instances=2, num_decode_instances=4, format="auto"
+        )
+        result = import_trtllm_data(native, config)
+        assert result.source_format == "native"
+
+    def test_auto_detect_unknown_raises(self):
+        config = TRTLLMImportConfig(
+            num_prefill_instances=1, num_decode_instances=1, format="auto"
+        )
+        with pytest.raises(ValueError, match="Cannot auto-detect"):
+            import_trtllm_data({"random": "data"}, config)
+
+    def test_measured_qps_computed(self):
+        data = _make_trtllm_data(10, qps=5.0)
+        config = TRTLLMImportConfig(
+            num_prefill_instances=1, num_decode_instances=1, format="trtllm"
+        )
+        result = import_trtllm_data(data, config)
+        assert result.benchmark_data.metadata.measured_qps > 0
+
+    def test_with_failed_requests(self):
+        data = _make_trtllm_data(5)
+        data.append(_make_trtllm_request(status="failed", timestamp=2000.0))
+        config = TRTLLMImportConfig(
+            num_prefill_instances=1, num_decode_instances=1, format="trtllm"
+        )
+        result = import_trtllm_data(data, config)
+        assert result.num_requests == 5
+        assert result.num_failed_filtered == 1
+        assert len(result.warnings) > 0
+
+    def test_non_list_raises(self):
+        config = TRTLLMImportConfig(
+            num_prefill_instances=1, num_decode_instances=1, format="trtllm"
+        )
+        with pytest.raises(ValueError, match="JSON array"):
+            import_trtllm_data({"not": "a list"}, config)
+
+    def test_output_file(self, tmp_path: Path):
+        data = _make_trtllm_data(3)
+        infile = tmp_path / "in.json"
+        infile.write_text(json.dumps(data))
+        config = TRTLLMImportConfig(
+            num_prefill_instances=1, num_decode_instances=1, format="trtllm"
+        )
+        result = import_trtllm(infile, config)
+        outfile = tmp_path / "out.json"
+        outfile.write_text(result.benchmark_data.model_dump_json(indent=2))
+        loaded = json.loads(outfile.read_text())
+        assert "metadata" in loaded
+        assert "requests" in loaded
+        assert len(loaded["requests"]) == 3
+
+    def test_single_request(self):
+        data = [_make_trtllm_request(timestamp=100.0)]
+        config = TRTLLMImportConfig(
+            num_prefill_instances=1, num_decode_instances=1, format="trtllm"
+        )
+        result = import_trtllm_data(data, config)
+        assert result.num_requests == 1
+        # Single request → QPS defaults to 1.0 (cannot compute from duration)
+        assert result.benchmark_data.metadata.measured_qps > 0
+
+    def test_file_not_found(self, tmp_path: Path):
+        config = TRTLLMImportConfig(
+            num_prefill_instances=1, num_decode_instances=1, format="trtllm"
+        )
+        with pytest.raises(FileNotFoundError):
+            import_trtllm(tmp_path / "nonexistent.json", config)
+
+
+# ---------------------------------------------------------------------------
+# Result model
+# ---------------------------------------------------------------------------
+
+
+class TestResultModel:
+    def test_result_fields(self):
+        data = _make_trtllm_data(3)
+        config = TRTLLMImportConfig(
+            num_prefill_instances=2, num_decode_instances=2, format="trtllm"
+        )
+        result = import_trtllm_data(data, config)
+        assert isinstance(result, TRTLLMImportResult)
+        assert result.source_format == "trtllm"
+        assert result.num_failed_filtered == 0
+        assert isinstance(result.warnings, list)
+
+    def test_result_serializable(self):
+        data = _make_trtllm_data(3)
+        config = TRTLLMImportConfig(
+            num_prefill_instances=1, num_decode_instances=1, format="trtllm"
+        )
+        result = import_trtllm_data(data, config)
+        d = result.model_dump()
+        assert "benchmark_data" in d
+        assert "num_requests" in d
+        assert "num_failed_filtered" in d
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+class TestCLIImport:
+    def test_format_choices_include_trtllm(self):
+        """Verify trtllm is in the CLI format choices."""
+        import argparse
+
+        from xpyd_plan.cli._import import add_import_parser
+
+        parser = argparse.ArgumentParser()
+        subs = parser.add_subparsers()
+        add_import_parser(subs)
+        # Parse with --format trtllm to verify it's accepted
+        args = parser.parse_args([
+            "import",
+            "--input", "dummy.json",
+            "--prefill-instances", "1",
+            "--decode-instances", "1",
+            "--format", "trtllm",
+        ])
+        assert args.format == "trtllm"


### PR DESCRIPTION
## Summary

Add TensorRT-LLM benchmark format importer, completing the trio of supported frameworks (vLLM, SGLang, TensorRT-LLM).

### Changes

- **`trtllm_import.py`** — `TRTLLMRequest`, `TRTLLMBenchmarkData`, `TRTLLMImportConfig`, `TRTLLMImportResult` Pydantic models
- **`import_trtllm()`** and **`import_trtllm_data()`** public API functions
- **Format auto-detection** via `_detect_trtllm_format()` — distinguishes TensorRT-LLM from vLLM/SGLang by field names (`input_tokens`, `end_to_end_latency`, `inter_token_latencies`)
- **Failed-request filtering** — filters requests with `status != "completed"` (failed, timeout) with warnings
- **TPOT computation** — mean of `inter_token_latencies` list, with fallback to `(e2e - ftl) / (output_tokens - 1)`
- **CLI** — `import --format trtllm` added to format choices; auto-detect updated
- **Exports** — all public types exported from `__init__.py`
- **32 new tests** covering format detection, model validation, conversion, end-to-end import, result serialization, CLI integration
- **ROADMAP.md** updated with M112
- **docs/iterations/current.md** updated

Closes #247